### PR TITLE
Implement Thinkspace lifecycle and Review Queue entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,6 @@ coverage
 # Misc
 *.tgz
 .cache
+.firecrawl
 tmp
 temp

--- a/apps/web/src/routes/thinkspaces.tsx
+++ b/apps/web/src/routes/thinkspaces.tsx
@@ -1,66 +1,243 @@
 import { Button } from "@better-agent/ui/components/button";
 import {
 	Card,
+	CardAction,
 	CardContent,
 	CardDescription,
 	CardHeader,
 	CardTitle,
 } from "@better-agent/ui/components/card";
+import { Input } from "@better-agent/ui/components/input";
+import { Label } from "@better-agent/ui/components/label";
+import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, getRouteApi, redirect } from "@tanstack/react-router";
+import { useState } from "react";
+import type { FormEvent } from "react";
 
 import { getUser } from "@/functions/get-user";
 
 const routeApi = getRouteApi("/thinkspaces");
 
+const dateFormatter = new Intl.DateTimeFormat("en", {
+	dateStyle: "medium",
+	timeStyle: "short",
+});
+
+const formatUpdatedAt = (value: Date | number | string): string =>
+	dateFormatter.format(new Date(value));
+
 const RouteComponent = () => {
-	const { session } = routeApi.useRouteContext();
-	const displayName = session?.user.name || session?.user.email || "there";
+	const context = routeApi.useRouteContext();
+	const { session } = context;
+	const queryClient = useQueryClient();
+	const thinkspacesQuery = useSuspenseQuery(context.orpc.thinkspaces.list.queryOptions());
+	const [goal, setGoal] = useState("");
+	const [initialInstructions, setInitialInstructions] = useState("");
+	const [configurationSummary, setConfigurationSummary] = useState("");
+	const createMutation = useMutation(
+		context.orpc.thinkspaces.create.mutationOptions({
+			onSuccess: async () => {
+				setGoal("");
+				setInitialInstructions("");
+				setConfigurationSummary("");
+				await queryClient.invalidateQueries({
+					queryKey: context.orpc.thinkspaces.list.queryKey(),
+				});
+			},
+		}),
+	);
+
+	const displayName = session.user.name || session.user.email || "there";
+	const trimmedGoal = goal.trim();
+	const trimmedConfigurationSummary = configurationSummary.trim();
+	const canCreate =
+		Boolean(trimmedGoal && trimmedConfigurationSummary) && !createMutation.isPending;
+
+	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+
+		if (!canCreate) {
+			return;
+		}
+
+		createMutation.mutate({
+			configurationSummary,
+			goal,
+			initialInstructions,
+		});
+	};
 
 	return (
-		<div className="mx-auto grid w-full max-w-5xl gap-6 px-4 py-8">
+		<div className="mx-auto grid w-full max-w-6xl gap-6 px-4 py-8">
 			<section className="grid gap-2">
 				<p className="text-muted-foreground text-xs uppercase tracking-[0.24em]">Better Agent</p>
 				<h1 className="text-3xl font-semibold tracking-tight">Thinkspaces</h1>
 				<p className="max-w-2xl text-muted-foreground text-sm leading-6">
-					Welcome back, {displayName}. Thinkspaces are durable environments for scoped agent work
-					around a bounded Goal.
+					Welcome back, {displayName}. Create durable Thinkspaces around bounded Goals, then return
+					here when work needs your judgement.
 				</p>
 			</section>
 
-			<Card>
-				<CardHeader>
-					<CardTitle>No Thinkspaces yet</CardTitle>
-					<CardDescription>
-						The next slice will add the Thinkspace lifecycle: create, review, list, open, and
-						archive. This baseline keeps the authenticated product direction centered on Thinkspaces
-						instead of scaffold demos.
-					</CardDescription>
-				</CardHeader>
-				<CardContent className="grid gap-4 sm:grid-cols-3">
-					<div className="border border-border p-3">
-						<h2 className="font-medium">Goal</h2>
-						<p className="mt-1 text-muted-foreground">
-							Each Thinkspace starts from one bounded, assessable outcome.
+			<div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_20rem]">
+				<Card id="review-queue" className="border-primary/20 bg-primary/5">
+					<CardHeader>
+						<CardTitle>Review Queue</CardTitle>
+						<CardDescription>
+							A cross-Thinkspace set of items awaiting your judgement: pending Approvals, drafts,
+							Memory to accept, and Goal assessments.
+						</CardDescription>
+					</CardHeader>
+					<CardContent className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-end">
+						<div className="grid gap-1">
+							<p className="font-medium">Nothing needs review yet.</p>
+							<p className="text-muted-foreground">
+								This slice creates the entry point. Runtime holdpoints will populate it later
+								without turning this page into a live activity surface.
+							</p>
+						</div>
+						<Button variant="outline" type="button" disabled>
+							Review Queue empty
+						</Button>
+					</CardContent>
+				</Card>
+
+				<Card>
+					<CardHeader>
+						<CardTitle>Create Thinkspace</CardTitle>
+						<CardDescription>
+							Start with one bounded Goal and a reviewable configuration summary. Skills, tools,
+							Permissions, and Approval defaults stay empty until explicitly scoped.
+						</CardDescription>
+					</CardHeader>
+					<CardContent>
+						<form className="grid gap-3" onSubmit={handleSubmit}>
+							<div className="grid gap-1.5">
+								<Label htmlFor="thinkspace-goal">Goal</Label>
+								<Input
+									id="thinkspace-goal"
+									name="goal"
+									onChange={(event) => setGoal(event.target.value)}
+									placeholder="Define the bounded outcome"
+									required
+									value={goal}
+								/>
+							</div>
+							<div className="grid gap-1.5">
+								<Label htmlFor="thinkspace-configuration-summary">
+									Initial configuration summary
+								</Label>
+								<textarea
+									aria-label="Initial configuration summary"
+									id="thinkspace-configuration-summary"
+									name="configurationSummary"
+									onChange={(event) => setConfigurationSummary(event.target.value)}
+									placeholder="Summarize the initial scope, Sources to consider, and review expectations"
+									required
+									rows={4}
+									value={configurationSummary}
+									className="min-h-24 w-full rounded-none border border-input bg-transparent px-2.5 py-2 text-xs outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+								/>
+							</div>
+							<div className="grid gap-1.5">
+								<Label htmlFor="thinkspace-initial-instructions">Initial instructions</Label>
+								<textarea
+									aria-label="Initial instructions"
+									id="thinkspace-initial-instructions"
+									name="initialInstructions"
+									onChange={(event) => setInitialInstructions(event.target.value)}
+									placeholder="Optional starting guidance for the Thinkspace Agent"
+									rows={3}
+									value={initialInstructions}
+									className="min-h-20 w-full rounded-none border border-input bg-transparent px-2.5 py-2 text-xs outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+								/>
+							</div>
+							{createMutation.error ? (
+								<p className="text-destructive text-xs" role="alert">
+									{createMutation.error.message}
+								</p>
+							) : null}
+							<Button className="w-fit" disabled={!canCreate} type="submit">
+								{createMutation.isPending ? "Creating…" : "Create Thinkspace"}
+							</Button>
+						</form>
+					</CardContent>
+				</Card>
+			</div>
+
+			<section className="grid gap-3" aria-labelledby="thinkspace-list-heading">
+				<div className="flex flex-wrap items-end justify-between gap-2">
+					<div className="grid gap-1">
+						<h2 id="thinkspace-list-heading" className="text-xl font-semibold tracking-tight">
+							Your Thinkspaces
+						</h2>
+						<p className="text-muted-foreground text-sm">
+							Only Thinkspaces owned by your account appear here.
 						</p>
 					</div>
