### PR TITLE
Port MCP catalog and connection storage

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -8,249 +8,245 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as ThinkspacesRouteImport } from './routes/thinkspaces'
-import { Route as SettingsRouteImport } from './routes/settings'
-import { Route as LoginRouteImport } from './routes/login'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as ThinkspacesIndexRouteImport } from './routes/thinkspaces.index'
-import { Route as SettingsIndexRouteImport } from './routes/settings.index'
-import { Route as ThinkspacesThinkspaceIdRouteImport } from './routes/thinkspaces.$thinkspaceId'
-import { Route as SettingsProfileRouteImport } from './routes/settings.profile'
-import { Route as SettingsProductRouteImport } from './routes/settings.product'
+import { Route as rootRouteImport } from "./routes/__root";
+import { Route as ThinkspacesRouteImport } from "./routes/thinkspaces";
+import { Route as SettingsRouteImport } from "./routes/settings";
+import { Route as LoginRouteImport } from "./routes/login";
+import { Route as IndexRouteImport } from "./routes/index";
+import { Route as ThinkspacesIndexRouteImport } from "./routes/thinkspaces.index";
+import { Route as SettingsIndexRouteImport } from "./routes/settings.index";
+import { Route as ThinkspacesThinkspaceIdRouteImport } from "./routes/thinkspaces.$thinkspaceId";
+import { Route as SettingsProfileRouteImport } from "./routes/settings.profile";
+import { Route as SettingsProductRouteImport } from "./routes/settings.product";
 
 const ThinkspacesRoute = ThinkspacesRouteImport.update({
-  id: '/thinkspaces',
-  path: '/thinkspaces',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: "/thinkspaces",
+	path: "/thinkspaces",
+	getParentRoute: () => rootRouteImport,
+} as any);
 const SettingsRoute = SettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: "/settings",
+	path: "/settings",
+	getParentRoute: () => rootRouteImport,
+} as any);
 const LoginRoute = LoginRouteImport.update({
-  id: '/login',
-  path: '/login',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: "/login",
+	path: "/login",
+	getParentRoute: () => rootRouteImport,
+} as any);
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: "/",
+	path: "/",
+	getParentRoute: () => rootRouteImport,
+} as any);
 const ThinkspacesIndexRoute = ThinkspacesIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => ThinkspacesRoute,
-} as any)
+	id: "/",
+	path: "/",
+	getParentRoute: () => ThinkspacesRoute,
+} as any);
 const SettingsIndexRoute = SettingsIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => SettingsRoute,
