### PR TITLE
Port model catalog and BYOK resolver

### DIFF
--- a/apps/web/src/routes/settings.product.tsx
+++ b/apps/web/src/routes/settings.product.tsx
@@ -1,84 +1,187 @@
 import { Badge } from "@better-agent/ui/components/badge";
 import { Button } from "@better-agent/ui/components/button";
+import { Input } from "@better-agent/ui/components/input";
+import { Label } from "@better-agent/ui/components/label";
 import { Separator } from "@better-agent/ui/components/separator";
-import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute, getRouteApi } from "@tanstack/react-router";
+import { useState } from "react";
+import type { FormEvent } from "react";
 
-const RouteComponent = () => (
-	<div className="grid gap-6">
-		<div className="grid gap-1">
-			<h2 className="text-xl font-semibold tracking-tight">Product settings</h2>
-			<p className="text-muted-foreground text-sm leading-6">
-				Configure product-level defaults and Connected Accounts. These choices prepare Better Agent,
-				but a Thinkspace Agent still needs scoped Permissions before it can use a resource.
-			</p>
-		</div>
+const routeApi = getRouteApi("/settings/product");
 
-		<section className="grid gap-3" aria-labelledby="product-defaults-heading">
-			<div className="flex items-center justify-between gap-3 border border-border p-4">
-				<div className="grid gap-1">
-					<div className="flex flex-wrap items-center gap-2">
-						<h3 id="product-defaults-heading" className="font-medium">
-							Coordinator defaults
-						</h3>
-						<Badge variant="outline">Coming next</Badge>
-					</div>
-					<p className="text-muted-foreground text-sm leading-6">
-						Future defaults for model preference and product-wide review posture. They are not
-						standing approvals for any Thinkspace.
-					</p>
-				</div>
-				<span
-					aria-label="Coordinator defaults placeholder"
-					className="inline-flex h-5 w-9 items-center border border-border bg-muted opacity-50"
-					role="switch"
-					aria-checked="false"
-				>
-					<span className="ml-0.5 size-4 bg-muted-foreground/40" />
-				</span>
-			</div>
-		</section>
+const PROVIDER_LABELS = {
+	anthropic: "Anthropic",
+	google: "Google",
+	openai: "OpenAI",
+} as const;
 
-		<Separator />
+const RouteComponent = () => {
+	const context = routeApi.useRouteContext();
+	const queryClient = useQueryClient();
+	const catalogQuery = useSuspenseQuery(context.orpc.models.listAvailable.queryOptions());
+	const credentialsQuery = useSuspenseQuery(context.orpc.models.listCredentials.queryOptions());
+	const [providerId, setProviderId] = useState<keyof typeof PROVIDER_LABELS>("openai");
+	const [credential, setCredential] = useState("");
+	const [label, setLabel] = useState("");
+	const saveCredential = useMutation(
+		context.orpc.models.saveCredential.mutationOptions({
+			onSuccess: async () => {
+				setCredential("");
+				setLabel("");
+				await Promise.all([
+					queryClient.invalidateQueries({ queryKey: context.orpc.models.listAvailable.queryKey() }),
+					queryClient.invalidateQueries({
+						queryKey: context.orpc.models.listCredentials.queryKey(),
+					}),
+				]);
+			},
+		}),
+	);
 
-		<section className="grid gap-3" aria-labelledby="connected-accounts-heading">
+	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (credential.trim().length < 8 || saveCredential.isPending) {
+			return;
+		}
+		saveCredential.mutate({ credential, label: label.trim() || undefined, providerId });
+	};
+
+	return (
+		<div className="grid gap-6">
 			<div className="grid gap-1">
-				<h3 id="connected-accounts-heading" className="font-medium">
-					Connected Accounts
-				</h3>
+				<h2 className="text-xl font-semibold tracking-tight">Product settings</h2>
 				<p className="text-muted-foreground text-sm leading-6">
-					Connect external services at the product level first. Later, grant narrow Thinkspace
-					Permissions from inside a Thinkspace.
+					Configure product-level defaults and Connected Accounts. These choices prepare Better
+					Agent, but a Thinkspace Agent still needs scoped Permissions before it can use a resource.
 				</p>
 			</div>
-			<div className="grid gap-2">
-				<div className="flex flex-col gap-3 border border-border p-4 sm:flex-row sm:items-center sm:justify-between">
-					<div className="grid gap-1">
-						<p className="font-medium">GitHub</p>
-						<p className="text-muted-foreground text-sm">
-							Not connected. Connecting here will not grant repository access to any Thinkspace by
-							itself.
-						</p>
-					</div>
-					<Button disabled type="button" variant="outline">
-						Connect later
-					</Button>
+
+			<section className="grid gap-3" aria-labelledby="model-catalog-heading">
+				<div className="grid gap-1">
+					<h3 id="model-catalog-heading" className="font-medium">
+						Model catalog
+					</h3>
+					<p className="text-muted-foreground text-sm leading-6">
+						Public model metadata is visible here. BYOK credentials make models available to your
+						account, but do not grant access to any Thinkspace by themselves.
+					</p>
 				</div>
-				<div className="flex flex-col gap-3 border border-border p-4 sm:flex-row sm:items-center sm:justify-between">
-					<div className="grid gap-1">
-						<p className="font-medium">Local Node</p>
-						<p className="text-muted-foreground text-sm">
-							No Local Node registered. Local resources will require scoped Permissions per
-							Thinkspace.
-						</p>
-					</div>
-					<Button disabled type="button" variant="outline">
-						Register later
-					</Button>
+				<div className="grid gap-2">
+					{catalogQuery.data.map((model) => (
+						<div
+							key={model.id}
+							className="grid gap-2 border border-border p-4 sm:grid-cols-[1fr_auto] sm:items-start"
+						>
+							<div className="grid gap-1">
+								<div className="flex flex-wrap items-center gap-2">
+									<p className="font-medium">{model.name}</p>
+									<Badge variant="outline">{model.providerName}</Badge>
+									<Badge variant={model.availableForAccount ? "default" : "outline"}>
+										{model.access === "app_provided" ? "App-provided" : "BYOK"}
+									</Badge>
+									{model.requiresThinkspacePermission ? (
+										<Badge variant="outline">Needs Thinkspace Permission</Badge>
+									) : null}
+								</div>
+								<p className="text-muted-foreground text-sm">{model.description}</p>
+								<p className="text-muted-foreground text-xs">
+									{model.id} · {model.contextWindow.toLocaleString()} context · reasoning:{" "}
+									{model.reasoning}
+								</p>
+							</div>
+							<span className="text-muted-foreground text-xs">
+								{model.availableForAccount ? "Available" : "Add credential"}
+							</span>
+						</div>
+					))}
 				</div>
-			</div>
-		</section>
-	</div>
-);
+			</section>
+
+			<Separator />
+
+			<section className="grid gap-3" aria-labelledby="provider-credentials-heading">
+				<div className="grid gap-1">
+					<h3 id="provider-credentials-heading" className="font-medium">
+						Provider credentials
+					</h3>
+					<p className="text-muted-foreground text-sm leading-6">
+						Credentials are encrypted when saved and only redacted status is returned after save.
+					</p>
+				</div>
+				<form className="grid gap-3 border border-border p-4" onSubmit={handleSubmit}>
+					<div className="grid gap-1.5">
+						<Label htmlFor="provider">Provider</Label>
+						<select
+							id="provider"
+							className="border border-input bg-background px-2.5 py-2 text-sm"
+							value={providerId}
+							onChange={(event) =>
+								setProviderId(event.target.value as keyof typeof PROVIDER_LABELS)
+							}
+						>
+							{Object.entries(PROVIDER_LABELS).map(([id, name]) => (
+								<option key={id} value={id}>
+									{name}
+								</option>
+							))}
+						</select>
+					</div>
+					<div className="grid gap-1.5">
+						<Label htmlFor="credential-label">Label</Label>
+						<Input
+							id="credential-label"
+							value={label}
+							onChange={(event) => setLabel(event.target.value)}
+							placeholder="Optional label"
+						/>
+					</div>
+					<div className="grid gap-1.5">
+						<Label htmlFor="credential">API key</Label>
+						<Input
+							id="credential"
+							type="password"
+							value={credential}
+							onChange={(event) => setCredential(event.target.value)}
+							placeholder="Paste provider API key"
+						/>
+					</div>
+					{saveCredential.error ? (
+						<p className="text-destructive text-xs" role="alert">
+							{saveCredential.error.message}
+						</p>
+					) : null}
+					<Button
+						className="w-fit"
+						type="submit"
+						disabled={credential.trim().length < 8 || saveCredential.isPending}
+					>
+						{saveCredential.isPending ? "Saving…" : "Save encrypted credential"}
+					</Button>
+				</form>
+				<div className="grid gap-2">
+					{credentialsQuery.data.length === 0 ? (
+						<p className="text-muted-foreground text-sm">No provider credentials saved.</p>
+					) : null}
+					{credentialsQuery.data.map((entry) => (
+						<div
+							key={entry.id}
+							className="flex flex-col gap-1 border border-border p-3 text-sm sm:flex-row sm:items-center sm:justify-between"
+						>
+							<span>
+								{PROVIDER_LABELS[entry.providerId as keyof typeof PROVIDER_LABELS]}{" "}
+								{entry.label ? `· ${entry.label}` : ""}
+							</span>
+							<span className="text-muted-foreground">
+								{entry.redactedCredential} · Permission still scoped per Thinkspace
+							</span>
+						</div>
+					))}
+				</div>
+			</section>
+		</div>
+	);
+};
 
 export const Route = createFileRoute("/settings/product")({
 	component: RouteComponent,

--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,10 @@
     "packages/api": {
       "name": "@better-agent/api",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.81",
+        "@ai-sdk/google": "^3.0.80",
+        "@ai-sdk/openai": "^3.0.68",
+        "@ai-sdk/provider": "^3.0.0",
         "@better-agent/auth": "workspace:*",
         "@better-agent/db": "workspace:*",
         "@better-agent/env": "workspace:*",
@@ -100,6 +104,7 @@
         "@orpc/openapi": "catalog:",
         "@orpc/server": "catalog:",
         "@orpc/zod": "catalog:",
+        "ai": "catalog:",
         "dotenv": "catalog:",
         "drizzle-orm": "^0.45.1",
         "zod": "catalog:",
@@ -218,6 +223,18 @@
     "zod": "^4.1.13",
   },
   "packages": {
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.81", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-B1JDd9Ugq9R5AgIaW3674lhGCMMYJcPUxnrZh8fzbGojgg4QvHFRv6eZahGQAUsmGHbcf74G9bdSBDLWQGY2GA=="],
+
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.125", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-tocl7cUDoTpmhZqeW8XVKMMznZQwwQAEunF0VyNKmf64qt8NbMIAEiet/vRMzh7Jr9WcFeb6EZjmhLTP4Qx2Og=="],
+
+    "@ai-sdk/google": ["@ai-sdk/google@3.0.80", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-5ORbm/yFUPO0MEvZsxBMN0cdKw2+lwU/wVn5KN3KF8Dmk1LughuDuUohMh/7iU/XFTiyB0OvmTW/tdV/J7O9zg=="],
+
+    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.68", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-FCs/DPr4M95UyZ/ABHJmTmCEYRCka/4J0Bna0nsd78QCdGIS0X/zhn+fVzB7mZJo7464uOWYUjROx9PGNGOb0w=="],
+
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
+
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
 
     "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
@@ -966,11 +983,15 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
+    "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.2", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.0" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ai": ["ai@6.0.197", "", { "dependencies": { "@ai-sdk/gateway": "3.0.125", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-U3KsjkqwQXGHC0u0VeUDqUaNaBS/uQc7v4Vj92Cjv5lPx5DIyRBQYk4Hipy5vwD9AQKIG8uRvdaN9R+pAvrtcQ=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -1367,6 +1388,8 @@
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,6 +13,10 @@
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@ai-sdk/anthropic": "^3.0.81",
+		"@ai-sdk/google": "^3.0.80",
+		"@ai-sdk/openai": "^3.0.68",
+		"@ai-sdk/provider": "^3.0.0",
 		"@better-agent/auth": "workspace:*",
 		"@better-agent/db": "workspace:*",
 		"@better-agent/env": "workspace:*",
@@ -20,6 +24,7 @@
 		"@orpc/openapi": "catalog:",
 		"@orpc/server": "catalog:",
 		"@orpc/zod": "catalog:",
+		"ai": "catalog:",
 		"dotenv": "catalog:",
 		"drizzle-orm": "^0.45.1",
 		"zod": "catalog:"

--- a/packages/api/src/models/catalog.ts
+++ b/packages/api/src/models/catalog.ts
@@ -1,0 +1,147 @@
+export const MODEL_PROVIDER_IDS = ["openai", "anthropic", "google"] as const;
+export type ModelProviderId = (typeof MODEL_PROVIDER_IDS)[number];
+
+export type ModelAccess = "app_provided" | "byok";
+export type ModelCapability = "text" | "tools" | "images" | "audio" | "video" | "pdf" | "reasoning";
+
+export interface ModelCatalogEntry {
+	access: ModelAccess;
+	capabilities: ModelCapability[];
+	contextWindow: number;
+	costPer1MTokens?: { input: number; output: number };
+	description: string;
+	id: `${ModelProviderId}:${string}`;
+	maxOutputTokens?: number;
+	name: string;
+	providerId: ModelProviderId;
+	providerName: string;
+	reasoning: "none" | "openai_reasoning_effort" | "anthropic_thinking" | "google_thinking_config";
+	reviewedAt: string;
+	source: string;
+}
+
+export const DEFAULT_MODEL_ID = "google:gemini-2.5-flash-lite";
+const REVIEWED_AT = "2026-06-04";
+const SOURCE = "Better Chat model catalog salvage, reviewed against AI SDK v6 provider factories.";
+
+export const MODEL_CATALOG = [
+	{
+		access: "app_provided",
+		capabilities: ["text", "tools", "images"],
+		contextWindow: 128_000,
+		costPer1MTokens: { input: 0.15, output: 0.6 },
+		description: "App-provided GPT-4o mini access with 128K context and vision support.",
+		id: "openai:gpt-4o-mini",
+		maxOutputTokens: 16_384,
+		name: "GPT-4o mini",
+		providerId: "openai",
+		providerName: "OpenAI",
+		reasoning: "none",
+		reviewedAt: REVIEWED_AT,
+		source: SOURCE,
+	},
+	{
+		access: "app_provided",
+		capabilities: ["text", "tools", "images", "audio", "video", "pdf", "reasoning"],
+		contextWindow: 1_048_576,
+		costPer1MTokens: { input: 0.1, output: 0.4 },
+		description: "App-provided Gemini 2.5 Flash Lite with 1M context and multimodal I/O.",
+		id: "google:gemini-2.5-flash-lite",
+		maxOutputTokens: 65_536,
+		name: "Gemini 2.5 Flash Lite",
+		providerId: "google",
+		providerName: "Google",
+		reasoning: "google_thinking_config",
+		reviewedAt: REVIEWED_AT,
+		source: SOURCE,
+	},
+	{
+		access: "byok",
+		capabilities: ["text", "tools", "images"],
+		contextWindow: 1_047_576,
+		costPer1MTokens: { input: 2, output: 8 },
+		description: "GPT-4.1 flagship with 1M context and vision support.",
+		id: "openai:gpt-4.1",
+		maxOutputTokens: 32_768,
+		name: "GPT-4.1",
+		providerId: "openai",
+		providerName: "OpenAI",
+		reasoning: "none",
+		reviewedAt: REVIEWED_AT,
+		source: SOURCE,
+	},
+	{
+		access: "byok",
+		capabilities: ["text", "tools", "images", "reasoning"],
+		contextWindow: 200_000,
+		costPer1MTokens: { input: 1.1, output: 4.4 },
+		description: "Reasoning-focused o4 mini with vision and tool use.",
+		id: "openai:o4-mini",
+		maxOutputTokens: 100_000,
+		name: "o4-mini",
+		providerId: "openai",
+		providerName: "OpenAI",
+		reasoning: "openai_reasoning_effort",
+		reviewedAt: REVIEWED_AT,
+		source: SOURCE,
+	},
+	{
+		access: "byok",
+		capabilities: ["text", "tools", "images", "audio", "video", "pdf", "reasoning"],
+		contextWindow: 1_048_576,
+		costPer1MTokens: { input: 0.3, output: 2.5 },
+		description: "Gemini 2.5 Flash multimodal model with native Google thinking support.",
+		id: "google:gemini-2.5-flash",
+		maxOutputTokens: 65_536,
+		name: "Gemini 2.5 Flash",
+		providerId: "google",
+		providerName: "Google",
+		reasoning: "google_thinking_config",
+		reviewedAt: REVIEWED_AT,
+		source: SOURCE,
+	},
+	{
+		access: "byok",
+		capabilities: ["text", "tools", "images", "audio", "video", "pdf", "reasoning"],
+		contextWindow: 1_048_576,
+		costPer1MTokens: { input: 1.25, output: 10 },
+		description: "Gemini 2.5 Pro with 1M context and native Google thinking support.",
+		id: "google:gemini-2.5-pro",
+		maxOutputTokens: 65_536,
+		name: "Gemini 2.5 Pro",
+		providerId: "google",
+		providerName: "Google",
+		reasoning: "google_thinking_config",
+		reviewedAt: REVIEWED_AT,
+		source: SOURCE,
+	},
+	{
+		access: "byok",
+		capabilities: ["text", "tools", "images", "reasoning"],
+		contextWindow: 200_000,
+		costPer1MTokens: { input: 3, output: 15 },
+		description: "Claude Sonnet 4.5 balanced for depth and speed with native thinking.",
+		id: "anthropic:claude-sonnet-4-5-20250929",
+		maxOutputTokens: 64_000,
+		name: "Claude Sonnet 4.5",
+		providerId: "anthropic",
+		providerName: "Anthropic",
+		reasoning: "anthropic_thinking",
+		reviewedAt: REVIEWED_AT,
+		source: SOURCE,
+	},
+] as const satisfies ModelCatalogEntry[];
+
+export const getModelCatalog = (): ModelCatalogEntry[] => [...MODEL_CATALOG];
+export const getModelDefinition = (modelId: string): ModelCatalogEntry | null =>
+	MODEL_CATALOG.find((model) => model.id === modelId) ?? null;
+export const parseModelId = (
+	modelId: string,
+): { providerId: ModelProviderId; providerModelId: string } => {
+	const [providerId, ...modelParts] = modelId.split(":");
+	const providerModelId = modelParts.join(":");
+	if (!MODEL_PROVIDER_IDS.includes(providerId as ModelProviderId) || !providerModelId) {
+		throw new Error(`Invalid model id: ${modelId}`);
+	}
+	return { providerId: providerId as ModelProviderId, providerModelId };
+};

--- a/packages/api/src/models/credentials.ts
+++ b/packages/api/src/models/credentials.ts
@@ -1,0 +1,114 @@
+import type { ProductDb } from "@better-agent/db";
+import { schema } from "@better-agent/db";
+import { and, eq } from "drizzle-orm";
+
+import type { ModelProviderId } from "./catalog";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const toBase64 = (value: ArrayBuffer | ArrayBufferView): string => {
+	const bytes =
+		value instanceof ArrayBuffer
+			? new Uint8Array(value)
+			: new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+	return btoa(String.fromCodePoint(...bytes));
+};
+const fromBase64 = (value: string): Uint8Array =>
+	Uint8Array.from(atob(value), (char) => char.codePointAt(0) ?? 0);
+
+const importKey = async (secret: string): Promise<CryptoKey> => {
+	const digest = await crypto.subtle.digest("SHA-256", encoder.encode(secret));
+	return await crypto.subtle.importKey("raw", digest, "AES-GCM", false, ["encrypt", "decrypt"]);
+};
+
+export const encryptCredential = async (credential: string, secret: string): Promise<string> => {
+	const iv = crypto.getRandomValues(new Uint8Array(12));
+	const ciphertext = await crypto.subtle.encrypt(
+		{ iv, name: "AES-GCM" },
+		await importKey(secret),
+		encoder.encode(credential),
+	);
+	return JSON.stringify({ alg: "AES-GCM", ciphertext: toBase64(ciphertext), iv: toBase64(iv) });
+};
+
+export const decryptCredential = async (
+	encryptedCredential: string,
+	secret: string,
+): Promise<string> => {
+	const payload = JSON.parse(encryptedCredential) as { iv: string; ciphertext: string };
+	const plaintext = await crypto.subtle.decrypt(
+		{ iv: fromBase64(payload.iv), name: "AES-GCM" },
+		await importKey(secret),
+		fromBase64(payload.ciphertext),
+	);
+	return decoder.decode(plaintext);
+};
+
+export const redactCredential = (credential: string): string => {
+	if (credential.length <= 8) {
+		return "••••";
+	}
+	return `${credential.slice(0, 4)}…${credential.slice(-4)}`;
+};
+
+export const upsertProviderCredential = async (
+	db: ProductDb,
+	input: {
+		encryptedCredential: string;
+		id: string;
+		label?: string;
+		providerId: ModelProviderId;
+		userId: string;
+	},
+) => {
+	const now = new Date();
+	await db
+		.insert(schema.userProviderCredentials)
+		.values({
+			encryptedCredential: input.encryptedCredential,
+			id: input.id,
+			label: input.label,
+			metadata: JSON.stringify({ permissionBoundary: "product_connected_account_only" }),
+			providerId: input.providerId,
+			updatedAt: now,
+			userId: input.userId,
+		})
+		.onConflictDoUpdate({
+			set: { encryptedCredential: input.encryptedCredential, label: input.label, updatedAt: now },
+			target: [schema.userProviderCredentials.userId, schema.userProviderCredentials.providerId],
+		});
+};
+
+export const listProviderCredentials = async (db: ProductDb, userId: string) =>
+	await db
+		.select()
+		.from(schema.userProviderCredentials)
+		.where(eq(schema.userProviderCredentials.userId, userId));
+
+export const getCredentialMap = async (
+	db: ProductDb,
+	userId: string,
+): Promise<Partial<Record<ModelProviderId, true>>> => {
+	const rows = await listProviderCredentials(db, userId);
+	return Object.fromEntries(rows.map((row) => [row.providerId, true])) as Partial<
+		Record<ModelProviderId, true>
+	>;
+};
+
+export const getDecryptedCredential = async (
+	db: ProductDb,
+	input: { providerId: ModelProviderId; secret: string; userId: string },
+): Promise<string | null> => {
+	const [row] = await db
+		.select()
+		.from(schema.userProviderCredentials)
+		.where(
+			and(
+				eq(schema.userProviderCredentials.userId, input.userId),
+				eq(schema.userProviderCredentials.providerId, input.providerId),
+			),
+		)
+		.limit(1);
+	return row ? await decryptCredential(row.encryptedCredential, input.secret) : null;
+};

--- a/packages/api/src/models/resolver.test.ts
+++ b/packages/api/src/models/resolver.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getModelDefinition, parseModelId } from "./catalog";
+import {
+	getReasoningProviderOptions,
+	ModelResolutionError,
+	resolveLanguageModel,
+} from "./resolver";
+
+test("parses native provider:model identifiers", () => {
+	assert.deepEqual(parseModelId("google:gemini-2.5-flash"), {
+		providerId: "google",
+		providerModelId: "gemini-2.5-flash",
+	});
+	assert.throws(() => parseModelId("google"));
+});
+
+test("rejects unknown models", () => {
+	assert.throws(
+		() => resolveLanguageModel({ appCredentials: {}, policy: { modelId: "openai:not-real" } }),
+		ModelResolutionError,
+	);
+});
+
+test("requires explicit Thinkspace Permission before a BYOK credential can resolve", () => {
+	assert.throws(
+		() =>
+			resolveLanguageModel({
+				policy: { modelId: "openai:gpt-4.1" },
+				userCredentials: { openai: "sk-test" },
+			}),
+		/Permission/u,
+	);
+});
+
+test("resolves Google BYOK through the native Google provider seam", () => {
+	const resolved = resolveLanguageModel({
+		policy: { credentialPermission: "granted", modelId: "google:gemini-2.5-flash" },
+		userCredentials: { google: "google-test-key" },
+	});
+
+	assert.equal(resolved.providerId, "google");
+	assert.equal(resolved.credentialSource, "user_byok");
+	assert.equal(resolved.providerModelId, "gemini-2.5-flash");
+	assert.notEqual(resolved.providerId, "openai");
+});
+
+test("maps provider-native reasoning options", () => {
+	const openai = getModelDefinition("openai:o4-mini");
+	const anthropic = getModelDefinition("anthropic:claude-sonnet-4-5-20250929");
+	const google = getModelDefinition("google:gemini-2.5-flash");
+
+	assert.deepEqual(openai && getReasoningProviderOptions(openai, "high"), {
+		openai: { reasoningEffort: "high" },
+	});
+	assert.deepEqual(anthropic && getReasoningProviderOptions(anthropic, "low"), {
+		anthropic: { thinking: { budgetTokens: 10_000, type: "enabled" } },
+	});
+	assert.deepEqual(google && getReasoningProviderOptions(google, "medium"), {
+		google: { thinkingConfig: { includeThoughts: true, thinkingBudget: 8192 } },
+	});
+});

--- a/packages/api/src/models/resolver.ts
+++ b/packages/api/src/models/resolver.ts
@@ -1,0 +1,129 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createGoogleGenerativeAI as createGoogle } from "@ai-sdk/google";
+import { createOpenAI } from "@ai-sdk/openai";
+import type { LanguageModelV3, SharedV3ProviderOptions } from "@ai-sdk/provider";
+import { defaultSettingsMiddleware, wrapLanguageModel } from "ai";
+
+import { getModelDefinition, parseModelId } from "./catalog";
+import type { ModelCatalogEntry, ModelProviderId } from "./catalog";
+
+export type ReasoningEffort = "low" | "medium" | "high";
+export type CredentialSource = "app_provided" | "user_byok";
+
+export interface ThinkspaceModelPolicy {
+	credentialPermission?: "not_granted" | "granted";
+	modelId: string;
+	reasoningEffort?: ReasoningEffort;
+}
+
+export interface ResolveLanguageModelInput {
+	appCredentials?: Partial<Record<ModelProviderId, string | undefined>>;
+	policy: ThinkspaceModelPolicy;
+	userCredentials?: Partial<Record<ModelProviderId, string | undefined>>;
+}
+
+export interface ResolvedLanguageModel {
+	credentialSource: CredentialSource;
+	model: LanguageModelV3;
+	modelDefinition: ModelCatalogEntry;
+	providerId: ModelProviderId;
+	providerModelId: string;
+	reasoningProviderOptions?: SharedV3ProviderOptions;
+	requiresThinkspacePermission: boolean;
+}
+
+const ANTHROPIC_BUDGET_MAP = { high: 64_000, low: 10_000, medium: 32_000 } as const;
+const GOOGLE_THINKING_BUDGET_MAP = { high: 16_384, low: 2048, medium: 8192 } as const;
+
+export class ModelResolutionError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ModelResolutionError";
+	}
+}
+
+export const getReasoningProviderOptions = (
+	model: ModelCatalogEntry,
+	effort: ReasoningEffort = "medium",
+): SharedV3ProviderOptions | undefined => {
+	if (model.reasoning === "openai_reasoning_effort") {
+		return { openai: { reasoningEffort: effort } };
+	}
+	if (model.reasoning === "anthropic_thinking") {
+		return {
+			anthropic: { thinking: { budgetTokens: ANTHROPIC_BUDGET_MAP[effort], type: "enabled" } },
+		};
+	}
+	if (model.reasoning === "google_thinking_config") {
+		return {
+			google: {
+				thinkingConfig: {
+					includeThoughts: true,
+					thinkingBudget: GOOGLE_THINKING_BUDGET_MAP[effort],
+				},
+			},
+		};
+	}
+	return undefined;
+};
+
+const withDefaultProviderOptions = (
+	model: LanguageModelV3,
+	providerOptions?: SharedV3ProviderOptions,
+): LanguageModelV3 => {
+	if (!providerOptions) {
+		return model;
+	}
+	return wrapLanguageModel({
+		middleware: defaultSettingsMiddleware({ settings: { providerOptions } }),
+		model,
+	});
+};
+
+export const resolveLanguageModel = ({
+	appCredentials,
+	policy,
+	userCredentials,
+}: ResolveLanguageModelInput): ResolvedLanguageModel => {
+	const modelDefinition = getModelDefinition(policy.modelId);
+	if (!modelDefinition) {
+		throw new ModelResolutionError(`Unknown model: ${policy.modelId}`);
+	}
+
+	const { providerId, providerModelId } = parseModelId(policy.modelId);
+	const requiresThinkspacePermission = modelDefinition.access === "byok";
+	if (requiresThinkspacePermission && policy.credentialPermission !== "granted") {
+		throw new ModelResolutionError(
+			"This Thinkspace has not been granted Permission to use the saved provider credential.",
+		);
+	}
+
+	const credentialSource: CredentialSource =
+		modelDefinition.access === "byok" ? "user_byok" : "app_provided";
+	const apiKey =
+		credentialSource === "user_byok" ? userCredentials?.[providerId] : appCredentials?.[providerId];
+	if (!apiKey) {
+		throw new ModelResolutionError(`Missing ${providerId} credential for ${policy.modelId}.`);
+	}
+
+	const providerOptions = getReasoningProviderOptions(modelDefinition, policy.reasoningEffort);
+	let baseModel: LanguageModelV3;
+	if (providerId === "openai") {
+		baseModel = createOpenAI({ apiKey })(providerModelId);
+	} else if (providerId === "anthropic") {
+		baseModel = createAnthropic({ apiKey })(providerModelId);
+	} else {
+		baseModel = createGoogle({ apiKey })(providerModelId);
+	}
+	const model = withDefaultProviderOptions(baseModel, providerOptions);
+
+	return {
+		credentialSource,
+		model,
+		modelDefinition,
+		providerId,
+		providerModelId,
+		reasoningProviderOptions: providerOptions,
+		requiresThinkspacePermission,
+	};
+};