-					<div className="border border-border p-3">
-						<h2 className="font-medium">Permissions</h2>
-						<p className="mt-1 text-muted-foreground">
-							Connected Accounts do not grant access until a Thinkspace receives scoped Permissions.
-						</p>
+				</div>
+
+				{thinkspacesQuery.data.length === 0 ? (
+					<Card>
+						<CardHeader>
+							<CardTitle>No Thinkspaces yet</CardTitle>
+							<CardDescription>
+								Create the first one around a Goal. It will be stored as active product metadata in
+								the D1 index for this account.
+							</CardDescription>
+						</CardHeader>
+						<CardContent className="grid gap-4 sm:grid-cols-3">
+							<div className="border border-border p-3">
+								<h3 className="font-medium">Goal</h3>
+								<p className="mt-1 text-muted-foreground">
+									Each Thinkspace starts from one bounded, assessable outcome.
+								</p>
+							</div>
+							<div className="border border-border p-3">
+								<h3 className="font-medium">Permissions</h3>
+								<p className="mt-1 text-muted-foreground">
+									Connected Accounts do not grant access until a Thinkspace receives scoped
+									Permissions.
+								</p>
+							</div>
+							<div className="border border-border p-3">
+								<h3 className="font-medium">Approvals</h3>
+								<p className="mt-1 text-muted-foreground">
+									External mutations default to draft or explicit consent before they move on.
+								</p>
+							</div>
+						</CardContent>
+					</Card>
+				) : (
+					<div className="grid gap-3">
+						{thinkspacesQuery.data.map((thinkspace) => (
+							<Card key={thinkspace.id}>
+								<CardHeader>
+									<CardTitle>{thinkspace.goal}</CardTitle>
+									<CardDescription>{thinkspace.configurationSummary}</CardDescription>
+									<CardAction>
+										<span className="border border-border px-2 py-1 text-muted-foreground text-xs capitalize">
+											{thinkspace.status}
+										</span>
+									</CardAction>
+								</CardHeader>
+								<CardContent className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-end">
+									<div className="grid gap-1 text-muted-foreground">
+										<p>Updated {formatUpdatedAt(thinkspace.updatedAt)}</p>
+										{thinkspace.initialInstructions ? (
+											<p>Initial instructions: {thinkspace.initialInstructions}</p>
+										) : (
+											<p>No initial instructions recorded.</p>
+										)}
+									</div>
+									<Button variant="outline" type="button" disabled>
+										Detail opens in next slice
+									</Button>
+								</CardContent>
+							</Card>
+						))}
 					</div>
-					<div className="border border-border p-3">
-						<h2 className="font-medium">Artifacts</h2>
-						<p className="mt-1 text-muted-foreground">
-							Durable outputs will live with Sources, Memory, Skills, Approvals, and the Audit
-							Trail.
-						</p>
-					</div>
-					<Button className="w-fit" disabled type="button">
-						Create Thinkspace coming soon
-					</Button>
-				</CardContent>
-			</Card>
+				)}
+			</section>
 		</div>
 	);
 };