-} as any)
+	id: "/",
+	path: "/",
+	getParentRoute: () => SettingsRoute,
+} as any);
 const ThinkspacesThinkspaceIdRoute = ThinkspacesThinkspaceIdRouteImport.update({
-  id: '/$thinkspaceId',
-  path: '/$thinkspaceId',
-  getParentRoute: () => ThinkspacesRoute,
-} as any)
+	id: "/$thinkspaceId",
+	path: "/$thinkspaceId",
+	getParentRoute: () => ThinkspacesRoute,
+} as any);
 const SettingsProfileRoute = SettingsProfileRouteImport.update({
-  id: '/profile',
-  path: '/profile',
-  getParentRoute: () => SettingsRoute,
-} as any)
+	id: "/profile",
+	path: "/profile",
+	getParentRoute: () => SettingsRoute,
+} as any);
 const SettingsProductRoute = SettingsProductRouteImport.update({
-  id: '/product',
-  path: '/product',
-  getParentRoute: () => SettingsRoute,
-} as any)
+	id: "/product",
+	path: "/product",
+	getParentRoute: () => SettingsRoute,
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/login': typeof LoginRoute
-  '/settings': typeof SettingsRouteWithChildren
-  '/thinkspaces': typeof ThinkspacesRouteWithChildren
-  '/settings/product': typeof SettingsProductRoute
-  '/settings/profile': typeof SettingsProfileRoute
-  '/thinkspaces/$thinkspaceId': typeof ThinkspacesThinkspaceIdRoute
-  '/settings/': typeof SettingsIndexRoute
-  '/thinkspaces/': typeof ThinkspacesIndexRoute
+	"/": typeof IndexRoute;
+	"/login": typeof LoginRoute;
+	"/settings": typeof SettingsRouteWithChildren;
+	"/thinkspaces": typeof ThinkspacesRouteWithChildren;
+	"/settings/product": typeof SettingsProductRoute;
+	"/settings/profile": typeof SettingsProfileRoute;
+	"/thinkspaces/$thinkspaceId": typeof ThinkspacesThinkspaceIdRoute;
+	"/settings/": typeof SettingsIndexRoute;
+	"/thinkspaces/": typeof ThinkspacesIndexRoute;
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/login': typeof LoginRoute
-  '/settings/product': typeof SettingsProductRoute
-  '/settings/profile': typeof SettingsProfileRoute
-  '/thinkspaces/$thinkspaceId': typeof ThinkspacesThinkspaceIdRoute
-  '/settings': typeof SettingsIndexRoute
-  '/thinkspaces': typeof ThinkspacesIndexRoute
+	"/": typeof IndexRoute;
+	"/login": typeof LoginRoute;
+	"/settings/product": typeof SettingsProductRoute;
+	"/settings/profile": typeof SettingsProfileRoute;
+	"/thinkspaces/$thinkspaceId": typeof ThinkspacesThinkspaceIdRoute;
+	"/settings": typeof SettingsIndexRoute;
+	"/thinkspaces": typeof ThinkspacesIndexRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/login': typeof LoginRoute
-  '/settings': typeof SettingsRouteWithChildren
-  '/thinkspaces': typeof ThinkspacesRouteWithChildren
-  '/settings/product': typeof SettingsProductRoute
-  '/settings/profile': typeof SettingsProfileRoute
-  '/thinkspaces/$thinkspaceId': typeof ThinkspacesThinkspaceIdRoute
-  '/settings/': typeof SettingsIndexRoute
-  '/thinkspaces/': typeof ThinkspacesIndexRoute
+	__root__: typeof rootRouteImport;
+	"/": typeof IndexRoute;
+	"/login": typeof LoginRoute;
+	"/settings": typeof SettingsRouteWithChildren;
+	"/thinkspaces": typeof ThinkspacesRouteWithChildren;
+	"/settings/product": typeof SettingsProductRoute;
+	"/settings/profile": typeof SettingsProfileRoute;
+	"/thinkspaces/$thinkspaceId": typeof ThinkspacesThinkspaceIdRoute;
+	"/settings/": typeof SettingsIndexRoute;
+	"/thinkspaces/": typeof ThinkspacesIndexRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths:
-    | '/'
-    | '/login'
-    | '/settings'
-    | '/thinkspaces'
-    | '/settings/product'
-    | '/settings/profile'
-    | '/thinkspaces/$thinkspaceId'
-    | '/settings/'
-    | '/thinkspaces/'
-  fileRoutesByTo: FileRoutesByTo
-  to:
-    | '/'
-    | '/login'
-    | '/settings/product'
-    | '/settings/profile'
-    | '/thinkspaces/$thinkspaceId'
-    | '/settings'
-    | '/thinkspaces'
-  id:
-    | '__root__'
-    | '/'
-    | '/login'
-    | '/settings'
-    | '/thinkspaces'
-    | '/settings/product'
-    | '/settings/profile'
-    | '/thinkspaces/$thinkspaceId'
-    | '/settings/'
-    | '/thinkspaces/'
-  fileRoutesById: FileRoutesById
+	fileRoutesByFullPath: FileRoutesByFullPath;
+	fullPaths:
+		| "/"
+		| "/login"
+		| "/settings"
+		| "/thinkspaces"
+		| "/settings/product"
+		| "/settings/profile"
+		| "/thinkspaces/$thinkspaceId"
+		| "/settings/"
+		| "/thinkspaces/";
+	fileRoutesByTo: FileRoutesByTo;
+	to:
+		| "/"
+		| "/login"
+		| "/settings/product"
+		| "/settings/profile"
+		| "/thinkspaces/$thinkspaceId"
+		| "/settings"
+		| "/thinkspaces";
+	id:
+		| "__root__"
+		| "/"
+		| "/login"
+		| "/settings"
+		| "/thinkspaces"
+		| "/settings/product"
+		| "/settings/profile"
+		| "/thinkspaces/$thinkspaceId"
+		| "/settings/"
+		| "/thinkspaces/";
+	fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  LoginRoute: typeof LoginRoute
-  SettingsRoute: typeof SettingsRouteWithChildren
-  ThinkspacesRoute: typeof ThinkspacesRouteWithChildren
+	IndexRoute: typeof IndexRoute;
+	LoginRoute: typeof LoginRoute;
+	SettingsRoute: typeof SettingsRouteWithChildren;
+	ThinkspacesRoute: typeof ThinkspacesRouteWithChildren;
 }
 