--- a/packages/api/src/models/router.ts
+++ b/packages/api/src/models/router.ts
@@ -1,0 +1,74 @@
+import { ORPCError } from "@orpc/server";
+import { z } from "zod";
+
+import { protectedProcedure, publicProcedure } from "../procedures";
+import { getModelCatalog, MODEL_PROVIDER_IDS } from "./catalog";
+import {
+	encryptCredential,
+	getCredentialMap,
+	listProviderCredentials,
+	redactCredential,
+	upsertProviderCredential,
+} from "./credentials";
+
+const providerIdSchema = z.enum(MODEL_PROVIDER_IDS);
+const saveCredentialInput = z.object({
+	credential: z.string().trim().min(8),
+	label: z.string().trim().max(80).optional(),
+	providerId: providerIdSchema,
+});
+
+const encryptionSecret = (env: { API_ENCRYPTION_KEY?: string; BETTER_AUTH_SECRET: string }) =>
+	env.API_ENCRYPTION_KEY ?? env.BETTER_AUTH_SECRET;
+
+export const modelsRouter = {
+	list: publicProcedure.handler(() => getModelCatalog()),
+	listAvailable: protectedProcedure.handler(async ({ context }) => {
+		const credentials = await getCredentialMap(context.db, context.session.user.id);
+		return getModelCatalog().map((model) => ({
+			...model,
+			availableForAccount:
+				model.access === "app_provided" || Boolean(credentials[model.providerId]),
+			requiresThinkspacePermission: model.access === "byok",
+		}));
+	}),
+	listCredentials: protectedProcedure.handler(async ({ context }) => {
+		const rows = await listProviderCredentials(context.db, context.session.user.id);
+		return rows.map((row) => ({
+			createdAt: row.createdAt,
+			id: row.id,
+			label: row.label,
+			permissionBoundary:
+				"Saved credential is a product-level Connected Account only; each Thinkspace still needs Permission.",
+			providerId: row.providerId,
+			redactedCredential: "••••",
+			updatedAt: row.updatedAt,
+		}));
+	}),
+	saveCredential: protectedProcedure
+		.input(saveCredentialInput)
+		.handler(async ({ context, input }) => {
+			try {
+				await upsertProviderCredential(context.db, {
+					encryptedCredential: await encryptCredential(
+						input.credential,
+						encryptionSecret(context.env),
+					),
+					id: `provider_credential_${crypto.randomUUID()}`,
+					label: input.label,
+					providerId: input.providerId,
+					userId: context.session.user.id,
+				});
+				return {
+					permissionBoundary:
+						"Saved credential is a product-level Connected Account only; each Thinkspace still needs Permission.",
+					providerId: input.providerId,
+					redactedCredential: redactCredential(input.credential),
+				};
+			} catch (error) {
+				throw new ORPCError("INTERNAL_SERVER_ERROR", {
+					message: error instanceof Error ? error.message : "Credential could not be saved.",
+				});
+			}
+		}),
+};

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -1,11 +1,13 @@
 import type { InferRouterInputs, InferRouterOutputs, RouterClient } from "@orpc/server";
 