@@ -77,4 +254,6 @@ export const Route = createFileRoute("/thinkspaces")({
 		return { session };
 	},
 	component: RouteComponent,
+	loader: async ({ context }) =>
+		await context.queryClient.ensureQueryData(context.orpc.thinkspaces.list.queryOptions()),
 });

--- a/bun.lock
+++ b/bun.lock
@@ -101,6 +101,7 @@
         "@orpc/server": "catalog:",
         "@orpc/zod": "catalog:",
         "dotenv": "catalog:",
+        "drizzle-orm": "^0.45.1",
         "zod": "catalog:",
       },
       "devDependencies": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,7 +9,9 @@
 			"default": "./src/*.ts"
 		}
 	},
-	"scripts": {},
+	"scripts": {
+		"check-types": "tsc --noEmit"
+	},
 	"dependencies": {
 		"@better-agent/auth": "workspace:*",
 		"@better-agent/db": "workspace:*",
@@ -19,6 +21,7 @@
 		"@orpc/server": "catalog:",
 		"@orpc/zod": "catalog:",
 		"dotenv": "catalog:",
+		"drizzle-orm": "^0.45.1",
 		"zod": "catalog:"
 	},
 	"devDependencies": {

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -1,13 +1,11 @@
 import type { InferRouterInputs, InferRouterOutputs, RouterClient } from "@orpc/server";
 
-import { protectedProcedure, publicProcedure } from "../procedures";
+import { publicProcedure } from "../procedures";
+import { thinkspacesRouter } from "../thinkspaces/router";
 
 export const appRouter = {
 	healthCheck: publicProcedure.handler(() => "OK"),
-	privateData: protectedProcedure.handler(({ context }) => ({
-		message: "This is private",
-		user: context.session?.user,
-	})),
+	thinkspaces: thinkspacesRouter,
 };
 export type AppRouter = typeof appRouter;
 export type AppRouterClient = RouterClient<AppRouter>;

--- a/packages/api/src/thinkspaces/lifecycle.test.ts
+++ b/packages/api/src/thinkspaces/lifecycle.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	createThinkspaceCreationRecord,
+	THINKSPACE_CREATION_DEFAULTS,
+	ThinkspaceLifecycleValidationError,
+} from "./lifecycle";
+
+test("creates an active Thinkspace record around a trimmed Goal and reviewable configuration", () => {
+	const record = createThinkspaceCreationRecord({
+		configurationSummary:
+			"  Review repository shape, sources, permissions, and expected artifact.  ",
+		goal: "  Prepare a dependency-aligned salvage plan  ",
+		id: "thinkspace_test",
+		initialInstructions: "  Start with the existing ADRs.  ",
+		ownerUserId: "user_123",
+	});
+
+	assert.equal(record.id, "thinkspace_test");
+	assert.equal(record.ownerUserId, "user_123");
+	assert.equal(record.goal, "Prepare a dependency-aligned salvage plan");
+	assert.equal(record.initialInstructions, "Start with the existing ADRs.");
+	assert.equal(
+		record.configurationSummary,
+		"Review repository shape, sources, permissions, and expected artifact.",
+	);
+	assert.equal(record.status, "active");
+	assert.equal(record.selectedSkillIds, "[]");
+	assert.equal(record.enabledToolIds, "[]");
+	assert.equal(record.requestedPermissions, "[]");
+	assert.equal(
+		record.approvalDefaults,
+		JSON.stringify(THINKSPACE_CREATION_DEFAULTS.approvalDefaults),
+	);
+	assert.equal(
+		record.memoryGovernance,
+		JSON.stringify(THINKSPACE_CREATION_DEFAULTS.memoryGovernance),
+	);
+});
+
+test("builds a deterministic configuration summary when none is supplied", () => {
+	const record = createThinkspaceCreationRecord({
+		goal: "Compare release notes",
+		id: "thinkspace_defaults",
+		ownerUserId: "user_123",
+	});
+
+	assert.match(record.configurationSummary ?? "", /Goal: Compare release notes/u);
+	assert.match(record.configurationSummary ?? "", /Skills, tools, requested Permissions/u);
+	assert.match(
+		record.configurationSummary ?? "",
+		/Memory governance starts in user-reviewed mode/u,
+	);
+});
+
+test("rejects missing Goal or owner before persistence", () => {
+	assert.throws(
+		() =>
+			createThinkspaceCreationRecord({
+				goal: "   ",
+				id: "thinkspace_missing_goal",
+				ownerUserId: "user_123",
+			}),
+		ThinkspaceLifecycleValidationError,
+	);
+
+	assert.throws(
+		() =>
+			createThinkspaceCreationRecord({
+				goal: "Prepare a bounded plan",
+				id: "thinkspace_missing_owner",
+				ownerUserId: "",
+			}),
+		ThinkspaceLifecycleValidationError,
+	);
+});

