### PR TITLE
Align control-plane API seams

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,21 +1,47 @@
-import { createContext } from "@better-agent/api/context";
-import { appRouter } from "@better-agent/api/routers/index";
+import { appRouter, createContext } from "@better-agent/api";
 import { createAuth } from "@better-agent/auth";
+import { createDb } from "@better-agent/db";
 import { env } from "@better-agent/env/server";
+import type { CloudflareEnv } from "@better-agent/env/types";
 import { OpenAPIHandler } from "@orpc/openapi/fetch";
 import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
 import { onError } from "@orpc/server";
 import { RPCHandler } from "@orpc/server/fetch";
 import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import { Hono } from "hono";
+import type { ErrorHandler } from "hono";
 import { cors } from "hono/cors";
+import { HTTPException } from "hono/http-exception";
 import { logger } from "hono/logger";
 
-const app = new Hono();
+const app = new Hono<{ Bindings: CloudflareEnv }>();
 
 const logError = (error: unknown) => {
 	console.error(error);
 };
+
+const errorHandler: ErrorHandler<{ Bindings: CloudflareEnv }> = (error, c) => {
+	logError(error);
+
+	if (error instanceof HTTPException) {
+		return error.getResponse();
+	}
+
+	return c.json({ error: "Internal Server Error" }, 500);
+};
+
+const apiHandler = new OpenAPIHandler(appRouter, {
+	interceptors: [onError(logError)],
+	plugins: [
+		new OpenAPIReferencePlugin({
+			schemaConverters: [new ZodToJsonSchemaConverter()],
+		}),
+	],
+});
+
+const rpcHandler = new RPCHandler(appRouter, {
+	interceptors: [onError(logError)],
+});
 
 app.use(logger());
 app.use(
@@ -28,45 +54,56 @@ app.use(
 	}),
 );
 
-app.on(["POST", "GET"], "/api/auth/*", (c) => createAuth().handler(c.req.raw));
+app.on(["GET", "POST"], "/api/auth/*", (c) =>
+	createAuth({
+		db: createDb(c.env.DB),
+		env: c.env,
+	}).handler(c.req.raw),
+);
 