-declare module '@tanstack/react-router' {
-  interface FileRoutesByPath {
-    '/thinkspaces': {
-      id: '/thinkspaces'
-      path: '/thinkspaces'
-      fullPath: '/thinkspaces'
-      preLoaderRoute: typeof ThinkspacesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/settings': {
-      id: '/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof SettingsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/login': {
-      id: '/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof LoginRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/thinkspaces/': {
-      id: '/thinkspaces/'
-      path: '/'
-      fullPath: '/thinkspaces/'
-      preLoaderRoute: typeof ThinkspacesIndexRouteImport
-      parentRoute: typeof ThinkspacesRoute
-    }
-    '/settings/': {
-      id: '/settings/'
-      path: '/'
-      fullPath: '/settings/'
-      preLoaderRoute: typeof SettingsIndexRouteImport
-      parentRoute: typeof SettingsRoute
-    }
-    '/thinkspaces/$thinkspaceId': {
-      id: '/thinkspaces/$thinkspaceId'
-      path: '/$thinkspaceId'
-      fullPath: '/thinkspaces/$thinkspaceId'
-      preLoaderRoute: typeof ThinkspacesThinkspaceIdRouteImport
-      parentRoute: typeof ThinkspacesRoute
-    }
-    '/settings/profile': {
-      id: '/settings/profile'
-      path: '/profile'
-      fullPath: '/settings/profile'
-      preLoaderRoute: typeof SettingsProfileRouteImport
-      parentRoute: typeof SettingsRoute
-    }
-    '/settings/product': {
-      id: '/settings/product'
-      path: '/product'
-      fullPath: '/settings/product'
-      preLoaderRoute: typeof SettingsProductRouteImport
-      parentRoute: typeof SettingsRoute
-    }
-  }
+declare module "@tanstack/react-router" {
+	interface FileRoutesByPath {
+		"/thinkspaces": {
+			id: "/thinkspaces";
+			path: "/thinkspaces";
+			fullPath: "/thinkspaces";
+			preLoaderRoute: typeof ThinkspacesRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		"/settings": {
+			id: "/settings";
+			path: "/settings";
+			fullPath: "/settings";
+			preLoaderRoute: typeof SettingsRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		"/login": {
+			id: "/login";
+			path: "/login";
+			fullPath: "/login";
+			preLoaderRoute: typeof LoginRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		"/": {
+			id: "/";
+			path: "/";
+			fullPath: "/";
+			preLoaderRoute: typeof IndexRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		"/thinkspaces/": {
+			id: "/thinkspaces/";
+			path: "/";
+			fullPath: "/thinkspaces/";
+			preLoaderRoute: typeof ThinkspacesIndexRouteImport;
+			parentRoute: typeof ThinkspacesRoute;
+		};
+		"/settings/": {
+			id: "/settings/";
+			path: "/";
+			fullPath: "/settings/";
+			preLoaderRoute: typeof SettingsIndexRouteImport;
+			parentRoute: typeof SettingsRoute;
+		};
+		"/thinkspaces/$thinkspaceId": {
+			id: "/thinkspaces/$thinkspaceId";
+			path: "/$thinkspaceId";
+			fullPath: "/thinkspaces/$thinkspaceId";
+			preLoaderRoute: typeof ThinkspacesThinkspaceIdRouteImport;
+			parentRoute: typeof ThinkspacesRoute;
+		};
+		"/settings/profile": {
+			id: "/settings/profile";
+			path: "/profile";
+			fullPath: "/settings/profile";
+			preLoaderRoute: typeof SettingsProfileRouteImport;
+			parentRoute: typeof SettingsRoute;
+		};
+		"/settings/product": {
+			id: "/settings/product";
+			path: "/product";
+			fullPath: "/settings/product";
+			preLoaderRoute: typeof SettingsProductRouteImport;
+			parentRoute: typeof SettingsRoute;
+		};
+	}
 }
 
 interface SettingsRouteChildren {
-  SettingsProductRoute: typeof SettingsProductRoute
-  SettingsProfileRoute: typeof SettingsProfileRoute
-  SettingsIndexRoute: typeof SettingsIndexRoute
+	SettingsProductRoute: typeof SettingsProductRoute;
+	SettingsProfileRoute: typeof SettingsProfileRoute;
+	SettingsIndexRoute: typeof SettingsIndexRoute;
 }
 
 const SettingsRouteChildren: SettingsRouteChildren = {
-  SettingsProductRoute: SettingsProductRoute,
-  SettingsProfileRoute: SettingsProfileRoute,
-  SettingsIndexRoute: SettingsIndexRoute,
-}
+	SettingsProductRoute: SettingsProductRoute,
+	SettingsProfileRoute: SettingsProfileRoute,
+	SettingsIndexRoute: SettingsIndexRoute,
+};
 
-const SettingsRouteWithChildren = SettingsRoute._addFileChildren(
-  SettingsRouteChildren,
-)
+const SettingsRouteWithChildren = SettingsRoute._addFileChildren(SettingsRouteChildren);
 
 interface ThinkspacesRouteChildren {
-  ThinkspacesThinkspaceIdRoute: typeof ThinkspacesThinkspaceIdRoute
-  ThinkspacesIndexRoute: typeof ThinkspacesIndexRoute
+	ThinkspacesThinkspaceIdRoute: typeof ThinkspacesThinkspaceIdRoute;
+	ThinkspacesIndexRoute: typeof ThinkspacesIndexRoute;
 }
 
 const ThinkspacesRouteChildren: ThinkspacesRouteChildren = {
-  ThinkspacesThinkspaceIdRoute: ThinkspacesThinkspaceIdRoute,
-  ThinkspacesIndexRoute: ThinkspacesIndexRoute,
-}
+	ThinkspacesThinkspaceIdRoute: ThinkspacesThinkspaceIdRoute,
+	ThinkspacesIndexRoute: ThinkspacesIndexRoute,
+};
 
-const ThinkspacesRouteWithChildren = ThinkspacesRoute._addFileChildren(
-  ThinkspacesRouteChildren,
-)
+const ThinkspacesRouteWithChildren = ThinkspacesRoute._addFileChildren(ThinkspacesRouteChildren);
 
 const rootRouteChildren: RootRouteChildren = {
-  IndexRoute: IndexRoute,
-  LoginRoute: LoginRoute,
-  SettingsRoute: SettingsRouteWithChildren,
-  ThinkspacesRoute: ThinkspacesRouteWithChildren,
-}
+	IndexRoute: IndexRoute,
+	LoginRoute: LoginRoute,
+	SettingsRoute: SettingsRouteWithChildren,
+	ThinkspacesRoute: ThinkspacesRouteWithChildren,
+};
 export const routeTree = rootRouteImport
-  ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+	._addFileChildren(rootRouteChildren)
+	._addFileTypes<FileRouteTypes>();
 
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
+import type { getRouter } from "./router.tsx";
+import type { createStart } from "@tanstack/react-start";
+declare module "@tanstack/react-start" {
+	interface Register {
+		ssr: true;
+		router: Awaited<ReturnType<typeof getRouter>>;
+	}
 }

--- a/packages/api/src/mcp/catalog.ts
+++ b/packages/api/src/mcp/catalog.ts
@@ -1,0 +1,60 @@
+export type McpTransport = "streamable_http" | "sse";
+export type McpAuthType = "none" | "bearer" | "api_key_header";
+export type McpRiskLevel = "read_only" | "unknown" | "mutating";
+
+export interface BuiltInMcpServer {
+	authType: McpAuthType;
+	description: string;
+	enabledByDefaultForThinkspaces: false;
+	id: string;
+	name: string;
+	riskLevel: McpRiskLevel;
+	transport: McpTransport;
+	url: string;
+}
+
+export const BUILT_IN_MCP_SERVERS: BuiltInMcpServer[] = [
+	{
+		authType: "api_key_header",
+		description: "Up-to-date code documentation for LLMs and AI code editors.",
+		enabledByDefaultForThinkspaces: false,
+		id: "context7",
+		name: "Context7",
+		riskLevel: "read_only",
+		transport: "streamable_http",
+		url: "https://mcp.context7.com/mcp",
+	},
+	{
+		authType: "none",
+		description: "Complete Cloudflare platform documentation and guides.",
+		enabledByDefaultForThinkspaces: false,
+		id: "cloudflare-docs",
+		name: "Cloudflare Docs",
+		riskLevel: "read_only",
+		transport: "streamable_http",
+		url: "https://docs.mcp.cloudflare.com/mcp",
+	},
+	{
+		authType: "none",
+		description:
+			"AWS knowledge sources including docs, API references, and architectural guidance.",
+		enabledByDefaultForThinkspaces: false,
+		id: "aws-knowledge",
+		name: "AWS Knowledge",
+		riskLevel: "read_only",
+		transport: "streamable_http",
+		url: "https://knowledge-mcp.global.api.aws",
+	},
+	{
+		authType: "none",
+		description: "Microsoft Learn technical documentation and learning resources.",
+		enabledByDefaultForThinkspaces: false,
+		id: "microsoft-learn",
+		name: "Microsoft Learn",
+		riskLevel: "read_only",
+		transport: "streamable_http",
+		url: "https://learn.microsoft.com/api/mcp",
+	},
+];
+
+export const listBuiltInMcpServers = (): BuiltInMcpServer[] => [...BUILT_IN_MCP_SERVERS];

--- a/packages/api/src/mcp/repository.ts
+++ b/packages/api/src/mcp/repository.ts
@@ -1,0 +1,80 @@
+import type { ProductDb } from "@better-agent/db";
+import { schema } from "@better-agent/db";
+import { and, eq } from "drizzle-orm";
+
+export interface CustomMcpConnectionInput {
+	description?: string;
+	encryptedHeaders: string;
+	id: string;
+	name: string;
+	transport: "streamable_http" | "sse";
+	url: string;
+	userId: string;
+}
+
+export const createCustomMcpConnection = async (db: ProductDb, input: CustomMcpConnectionInput) => {
+	const [created] = await db
+		.insert(schema.userMcpConnections)
+		.values({
+			catalogVisible: true,
+			description: input.description,
+			encryptedHeaders: input.encryptedHeaders,
+			id: input.id,
+			name: input.name,
+			transport: input.transport,
+			url: input.url,
+			userId: input.userId,
+		})
+		.returning();
+	if (!created) {
+		throw new Error("MCP connection was not persisted.");
+	}
+
+	return created;
+};
+
+export const listCustomMcpConnections = async (db: ProductDb, userId: string) =>
+	await db
+		.select()
+		.from(schema.userMcpConnections)
+		.where(eq(schema.userMcpConnections.userId, userId));
+
+export const updateCustomMcpConnection = async (
+	db: ProductDb,
+	input: Partial<Omit<CustomMcpConnectionInput, "id" | "userId">> & { id: string; userId: string },
+) => {
+	const [updated] = await db
+		.update(schema.userMcpConnections)
+		.set({
+			description: input.description,
+			encryptedHeaders: input.encryptedHeaders,
+			name: input.name,
+			transport: input.transport,
+			updatedAt: new Date(),
+			url: input.url,
+		})
+		.where(
+			and(
+				eq(schema.userMcpConnections.id, input.id),
+				eq(schema.userMcpConnections.userId, input.userId),
+			),
+		)
+		.returning();
+	return updated ?? null;
+};
+
+export const deleteCustomMcpConnection = async (
+	db: ProductDb,
+	input: { id: string; userId: string },
+) => {
+	const deleted = await db
+		.delete(schema.userMcpConnections)
+		.where(
+			and(
+				eq(schema.userMcpConnections.id, input.id),
+				eq(schema.userMcpConnections.userId, input.userId),
+			),
+		)
+		.returning();
+	return deleted.length > 0;
+};

--- a/packages/api/src/mcp/router.ts
+++ b/packages/api/src/mcp/router.ts
@@ -1,0 +1,116 @@
+import { ORPCError } from "@orpc/server";
+import { z } from "zod";
+
+import { encryptCredential } from "../models/credentials";
+import { protectedProcedure, publicProcedure } from "../procedures";
+import { listBuiltInMcpServers } from "./catalog";
+import {
+	createCustomMcpConnection,
+	deleteCustomMcpConnection,
+	listCustomMcpConnections,
+	updateCustomMcpConnection,
+} from "./repository";
+import { assertSafeMcpServerUrl, McpUrlPolicyError } from "./url-policy";
+
+const transportSchema = z.enum(["streamable_http", "sse"]);
+const headersSchema = z.record(z.string().min(1), z.string().min(1)).optional();
+const connectionInput = z.object({
+	description: z.string().trim().max(400).optional(),
+	headers: headersSchema,
+	name: z.string().trim().min(1).max(100),
+	transport: transportSchema.default("streamable_http"),
+	url: z.string().trim().min(1),
+});
+const updateInput = connectionInput.partial().extend({ connectionId: z.string().min(1) });
+const deleteInput = z.object({ connectionId: z.string().min(1) });
+
+const encryptionSecret = (env: { API_ENCRYPTION_KEY?: string; BETTER_AUTH_SECRET: string }) =>
+	env.API_ENCRYPTION_KEY ?? env.BETTER_AUTH_SECRET;
+const redactHeaderNames = (headers: Record<string, string> | undefined) =>
+	Object.keys(headers ?? {}).map((name) => ({ name, value: "••••" }));
+const toConnectionOutput = (row: Awaited<ReturnType<typeof listCustomMcpConnections>>[number]) => ({
+	createdAt: row.createdAt,
+	description: row.description,
+	enabledByDefaultForThinkspaces: false,
+	id: row.id,
+	isBuiltIn: false,
+	name: row.name,
+	redactedHeaders:
+		row.encryptedHeaders === "{}" ? [] : [{ name: "stored secret headers", value: "••••" }],
+	transport: row.transport,
+	updatedAt: row.updatedAt,
+	url: row.url,
+});
+
+const toBadRequest = (error: Error) => new ORPCError("BAD_REQUEST", { message: error.message });
+
+export const mcpRouter = {
+	createConnection: protectedProcedure
+		.input(connectionInput)
+		.handler(async ({ context, input }) => {
+			try {
+				const url = assertSafeMcpServerUrl(input.url);
+				const encryptedHeaders = input.headers
+					? await encryptCredential(JSON.stringify(input.headers), encryptionSecret(context.env))
+					: "{}";
+				const created = await createCustomMcpConnection(context.db, {
+					description: input.description,
+					encryptedHeaders,
+					id: `mcp_connection_${crypto.randomUUID()}`,
+					name: input.name,
+					transport: input.transport,
+					url: url.toString(),
+					userId: context.session.user.id,
+				});
+				return {
+					...toConnectionOutput(created),
+					redactedHeaders: redactHeaderNames(input.headers),
+				};
+			} catch (error) {
+				if (error instanceof McpUrlPolicyError) {
+					throw toBadRequest(error);
+				}
+				throw error;
+			}
+		}),
+	deleteConnection: protectedProcedure.input(deleteInput).handler(async ({ context, input }) => {
+		const deleted = await deleteCustomMcpConnection(context.db, {
+			id: input.connectionId,
+			userId: context.session.user.id,
+		});
+		if (!deleted) {
+			throw new ORPCError("NOT_FOUND", { message: "MCP connection was not found." });
+		}
+		return { success: true };
+	}),
+	listCatalog: publicProcedure.handler(() => listBuiltInMcpServers()),
+	listConnections: protectedProcedure.handler(async ({ context }) => {
+		const rows = await listCustomMcpConnections(context.db, context.session.user.id);
+		return rows.map(toConnectionOutput);
+	}),
+	updateConnection: protectedProcedure.input(updateInput).handler(async ({ context, input }) => {
+		try {
+			const encryptedHeaders = input.headers
+				? await encryptCredential(JSON.stringify(input.headers), encryptionSecret(context.env))
+				: undefined;
+			const updated = await updateCustomMcpConnection(context.db, {
+				description: input.description,
+				encryptedHeaders,
+				id: input.connectionId,
+				name: input.name,
+				transport: input.transport,
+				url: input.url ? assertSafeMcpServerUrl(input.url).toString() : undefined,
+				userId: context.session.user.id,
+			});
+			if (!updated) {
+				throw new ORPCError("NOT_FOUND", { message: "MCP connection was not found." });
+			}
+			return { ...toConnectionOutput(updated), redactedHeaders: redactHeaderNames(input.headers) };
+		} catch (error) {
+			if (error instanceof McpUrlPolicyError) {
+				throw toBadRequest(error);
+			}
+			throw error;
+		}
+	}),
+};

--- a/packages/api/src/mcp/tool-identity.ts
+++ b/packages/api/src/mcp/tool-identity.ts
@@ -1,0 +1,20 @@
+export interface CanonicalMcpToolIdentity {
+	modelAlias: string;
+	serverId: string;
+	toolName: string;
+}
+
+const ALIAS_SAFE_CHARACTER = /[^a-zA-Z0-9_-]/gu;
+
+export const createCanonicalMcpToolIdentity = (
+	serverId: string,
+	toolName: string,
+): CanonicalMcpToolIdentity => {
+	const safeServerId = serverId.replace(ALIAS_SAFE_CHARACTER, "_");
+	const safeToolName = toolName.replace(ALIAS_SAFE_CHARACTER, "_");
+	return {
+		modelAlias: `${safeServerId}__${safeToolName}`,
+		serverId,
+		toolName,
+	};
+};

--- a/packages/api/src/mcp/url-policy.test.ts
+++ b/packages/api/src/mcp/url-policy.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { listBuiltInMcpServers } from "./catalog";
+import { createCanonicalMcpToolIdentity } from "./tool-identity";
+import { assertSafeMcpServerUrl, McpUrlPolicyError } from "./url-policy";
+
+test("built-in MCP catalog entries do not expose tools to Thinkspaces by default", () => {
+	assert.ok(listBuiltInMcpServers().some((server) => server.id === "context7"));
+	assert.equal(
+		listBuiltInMcpServers().every((server) => server.enabledByDefaultForThinkspaces === false),
+		true,
+	);
+});
+
+test("MCP URL policy requires HTTPS and blocks private targets", () => {
+	assert.equal(
+		assertSafeMcpServerUrl("https://docs.mcp.cloudflare.com/mcp").hostname,
+		"docs.mcp.cloudflare.com",
+	);
+	assert.throws(() => assertSafeMcpServerUrl("http://example.com/mcp"), McpUrlPolicyError);
+	assert.throws(() => assertSafeMcpServerUrl("https://127.0.0.1/mcp"), McpUrlPolicyError);
+	assert.throws(
+		() => assertSafeMcpServerUrl("https://169.254.169.254/latest/meta-data"),
+		McpUrlPolicyError,
+	);
+	assert.throws(
+		() => assertSafeMcpServerUrl("https://user:pass@example.com/mcp"),
+		McpUrlPolicyError,
+	);
+});
+
+test("tool identity keeps canonical server/tool ids separate from model aliases", () => {
+	assert.deepEqual(createCanonicalMcpToolIdentity("context7", "resolve-library-id"), {
+		modelAlias: "context7__resolve-library-id",
+		serverId: "context7",
+		toolName: "resolve-library-id",
+	});
+});

--- a/packages/api/src/mcp/url-policy.ts
+++ b/packages/api/src/mcp/url-policy.ts
@@ -1,0 +1,44 @@
+const PRIVATE_HOSTS = new Set(["localhost", "0.0.0.0", "127.0.0.1", "::1", "169.254.169.254"]);
+const PRIVATE_IPV4_RANGES = [
+	/^10\./u,
+	/^127\./u,
+	/^169\.254\./u,
+	/^172\.(1[6-9]|2\d|3[01])\./u,
+	/^192\.168\./u,
+];
+
+export class McpUrlPolicyError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "McpUrlPolicyError";
+	}
+}
+
+export const assertSafeMcpServerUrl = (value: string, allowInsecureDevUrls = false): URL => {
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		throw new McpUrlPolicyError("MCP server URL must be a valid URL.");
+	}
+
+	if (url.protocol !== "https:" && !allowInsecureDevUrls) {
+		throw new McpUrlPolicyError("MCP server URL must use HTTPS.");
+	}
+
+	const hostname = url.hostname.toLowerCase();
+	if (
+		!allowInsecureDevUrls &&
+		(PRIVATE_HOSTS.has(hostname) || PRIVATE_IPV4_RANGES.some((range) => range.test(hostname)))
+	) {
+		throw new McpUrlPolicyError(
+			"MCP server URL cannot target private, loopback, link-local, or cloud metadata hosts.",
+		);
+	}
+
+	if (url.username || url.password) {
+		throw new McpUrlPolicyError("MCP credentials must not be embedded in URLs.");
+	}
+
+	return url;
+};

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -1,5 +1,6 @@
 import type { InferRouterInputs, InferRouterOutputs, RouterClient } from "@orpc/server";
 
+import { mcpRouter } from "../mcp/router";
 import { modelsRouter } from "../models/router";
 import { profileRouter } from "../profile/router";
 import { publicProcedure } from "../procedures";
@@ -7,6 +8,7 @@ import { thinkspacesRouter } from "../thinkspaces/router";
 
 export const appRouter = {
 	healthCheck: publicProcedure.handler(() => "OK"),
+	mcp: mcpRouter,
 	models: modelsRouter,
 	profile: profileRouter,
 	thinkspaces: thinkspacesRouter,


### PR DESCRIPTION
## Problem / Intent

Better Agent needs product-level MCP catalog and connection management without inheriting Better Chat's global tool enablement defaults or plaintext header storage.

## Approach

Represent built-in MCP servers as catalog metadata with zero Thinkspace exposure by default, add protected CRUD for user MCP connections with encrypted/redacted header material, enforce server-side HTTPS/private-network URL policy, and add a canonical tool identity seam that separates `{ serverId, toolName }` from model-facing aliases.