--- a/packages/api/src/thinkspaces/lifecycle.ts
+++ b/packages/api/src/thinkspaces/lifecycle.ts
@@ -1,0 +1,94 @@
+import { THINKSPACE_STATUS } from "@better-agent/db/schema/thinkspaces";
+import type { NewThinkspace } from "@better-agent/db/schema/thinkspaces";
+
+const MAX_GOAL_LENGTH = 280;
+const MAX_INITIAL_INSTRUCTIONS_LENGTH = 4000;
+const MAX_CONFIGURATION_SUMMARY_LENGTH = 1600;
+
+export const THINKSPACE_CREATION_DEFAULTS = {
+	approvalDefaults: {
+		externalMutations: "require_approval",
+	},
+	enabledToolIds: [] as string[],
+	memoryGovernance: {
+		retention: "user_reviewed",
+	},
+	requestedPermissions: [] as string[],
+	selectedSkillIds: [] as string[],
+} as const;
+
+export interface CreateThinkspaceLifecycleInput {
+	configurationSummary?: string | null;
+	goal: string;
+	id: string;
+	initialInstructions?: string | null;
+	ownerUserId: string;
+}
+
+export class ThinkspaceLifecycleValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ThinkspaceLifecycleValidationError";
+	}
+}
+
+const normalizeText = (value: string | null | undefined): string => value?.trim() ?? "";
+
+const assertMaxLength = (label: string, value: string, maxLength: number) => {
+	if (value.length > maxLength) {
+		throw new ThinkspaceLifecycleValidationError(
+			`${label} must be ${maxLength} characters or fewer.`,
+		);
+	}
+};
+
+const buildDefaultConfigurationSummary = (goal: string): string =>
+	[
+		`Goal: ${goal}`,
+		"Initial configuration keeps Skills, tools, requested Permissions, and Approval policy placeholders empty until the user deliberately scopes them.",
+		"Memory governance starts in user-reviewed mode so retained understanding is accepted intentionally.",
+	].join("\n");
+
+export const createThinkspaceCreationRecord = ({
+	configurationSummary,
+	goal,
+	id,
+	initialInstructions,
+	ownerUserId,
+}: CreateThinkspaceLifecycleInput): NewThinkspace => {
+	const normalizedGoal = normalizeText(goal);
+	const normalizedInstructions = normalizeText(initialInstructions);
+	const normalizedSummary = normalizeText(configurationSummary);
+
+	if (!ownerUserId) {
+		throw new ThinkspaceLifecycleValidationError(
+			"A Thinkspace must belong to an authenticated owner.",
+		);
+	}
+
+	if (!id) {
+		throw new ThinkspaceLifecycleValidationError("A Thinkspace requires a stable identifier.");
+	}
+
+	if (!normalizedGoal) {
+		throw new ThinkspaceLifecycleValidationError("Goal is required to create a Thinkspace.");
+	}
+
+	assertMaxLength("Goal", normalizedGoal, MAX_GOAL_LENGTH);
+	assertMaxLength("Initial instructions", normalizedInstructions, MAX_INITIAL_INSTRUCTIONS_LENGTH);
+	assertMaxLength("Configuration summary", normalizedSummary, MAX_CONFIGURATION_SUMMARY_LENGTH);
+
+	return {
+		approvalDefaults: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.approvalDefaults),
+		configurationSummary: normalizedSummary || buildDefaultConfigurationSummary(normalizedGoal),
+		enabledToolIds: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.enabledToolIds),
+		goal: normalizedGoal,
+		id,
+		initialInstructions: normalizedInstructions,
+		memoryGovernance: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.memoryGovernance),
+		ownerUserId,
+		requestedPermissions: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.requestedPermissions),
+		selectedSkillIds: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.selectedSkillIds),
+		status: THINKSPACE_STATUS.ACTIVE,
+	};
+};