-export const apiHandler = new OpenAPIHandler(appRouter, {
-	interceptors: [onError(logError)],
-	plugins: [
-		new OpenAPIReferencePlugin({
-			schemaConverters: [new ZodToJsonSchemaConverter()],
+app.use("/api/rpc/*", async (c, next) => {
+	const result = await rpcHandler.handle(c.req.raw, {
+		context: await createContext({
+			env: c.env,
+			executionCtx: c.executionCtx,
+			headers: c.req.raw.headers,
 		}),
-	],
-});
-
-export const rpcHandler = new RPCHandler(appRouter, {
-	interceptors: [onError(logError)],
-});
-
-app.use("/*", async (c, next) => {
-	const context = await createContext({ context: c });
-
-	const rpcResult = await rpcHandler.handle(c.req.raw, {
-		context,
-		prefix: "/rpc",
+		prefix: "/api/rpc",
 	});
 
-	if (rpcResult.matched) {
-		return c.newResponse(rpcResult.response.body, rpcResult.response);
+	if (!result.matched) {
+		return next();
 	}
 
-	const apiResult = await apiHandler.handle(c.req.raw, {
-		context,
-		prefix: "/api-reference",
+	return c.newResponse(result.response.body, result.response);
+});
+
+app.use("/api/openapi/*", async (c, next) => {
+	const result = await apiHandler.handle(c.req.raw, {
+		context: await createContext({
+			env: c.env,
+			executionCtx: c.executionCtx,
+			headers: c.req.raw.headers,
+		}),
+		prefix: "/api/openapi",
 	});
 
-	if (apiResult.matched) {
-		return c.newResponse(apiResult.response.body, apiResult.response);
+	if (!result.matched) {
+		return next();
 	}
 
-	await next();
+	return c.newResponse(result.response.body, result.response);
 });
+
+app.onError(errorHandler);
 
 app.get("/", (c) => c.text("OK"));
+app.get("/api/health", (c) => c.text("OK"));
 
-export default app;
+const worker: ExportedHandler = {
+	fetch(request, bindings, executionCtx) {
+		return app.fetch(request, bindings as CloudflareEnv, executionCtx);
+	},
+};
+
+export default worker;

--- a/apps/server/tsdown.config.ts
+++ b/apps/server/tsdown.config.ts
@@ -2,8 +2,12 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	clean: true,
+	deps: {
+		alwaysBundle: [/@better-agent\/.*/u],
+		neverBundle: ["cloudflare:workers"],
+		onlyBundle: ["drizzle-orm"],
+	},
 	entry: "./src/index.ts",
 	format: "esm",
-	noExternal: [/@better-agent\/.*/u],
 	outDir: "./dist",
 });

--- a/apps/web/src/utils/orpc.ts
+++ b/apps/web/src/utils/orpc.ts
@@ -1,4 +1,4 @@
-import type { AppRouter } from "@better-agent/api/routers/index";
+import type { AppRouter } from "@better-agent/api";
 import { env } from "@better-agent/env/web";
 import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
@@ -27,7 +27,7 @@ const link = new RPCLink({
 			credentials: "include",
 		});
 	},
-	url: `${env.VITE_SERVER_URL}/rpc`,
+	url: `${env.VITE_SERVER_URL}/api/rpc`,
 });
 
 const getORPCClient = () => createORPCClient(link) as RouterClient<AppRouter>;

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -1,16 +1,26 @@
 import { createAuth } from "@better-agent/auth";
-import type { Context as HonoContext } from "hono";
+import { createDb } from "@better-agent/db";
+import type { CloudflareEnv } from "@better-agent/env/types";
+
+export type ControlPlaneEnv = CloudflareEnv;
 
 export interface CreateContextOptions {
-	context: HonoContext;
+	env: ControlPlaneEnv;
+	executionCtx?: ExecutionContext;
+	headers: Headers;
 }
 
-export const createContext = async ({ context }: CreateContextOptions) => {
-	const session = await createAuth().api.getSession({
-		headers: context.req.raw.headers,
+export const createContext = async ({ env, executionCtx, headers }: CreateContextOptions) => {
+	const db = createDb(env.DB);
+	const session = await createAuth({ db, env }).api.getSession({
+		headers,
 	});
+
 	return {
-		auth: null,
+		db,
+		env,
+		executionCtx,
+		headers,
 		session,
 	};
 };

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,20 +1,5 @@
-import { ORPCError, os } from "@orpc/server";
-
-import type { Context } from "./context";
-
-export const o = os.$context<Context>();
-
-export const publicProcedure = o;
-
-const requireAuth = o.middleware(async ({ context, next }) => {
-	if (!context.session?.user) {
-		throw new ORPCError("UNAUTHORIZED");
-	}
-	return await next({
-		context: {
-			session: context.session,
-		},
-	});
-});
-
-export const protectedProcedure = publicProcedure.use(requireAuth);
+export { createContext } from "./context";
+export type { Context, ControlPlaneEnv, CreateContextOptions } from "./context";
+export { protectedProcedure, publicProcedure } from "./procedures";
+export { appRouter } from "./routers/index";
+export type { AppRouter, AppRouterClient, RouterInputs, RouterOutputs } from "./routers/index";

--- a/packages/api/src/procedures.ts
+++ b/packages/api/src/procedures.ts
@@ -1,0 +1,21 @@
+import { ORPCError, os } from "@orpc/server";
+
+import type { Context } from "./context";
+
+export const o = os.$context<Context>();
+
+export const publicProcedure = o;
+
+const requireAuth = o.middleware(async ({ context, next }) => {
+	if (!context.session?.user) {
+		throw new ORPCError("UNAUTHORIZED");
+	}
+
+	return await next({
+		context: {
+			session: context.session,
+		},
+	});
+});
+
+export const protectedProcedure = publicProcedure.use(requireAuth);

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -1,6 +1,6 @@
-import type { RouterClient } from "@orpc/server";
+import type { InferRouterInputs, InferRouterOutputs, RouterClient } from "@orpc/server";
 
-import { protectedProcedure, publicProcedure } from "../index";
+import { protectedProcedure, publicProcedure } from "../procedures";
 
 export const appRouter = {
 	healthCheck: publicProcedure.handler(() => "OK"),
@@ -10,4 +10,6 @@ export const appRouter = {
 	})),
 };
 export type AppRouter = typeof appRouter;
-export type AppRouterClient = RouterClient<typeof appRouter>;
+export type AppRouterClient = RouterClient<AppRouter>;
+export type RouterInputs = InferRouterInputs<AppRouter>;
+export type RouterOutputs = InferRouterOutputs<AppRouter>;

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,11 +1,21 @@
 import { createDb } from "@better-agent/db";
+import type { ProductDb } from "@better-agent/db";
 import * as schema from "@better-agent/db/schema/auth";
-import { env } from "@better-agent/env/server";
+import { env as serverEnv } from "@better-agent/env/server";
+import type { CloudflareEnv } from "@better-agent/env/types";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 
-export const createAuth = () => {
-	const db = createDb();
+type AuthEnv = Pick<CloudflareEnv, "BETTER_AUTH_SECRET" | "BETTER_AUTH_URL" | "CORS_ORIGIN">;
+
+export interface CreateAuthOptions {
+	db?: ProductDb;
+	env?: AuthEnv;
+}
+
+export const createAuth = (options: CreateAuthOptions = {}) => {
+	const bindings = options.env ?? serverEnv;
+	const db = options.db ?? createDb();
 
 	return betterAuth({
 		advanced: {
@@ -15,7 +25,7 @@ export const createAuth = () => {
 				secure: true,
 			},
 		},
-		baseURL: env.BETTER_AUTH_URL,
+		baseURL: bindings.BETTER_AUTH_URL,
 		database: drizzleAdapter(db, {
 			provider: "sqlite",
 			schema,
@@ -23,7 +33,7 @@ export const createAuth = () => {
 		emailAndPassword: {
 			enabled: true,
 		},
-		secret: env.BETTER_AUTH_SECRET,
-		trustedOrigins: [env.CORS_ORIGIN],
+		secret: bindings.BETTER_AUTH_SECRET,
+		trustedOrigins: [bindings.CORS_ORIGIN],
 	});
 };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,4 +3,6 @@ import { drizzle } from "drizzle-orm/d1";
 
 import * as schema from "./schema";
 
-export const createDb = () => drizzle(env.DB, { schema });
+export const createDb = (binding: D1Database = env.DB) => drizzle(binding, { schema });
+
+export type ProductDb = ReturnType<typeof createDb>;

--- a/packages/env/env.d.ts
+++ b/packages/env/env.d.ts
@@ -1,9 +1,7 @@
-import type { server } from "@better-agent/infra/alchemy.run";
+import type { CloudflareEnv } from "./src/types";
 
-// This file infers types for the cloudflare:workers environment from your Alchemy Worker.
-// @see https://alchemy.run/concepts/bindings/#type-safe-bindings
-
-export type CloudflareEnv = typeof server.Env;
+// This file declares the cloudflare:workers environment shape used by the app.
+// Runtime bindings are configured in packages/infra/alchemy.run.ts.
 
 declare global {
 	type Env = CloudflareEnv;

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"exports": {
 		"./server": "./src/server.ts",
+		"./types": "./src/types.ts",
 		"./web": "./src/web.ts"
 	},
 	"dependencies": {

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -1,7 +1,7 @@
 import { env as workerEnv } from "cloudflare:workers";
 
-import type { CloudflareEnv } from "../env";
+import type { CloudflareEnv } from "./types";
 
 // For Cloudflare Workers, env is accessed via cloudflare:workers module.
-// Types are defined in env.d.ts based on your alchemy.run.ts bindings.
+// Bindings are configured in packages/infra/alchemy.run.ts.
 export const env = workerEnv as CloudflareEnv;

--- a/packages/env/src/types.ts
+++ b/packages/env/src/types.ts
@@ -1,0 +1,7 @@
+export interface CloudflareEnv {
+	BETTER_AUTH_SECRET: string;
+	BETTER_AUTH_URL: string;
+	CORS_ORIGIN: string;
+	DB: D1Database;
+	VITE_SERVER_URL?: string;
+}


### PR DESCRIPTION
## Summary
- make Hono the explicit control-plane entrypoint for auth, RPC, OpenAPI, CORS, and Worker error handling
- expand transport-neutral API context with Cloudflare env/bindings, headers, execution context, product DB, and nullable session
- centralize procedure/router exports and move the web oRPC client to /api/rpc
- clean up env binding types and tsdown dependency configuration

## Validation
- bun x ultracite check
- bun run check-types
- bun run build

Closes #5