+import { modelsRouter } from "../models/router";
 import { profileRouter } from "../profile/router";
 import { publicProcedure } from "../procedures";
 import { thinkspacesRouter } from "../thinkspaces/router";
 
 export const appRouter = {
 	healthCheck: publicProcedure.handler(() => "OK"),
+	models: modelsRouter,
 	profile: profileRouter,
 	thinkspaces: thinkspacesRouter,
 };

--- a/packages/env/src/types.ts
+++ b/packages/env/src/types.ts
@@ -3,5 +3,9 @@ export interface CloudflareEnv {
 	BETTER_AUTH_URL: string;
 	CORS_ORIGIN: string;
 	DB: D1Database;
+	API_ENCRYPTION_KEY?: string;
+	GOOGLE_GENERATIVE_AI_API_KEY?: string;
+	OPENAI_API_KEY?: string;
+	ANTHROPIC_API_KEY?: string;
 	VITE_SERVER_URL?: string;
 }


### PR DESCRIPTION
## Problem / Intent

Better Agent needs a product-level model catalog and BYOK credential seam for future Thinkspace Agent runtime work without preserving Better Chat's request-scoped chat completion architecture.

## Approach

Expose non-sensitive model metadata through the API and product settings UI, store provider credentials encrypted with redacted responses, and add a runtime resolver seam that uses AI SDK v6 provider-native factories for OpenAI, Anthropic, and Google while keeping saved credentials behind an explicit Thinkspace Permission boundary.