--- a/packages/api/src/thinkspaces/repository.ts
+++ b/packages/api/src/thinkspaces/repository.ts
@@ -1,0 +1,36 @@
+import type { ProductDb } from "@better-agent/db";
+import { THINKSPACE_STATUS, thinkspaces } from "@better-agent/db/schema/thinkspaces";
+import type { Thinkspace, ThinkspaceStatus } from "@better-agent/db/schema/thinkspaces";
+import { and, desc, eq } from "drizzle-orm";
+
+export interface ListThinkspacesInput {
+	ownerUserId: string;
+	status?: ThinkspaceStatus;
+}
+
+export interface CreateThinkspaceInput {
+	record: typeof thinkspaces.$inferInsert;
+}
+
+export const createThinkspace = async (
+	db: ProductDb,
+	{ record }: CreateThinkspaceInput,
+): Promise<Thinkspace> => {
+	const [created] = await db.insert(thinkspaces).values(record).returning();
+
+	if (!created) {
+		throw new Error("Thinkspace was not persisted.");
+	}
+
+	return created;
+};
+
+export const listThinkspaces = async (
+	db: ProductDb,
+	{ ownerUserId, status = THINKSPACE_STATUS.ACTIVE }: ListThinkspacesInput,
+): Promise<Thinkspace[]> =>
+	await db
+		.select()
+		.from(thinkspaces)
+		.where(and(eq(thinkspaces.ownerUserId, ownerUserId), eq(thinkspaces.status, status)))
+		.orderBy(desc(thinkspaces.updatedAt));

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -1,0 +1,44 @@
+import { ORPCError } from "@orpc/server";
+import { z } from "zod";
+
+import { protectedProcedure } from "../procedures";
+import { createThinkspaceCreationRecord, ThinkspaceLifecycleValidationError } from "./lifecycle";
+import { createThinkspace, listThinkspaces } from "./repository";
+
+const createThinkspaceInput = z.object({
+	configurationSummary: z.string().optional(),
+	goal: z.string(),
+	initialInstructions: z.string().optional(),
+});
+
+const createThinkspaceId = (): string => `thinkspace_${crypto.randomUUID()}`;
+
+const toBadRequest = (
+	error: ThinkspaceLifecycleValidationError,
+): ORPCError<"BAD_REQUEST", undefined> => new ORPCError("BAD_REQUEST", { message: error.message });
+
+export const thinkspacesRouter = {
+	create: protectedProcedure.input(createThinkspaceInput).handler(async ({ context, input }) => {
+		try {
+			const record = createThinkspaceCreationRecord({
+				configurationSummary: input.configurationSummary,
+				goal: input.goal,
+				id: createThinkspaceId(),
+				initialInstructions: input.initialInstructions,
+				ownerUserId: context.session.user.id,
+			});
+
+			return await createThinkspace(context.db, { record });
+		} catch (error) {
+			if (error instanceof ThinkspaceLifecycleValidationError) {
+				throw toBadRequest(error);
+			}
+
+			throw error;
+		}
+	}),
+	list: protectedProcedure.handler(
+		async ({ context }) =>
+			await listThinkspaces(context.db, { ownerUserId: context.session.user.id }),
+	),
+};


### PR DESCRIPTION
## Problem / Intent

Closes #8.

Authenticated users need the first thin Thinkspace path: create a Thinkspace around a Goal, persist it in the product index, return to it from `/thinkspaces`, and see the Review Queue as the primary judgement-oriented entry point.

## Approach

Add a small Thinkspace lifecycle module with pure validation/defaulting, expose protected oRPC create/list procedures backed by the D1 product index, and pre-warm the `/thinkspaces` list through TanStack route loading. The page now supports creating and listing owned active Thinkspaces while keeping the Review Queue as an empty placeholder for future runtime holdpoints.
