### PR TITLE
Add Thinkspace tool policy placeholders

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -8,245 +8,249 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as ThinkspacesRouteImport } from "./routes/thinkspaces";
-import { Route as SettingsRouteImport } from "./routes/settings";
-import { Route as LoginRouteImport } from "./routes/login";
-import { Route as IndexRouteImport } from "./routes/index";
-import { Route as ThinkspacesIndexRouteImport } from "./routes/thinkspaces.index";
-import { Route as SettingsIndexRouteImport } from "./routes/settings.index";
-import { Route as ThinkspacesThinkspaceIdRouteImport } from "./routes/thinkspaces.$thinkspaceId";
-import { Route as SettingsProfileRouteImport } from "./routes/settings.profile";
-import { Route as SettingsProductRouteImport } from "./routes/settings.product";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as ThinkspacesRouteImport } from './routes/thinkspaces'
+import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as LoginRouteImport } from './routes/login'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as ThinkspacesIndexRouteImport } from './routes/thinkspaces.index'
+import { Route as SettingsIndexRouteImport } from './routes/settings.index'
+import { Route as ThinkspacesThinkspaceIdRouteImport } from './routes/thinkspaces.$thinkspaceId'
+import { Route as SettingsProfileRouteImport } from './routes/settings.profile'
+import { Route as SettingsProductRouteImport } from './routes/settings.product'
 
 const ThinkspacesRoute = ThinkspacesRouteImport.update({
-	id: "/thinkspaces",
-	path: "/thinkspaces",
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/thinkspaces',
+  path: '/thinkspaces',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SettingsRoute = SettingsRouteImport.update({
-	id: "/settings",
-	path: "/settings",
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoginRoute = LoginRouteImport.update({
-	id: "/login",
-	path: "/login",
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/login',
+  path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
-	id: "/",
-	path: "/",
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ThinkspacesIndexRoute = ThinkspacesIndexRouteImport.update({
-	id: "/",
-	path: "/",
-	getParentRoute: () => ThinkspacesRoute,
-} as any);
+  id: '/',
+  path: '/',
+  getParentRoute: () => ThinkspacesRoute,
+} as any)
 const SettingsIndexRoute = SettingsIndexRouteImport.update({
-	id: "/",
-	path: "/",
-	getParentRoute: () => SettingsRoute,
-} as any);
+  id: '/',
+  path: '/',
+  getParentRoute: () => SettingsRoute,
+} as any)
 const ThinkspacesThinkspaceIdRoute = ThinkspacesThinkspaceIdRouteImport.update({
-	id: "/$thinkspaceId",
-	path: "/$thinkspaceId",
-	getParentRoute: () => ThinkspacesRoute,
-} as any);
+  id: '/$thinkspaceId',
+  path: '/$thinkspaceId',
+  getParentRoute: () => ThinkspacesRoute,
+} as any)
 const SettingsProfileRoute = SettingsProfileRouteImport.update({
-	id: "/profile",
-	path: "/profile",
-	getParentRoute: () => SettingsRoute,
-} as any);
+  id: '/profile',
+  path: '/profile',
+  getParentRoute: () => SettingsRoute,
+} as any)
 const SettingsProductRoute = SettingsProductRouteImport.update({
-	id: "/product",
-	path: "/product",
-	getParentRoute: () => SettingsRoute,
-} as any);
+  id: '/product',
+  path: '/product',
+  getParentRoute: () => SettingsRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
-	"/": typeof IndexRoute;
-	"/login": typeof LoginRoute;
-	"/settings": typeof SettingsRouteWithChildren;
-	"/thinkspaces": typeof ThinkspacesRouteWithChildren;
-	"/settings/product": typeof SettingsProductRoute;
-	"/settings/profile": typeof SettingsProfileRoute;
-	"/thinkspaces/$thinkspaceId": typeof ThinkspacesThinkspaceIdRoute;
-	"/settings/": typeof SettingsIndexRoute;
-	"/thinkspaces/": typeof ThinkspacesIndexRoute;
+  '/': typeof IndexRoute
+  '/login': typeof LoginRoute
+  '/settings': typeof SettingsRouteWithChildren
+  '/thinkspaces': typeof ThinkspacesRouteWithChildren
+  '/settings/product': typeof SettingsProductRoute
+  '/settings/profile': typeof SettingsProfileRoute
+  '/thinkspaces/$thinkspaceId': typeof ThinkspacesThinkspaceIdRoute
+  '/settings/': typeof SettingsIndexRoute
+  '/thinkspaces/': typeof ThinkspacesIndexRoute
 }
 export interface FileRoutesByTo {
-	"/": typeof IndexRoute;
-	"/login": typeof LoginRoute;
-	"/settings/product": typeof SettingsProductRoute;
-	"/settings/profile": typeof SettingsProfileRoute;
-	"/thinkspaces/$thinkspaceId": typeof ThinkspacesThinkspaceIdRoute;
-	"/settings": typeof SettingsIndexRoute;
-	"/thinkspaces": typeof ThinkspacesIndexRoute;
+  '/': typeof IndexRoute
+  '/login': typeof LoginRoute
+  '/settings/product': typeof SettingsProductRoute
+  '/settings/profile': typeof SettingsProfileRoute
+  '/thinkspaces/$thinkspaceId': typeof ThinkspacesThinkspaceIdRoute
+  '/settings': typeof SettingsIndexRoute
+  '/thinkspaces': typeof ThinkspacesIndexRoute
 }
 export interface FileRoutesById {
-	__root__: typeof rootRouteImport;
-	"/": typeof IndexRoute;
-	"/login": typeof LoginRoute;
-	"/settings": typeof SettingsRouteWithChildren;
-	"/thinkspaces": typeof ThinkspacesRouteWithChildren;
-	"/settings/product": typeof SettingsProductRoute;
-	"/settings/profile": typeof SettingsProfileRoute;
-	"/thinkspaces/$thinkspaceId": typeof ThinkspacesThinkspaceIdRoute;
-	"/settings/": typeof SettingsIndexRoute;
-	"/thinkspaces/": typeof ThinkspacesIndexRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/login': typeof LoginRoute
+  '/settings': typeof SettingsRouteWithChildren
+  '/thinkspaces': typeof ThinkspacesRouteWithChildren
+  '/settings/product': typeof SettingsProductRoute
+  '/settings/profile': typeof SettingsProfileRoute
+  '/thinkspaces/$thinkspaceId': typeof ThinkspacesThinkspaceIdRoute
+  '/settings/': typeof SettingsIndexRoute
+  '/thinkspaces/': typeof ThinkspacesIndexRoute
 }
 export interface FileRouteTypes {
-	fileRoutesByFullPath: FileRoutesByFullPath;
-	fullPaths:
-		| "/"
-		| "/login"
-		| "/settings"
-		| "/thinkspaces"
-		| "/settings/product"
-		| "/settings/profile"
-		| "/thinkspaces/$thinkspaceId"
-		| "/settings/"
-		| "/thinkspaces/";
-	fileRoutesByTo: FileRoutesByTo;
-	to:
-		| "/"
-		| "/login"
-		| "/settings/product"
-		| "/settings/profile"
-		| "/thinkspaces/$thinkspaceId"
-		| "/settings"
-		| "/thinkspaces";
-	id:
-		| "__root__"
-		| "/"
-		| "/login"
-		| "/settings"
-		| "/thinkspaces"
-		| "/settings/product"
-		| "/settings/profile"
-		| "/thinkspaces/$thinkspaceId"
-		| "/settings/"
-		| "/thinkspaces/";
-	fileRoutesById: FileRoutesById;
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/login'
+    | '/settings'
+    | '/thinkspaces'
+    | '/settings/product'
+    | '/settings/profile'
+    | '/thinkspaces/$thinkspaceId'
+    | '/settings/'
+    | '/thinkspaces/'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/login'
+    | '/settings/product'
+    | '/settings/profile'
+    | '/thinkspaces/$thinkspaceId'
+    | '/settings'
+    | '/thinkspaces'
+  id:
+    | '__root__'
+    | '/'
+    | '/login'
+    | '/settings'
+    | '/thinkspaces'
+    | '/settings/product'
+    | '/settings/profile'
+    | '/thinkspaces/$thinkspaceId'
+    | '/settings/'
+    | '/thinkspaces/'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-	IndexRoute: typeof IndexRoute;
-	LoginRoute: typeof LoginRoute;
-	SettingsRoute: typeof SettingsRouteWithChildren;
-	ThinkspacesRoute: typeof ThinkspacesRouteWithChildren;
+  IndexRoute: typeof IndexRoute
+  LoginRoute: typeof LoginRoute
+  SettingsRoute: typeof SettingsRouteWithChildren
+  ThinkspacesRoute: typeof ThinkspacesRouteWithChildren
 }
 
-declare module "@tanstack/react-router" {
-	interface FileRoutesByPath {
-		"/thinkspaces": {
-			id: "/thinkspaces";
-			path: "/thinkspaces";
-			fullPath: "/thinkspaces";
-			preLoaderRoute: typeof ThinkspacesRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		"/settings": {
-			id: "/settings";
-			path: "/settings";
-			fullPath: "/settings";
-			preLoaderRoute: typeof SettingsRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		"/login": {
-			id: "/login";
-			path: "/login";
-			fullPath: "/login";
-			preLoaderRoute: typeof LoginRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		"/": {
-			id: "/";
-			path: "/";
-			fullPath: "/";
-			preLoaderRoute: typeof IndexRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		"/thinkspaces/": {
-			id: "/thinkspaces/";
-			path: "/";
-			fullPath: "/thinkspaces/";
-			preLoaderRoute: typeof ThinkspacesIndexRouteImport;
-			parentRoute: typeof ThinkspacesRoute;
-		};
-		"/settings/": {
-			id: "/settings/";
-			path: "/";
-			fullPath: "/settings/";
-			preLoaderRoute: typeof SettingsIndexRouteImport;
-			parentRoute: typeof SettingsRoute;
-		};
-		"/thinkspaces/$thinkspaceId": {
-			id: "/thinkspaces/$thinkspaceId";
-			path: "/$thinkspaceId";
-			fullPath: "/thinkspaces/$thinkspaceId";
-			preLoaderRoute: typeof ThinkspacesThinkspaceIdRouteImport;
-			parentRoute: typeof ThinkspacesRoute;
-		};
-		"/settings/profile": {
-			id: "/settings/profile";
-			path: "/profile";
-			fullPath: "/settings/profile";
-			preLoaderRoute: typeof SettingsProfileRouteImport;
-			parentRoute: typeof SettingsRoute;
-		};
-		"/settings/product": {
-			id: "/settings/product";
-			path: "/product";
-			fullPath: "/settings/product";
-			preLoaderRoute: typeof SettingsProductRouteImport;
-			parentRoute: typeof SettingsRoute;
-		};
-	}
+declare module '@tanstack/react-router' {
+  interface FileRoutesByPath {
+    '/thinkspaces': {
+      id: '/thinkspaces'
+      path: '/thinkspaces'
+      fullPath: '/thinkspaces'
+      preLoaderRoute: typeof ThinkspacesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/thinkspaces/': {
+      id: '/thinkspaces/'
+      path: '/'
+      fullPath: '/thinkspaces/'
+      preLoaderRoute: typeof ThinkspacesIndexRouteImport
+      parentRoute: typeof ThinkspacesRoute
+    }
+    '/settings/': {
+      id: '/settings/'
+      path: '/'
+      fullPath: '/settings/'
+      preLoaderRoute: typeof SettingsIndexRouteImport
+      parentRoute: typeof SettingsRoute
+    }
+    '/thinkspaces/$thinkspaceId': {
+      id: '/thinkspaces/$thinkspaceId'
+      path: '/$thinkspaceId'
+      fullPath: '/thinkspaces/$thinkspaceId'
+      preLoaderRoute: typeof ThinkspacesThinkspaceIdRouteImport
+      parentRoute: typeof ThinkspacesRoute
+    }
+    '/settings/profile': {
+      id: '/settings/profile'
+      path: '/profile'
+      fullPath: '/settings/profile'
+      preLoaderRoute: typeof SettingsProfileRouteImport
+      parentRoute: typeof SettingsRoute
+    }
+    '/settings/product': {
+      id: '/settings/product'
+      path: '/product'
+      fullPath: '/settings/product'
+      preLoaderRoute: typeof SettingsProductRouteImport
+      parentRoute: typeof SettingsRoute
+    }
+  }
 }
 
 interface SettingsRouteChildren {
-	SettingsProductRoute: typeof SettingsProductRoute;
-	SettingsProfileRoute: typeof SettingsProfileRoute;
-	SettingsIndexRoute: typeof SettingsIndexRoute;
+  SettingsProductRoute: typeof SettingsProductRoute
+  SettingsProfileRoute: typeof SettingsProfileRoute
+  SettingsIndexRoute: typeof SettingsIndexRoute
 }
 
 const SettingsRouteChildren: SettingsRouteChildren = {
-	SettingsProductRoute: SettingsProductRoute,
-	SettingsProfileRoute: SettingsProfileRoute,
-	SettingsIndexRoute: SettingsIndexRoute,
-};
+  SettingsProductRoute: SettingsProductRoute,
+  SettingsProfileRoute: SettingsProfileRoute,
+  SettingsIndexRoute: SettingsIndexRoute,
+}
 
-const SettingsRouteWithChildren = SettingsRoute._addFileChildren(SettingsRouteChildren);
+const SettingsRouteWithChildren = SettingsRoute._addFileChildren(
+  SettingsRouteChildren,
+)
 
 interface ThinkspacesRouteChildren {
-	ThinkspacesThinkspaceIdRoute: typeof ThinkspacesThinkspaceIdRoute;
-	ThinkspacesIndexRoute: typeof ThinkspacesIndexRoute;
+  ThinkspacesThinkspaceIdRoute: typeof ThinkspacesThinkspaceIdRoute
+  ThinkspacesIndexRoute: typeof ThinkspacesIndexRoute
 }
 
 const ThinkspacesRouteChildren: ThinkspacesRouteChildren = {
-	ThinkspacesThinkspaceIdRoute: ThinkspacesThinkspaceIdRoute,
-	ThinkspacesIndexRoute: ThinkspacesIndexRoute,
-};
+  ThinkspacesThinkspaceIdRoute: ThinkspacesThinkspaceIdRoute,
+  ThinkspacesIndexRoute: ThinkspacesIndexRoute,
+}
 
-const ThinkspacesRouteWithChildren = ThinkspacesRoute._addFileChildren(ThinkspacesRouteChildren);
+const ThinkspacesRouteWithChildren = ThinkspacesRoute._addFileChildren(
+  ThinkspacesRouteChildren,
+)
 
 const rootRouteChildren: RootRouteChildren = {
-	IndexRoute: IndexRoute,
-	LoginRoute: LoginRoute,
-	SettingsRoute: SettingsRouteWithChildren,
-	ThinkspacesRoute: ThinkspacesRouteWithChildren,
-};
+  IndexRoute: IndexRoute,
+  LoginRoute: LoginRoute,
+  SettingsRoute: SettingsRouteWithChildren,
+  ThinkspacesRoute: ThinkspacesRouteWithChildren,
+}
 export const routeTree = rootRouteImport
-	._addFileChildren(rootRouteChildren)
-	._addFileTypes<FileRouteTypes>();
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from "./router.tsx";
-import type { createStart } from "@tanstack/react-start";
-declare module "@tanstack/react-start" {
-	interface Register {
-		ssr: true;
-		router: Awaited<ReturnType<typeof getRouter>>;
-	}
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
 }

--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -40,16 +40,6 @@ const referenceSurfaces = [
 	},
 	{
 		description:
-			"Skills will be reusable procedures deliberately enabled for this Goal. New Thinkspaces start with none enabled.",
-		title: "Skills",
-	},
-	{
-		description:
-			"Permissions will define scoped allowances for resources or actions. Connected Accounts never grant access by themselves.",
-		title: "Permissions",
-	},
-	{
-		description:
 			"Audit Trail will be the user-facing history of meaningful changes and actions inside this Thinkspace.",
 		title: "Audit Trail",
 	},
@@ -60,6 +50,32 @@ const referenceSurfaces = [
 	},
 ] as const;
 
+interface EnabledToolSelection {
+	risk: "read_only" | "mutating" | "unknown";
+	serverId: string;
+	toolName?: string;
+}
+
+interface PermissionPlaceholder {
+	actions: string[];
+	approvalRequired: boolean;
+	resource: {
+		serverId: string;
+		toolName: string;
+	};
+	risk: string;
+	type: string;
+}
+
+const parseJsonArray = <T,>(value: string): T[] => {
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		return Array.isArray(parsed) ? (parsed as T[]) : [];
+	} catch {
+		return [];
+	}
+};
+
 const RouteComponent = () => {
 	const { thinkspaceId } = routeApi.useParams();
 	const context = routeApi.useRouteContext();
@@ -67,6 +83,7 @@ const RouteComponent = () => {
 	const thinkspaceQuery = useSuspenseQuery(
 		context.orpc.thinkspaces.get.queryOptions({ input: { thinkspaceId } }),
 	);
+	const mcpCatalogQuery = useSuspenseQuery(context.orpc.mcp.listCatalog.queryOptions());
 	const archiveMutation = useMutation(
 		context.orpc.thinkspaces.archive.mutationOptions({
 			onSuccess: async () => {
@@ -81,9 +98,22 @@ const RouteComponent = () => {
 			},
 		}),
 	);
+	const updateToolSelectionsMutation = useMutation(
+		context.orpc.thinkspaces.updateToolSelections.mutationOptions({
+			onSuccess: async () => {
+				await queryClient.invalidateQueries({
+					queryKey: context.orpc.thinkspaces.get.queryKey({ input: { thinkspaceId } }),
+				});
+			},
+		}),
+	);
 
 	const thinkspace = thinkspaceQuery.data;
 	const isArchived = thinkspace.status === "archived";
+	const enabledTools = parseJsonArray<EnabledToolSelection>(thinkspace.enabledToolIds);
+	const requestedPermissions = parseJsonArray<PermissionPlaceholder>(
+		thinkspace.requestedPermissions,
+	);
 	const archiveButtonLabel = (() => {
 		if (isArchived) {
 			return "Thinkspace archived";
@@ -102,6 +132,15 @@ const RouteComponent = () => {
 		}
 
 		archiveMutation.mutate({ thinkspaceId });
+	};
+
+	const toggleCatalogTool = (serverId: string, risk: "read_only" | "mutating" | "unknown") => {
+		const selected = enabledTools.some((tool) => tool.serverId === serverId);
+		const selections = selected
+			? enabledTools.filter((tool) => tool.serverId !== serverId)
+			: [...enabledTools, { risk, serverId }];
+
+		updateToolSelectionsMutation.mutate({ selections, thinkspaceId });
 	};
 
 	return (
@@ -171,6 +210,104 @@ const RouteComponent = () => {
 					</div>
 				</CardContent>
 			</Card>
+
+			<section className="grid gap-3" aria-labelledby="tools-heading">
+				<div className="grid gap-1">
+					<p className="text-muted-foreground text-xs uppercase tracking-[0.24em]">
+						Thinkspace scoped
+					</p>
+					<h2 id="tools-heading" className="text-xl font-semibold tracking-tight">
+						Skills and tools
+					</h2>
+					<p className="max-w-3xl text-muted-foreground">
+						Product-level MCP catalog entries and Connected Accounts do not grant this Thinkspace
+						access. Select catalog tools explicitly for this Goal; this slice records placeholders
+						and performs no external execution.
+					</p>
+				</div>
+				<div className="grid gap-3 md:grid-cols-2">
+					{mcpCatalogQuery.data.map((server) => {
+						const selected = enabledTools.some((tool) => tool.serverId === server.id);
+						return (
+							<Card
+								key={server.id}
+								className={selected ? "border-primary/40 bg-primary/5" : undefined}
+							>
+								<CardHeader>
+									<CardTitle>{server.name}</CardTitle>
+									<CardDescription>{server.description}</CardDescription>
+									<CardAction>
+										<span className="border border-border px-2 py-1 text-muted-foreground text-xs">
+											{server.riskLevel}
+										</span>
+									</CardAction>
+								</CardHeader>
+								<CardContent className="grid gap-3">
+									<p className="text-muted-foreground text-xs">
+										Default for new Thinkspaces:{" "}
+										{server.enabledByDefaultForThinkspaces ? "enabled" : "disabled"}
+									</p>
+									<Button
+										disabled={isArchived || updateToolSelectionsMutation.isPending}
+										onClick={() => toggleCatalogTool(server.id, server.riskLevel)}
+										type="button"
+										variant={selected ? "secondary" : "outline"}
+									>
+										{selected ? "Remove from this Thinkspace" : "Select for this Goal"}
+									</Button>
+								</CardContent>
+							</Card>
+						);
+					})}
+				</div>
+				{updateToolSelectionsMutation.error ? (
+					<p className="text-destructive text-xs" role="alert">
+						{updateToolSelectionsMutation.error.message}
+					</p>
+				) : null}
+			</section>
+
+			<section className="grid gap-3" aria-labelledby="permissions-heading">
+				<div className="grid gap-1">
+					<h2 id="permissions-heading" className="text-xl font-semibold tracking-tight">
+						Permissions
+					</h2>
+					<p className="max-w-3xl text-muted-foreground">
+						Permissions describe possible access for this Thinkspace. They are not Approvals for any
+						proposed action.
+					</p>
+				</div>
+				<Card>
+					<CardHeader>
+						<CardTitle>
+							{requestedPermissions.length === 0
+								? "No Permissions requested"
+								: "Permission placeholders"}
+						</CardTitle>
+						<CardDescription>
+							{requestedPermissions.length === 0
+								? "New Thinkspaces start with no enabled tools and no Permissions."
+								: "These placeholders can become narrow, reviewable Permissions in a later runtime slice."}
+						</CardDescription>
+					</CardHeader>
+					{requestedPermissions.length > 0 ? (
+						<CardContent className="grid gap-2">
+							{requestedPermissions.map((permission) => (
+								<div
+									key={`${permission.resource.serverId}:${permission.resource.toolName}`}
+									className="border border-border p-3 text-sm"
+								>
+									<p className="font-medium">{permission.resource.serverId}</p>
+									<p className="text-muted-foreground text-xs">
+										Risk: {permission.risk} · Approval required:{" "}
+										{permission.approvalRequired ? "yes" : "no"}
+									</p>
+								</div>
+							))}
+						</CardContent>
+					) : null}
+				</Card>
+			</section>
 
 			<section className="grid gap-3" aria-labelledby="approvals-heading">
 				<div className="grid gap-1">

--- a/packages/api/src/thinkspaces/policy.test.ts
+++ b/packages/api/src/thinkspaces/policy.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	assessPermissionPolicy,
+	createToolPermissionPlaceholder,
+	DEFAULT_APPROVAL_POLICY,
+	PermissionPolicyError,
+	serializeThinkspaceToolSelections,
+} from "./policy";
+
+test("new Thinkspace defaults require explicit approval for mutating or unknown tools", () => {
+	assert.equal(DEFAULT_APPROVAL_POLICY.mutating, "draft_or_explicit_approval");
+	assert.equal(DEFAULT_APPROVAL_POLICY.unknown, "explicit_approval_required");
+});
+
+test("distinguishes possible access from approved action", () => {
+	assert.equal(
+		assessPermissionPolicy({ hasPermission: false, risk: "read_only" }),
+		"possible_access",
+	);
+	assert.equal(
+		assessPermissionPolicy({ hasPermission: true, risk: "mutating" }),
+		"approved_action_required",
+	);
+	assert.equal(
+		assessPermissionPolicy({ hasPermission: true, risk: "read_only", standingApproval: true }),
+		"allowed_without_approval",
+	);
+});
+
+test("serializes explicit Thinkspace tool selections and rejects duplicates", () => {
+	assert.equal(
+		serializeThinkspaceToolSelections([{ risk: "read_only", serverId: "context7" }]),
+		JSON.stringify([{ risk: "read_only", serverId: "context7" }]),
+	);
+	assert.throws(
+		() =>
+			serializeThinkspaceToolSelections([
+				{ risk: "read_only", serverId: "context7" },
+				{ risk: "read_only", serverId: "context7" },
+			]),
+		PermissionPolicyError,
+	);
+});
+
+test("permission placeholders keep possible access separate from Approval", () => {
+	assert.deepEqual(createToolPermissionPlaceholder({ risk: "unknown", serverId: "custom" }), {
+		actions: ["propose_action"],
+		approvalRequired: true,
+		resource: { serverId: "custom", toolName: "any_explicitly_enabled_tool" },
+		risk: "unknown",
+		type: "mcp_tool_permission_placeholder",
+	});
+});

--- a/packages/api/src/thinkspaces/policy.ts
+++ b/packages/api/src/thinkspaces/policy.ts
@@ -1,0 +1,78 @@
+export type ToolRisk = "read_only" | "mutating" | "unknown";
+export type PermissionDecision =
+	| "possible_access"
+	| "approved_action_required"
+	| "allowed_without_approval";
+
+export interface ThinkspaceToolSelection {
+	serverId: string;
+	toolName?: string;
+	risk: ToolRisk;
+}
+
+export interface PermissionPolicyInput {
+	hasPermission: boolean;
+	risk: ToolRisk;
+	standingApproval?: boolean;
+}
+
+export const DEFAULT_APPROVAL_POLICY = {
+	mutating: "draft_or_explicit_approval",
+	readOnly: "permission_required",
+	unknown: "explicit_approval_required",
+} as const;
+
+export class PermissionPolicyError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "PermissionPolicyError";
+	}
+}
+
+export const assessPermissionPolicy = ({
+	hasPermission,
+	risk,
+	standingApproval = false,
+}: PermissionPolicyInput): PermissionDecision => {
+	if (!hasPermission) {
+		return "possible_access";
+	}
+
+	if (risk === "read_only" && standingApproval) {
+		return "allowed_without_approval";
+	}
+
+	return "approved_action_required";
+};
+
+export const createToolPermissionPlaceholder = (selection: ThinkspaceToolSelection) => ({
+	actions: selection.risk === "read_only" ? ["read"] : ["propose_action"],
+	approvalRequired: selection.risk !== "read_only",
+	resource: {
+		serverId: selection.serverId,
+		toolName: selection.toolName ?? "any_explicitly_enabled_tool",
+	},
+	risk: selection.risk,
+	type: "mcp_tool_permission_placeholder",
+});
+
+export const serializeThinkspaceToolSelections = (
+	selections: ThinkspaceToolSelection[],
+): string => {
+	const seen = new Set<string>();
+	const normalized = selections.map((selection) => {
+		const serverId = selection.serverId.trim();
+		const toolName = selection.toolName?.trim() || undefined;
+		if (!serverId) {
+			throw new PermissionPolicyError("Enabled tool selections require a server ID.");
+		}
+		const key = `${serverId}:${toolName ?? "*"}`;
+		if (seen.has(key)) {
+			throw new PermissionPolicyError("Enabled tool selections must be unique per Thinkspace.");
+		}
+		seen.add(key);
+		return { risk: selection.risk, serverId, toolName };
+	});
+
+	return JSON.stringify(normalized);
+};

--- a/packages/api/src/thinkspaces/repository.ts
+++ b/packages/api/src/thinkspaces/repository.ts
@@ -17,6 +17,13 @@ export interface ArchiveThinkspaceInput extends GetThinkspaceInput {
 	patch: Pick<typeof thinkspaces.$inferInsert, "archivedAt" | "status" | "updatedAt">;
 }
 
+export interface UpdateThinkspaceConfigurationInput extends GetThinkspaceInput {
+	patch: Pick<
+		typeof thinkspaces.$inferInsert,
+		"approvalDefaults" | "enabledToolIds" | "requestedPermissions" | "updatedAt"
+	>;
+}
+
 export interface CreateThinkspaceInput {
 	record: typeof thinkspaces.$inferInsert;
 }
@@ -58,6 +65,19 @@ export const archiveThinkspace = async (
 		.returning();
 
 	return archived ?? null;
+};
+
+export const updateThinkspaceConfiguration = async (
+	db: ProductDb,
+	{ ownerUserId, patch, thinkspaceId }: UpdateThinkspaceConfigurationInput,
+): Promise<Thinkspace | null> => {
+	const [updated] = await db
+		.update(thinkspaces)
+		.set(patch)
+		.where(and(eq(thinkspaces.id, thinkspaceId), eq(thinkspaces.ownerUserId, ownerUserId)))
+		.returning();
+
+	return updated ?? null;
 };
 
 export const listThinkspaces = async (

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -3,11 +3,22 @@ import { z } from "zod";
 
 import { protectedProcedure } from "../procedures";
 import {
+	createToolPermissionPlaceholder,
+	DEFAULT_APPROVAL_POLICY,
+	serializeThinkspaceToolSelections,
+} from "./policy";
+import {
 	createThinkspaceArchivePatch,
 	createThinkspaceCreationRecord,
 	ThinkspaceLifecycleValidationError,
 } from "./lifecycle";
-import { archiveThinkspace, createThinkspace, getThinkspace, listThinkspaces } from "./repository";
+import {
+	archiveThinkspace,
+	createThinkspace,
+	getThinkspace,
+	listThinkspaces,
+	updateThinkspaceConfiguration,
+} from "./repository";
 
 const createThinkspaceInput = z.object({
 	configurationSummary: z.string().optional(),
@@ -16,6 +27,17 @@ const createThinkspaceInput = z.object({
 });
 
 const thinkspaceIdInput = z.object({
+	thinkspaceId: z.string().min(1),
+});
+
+const toolSelectionSchema = z.object({
+	risk: z.enum(["read_only", "mutating", "unknown"]),
+	serverId: z.string().trim().min(1),
+	toolName: z.string().trim().min(1).optional(),
+});
+
+const updateToolSelectionsInput = z.object({
+	selections: z.array(toolSelectionSchema),
 	thinkspaceId: z.string().min(1),
 });
 
@@ -94,4 +116,41 @@ export const thinkspacesRouter = {
 		async ({ context }) =>
 			await listThinkspaces(context.db, { ownerUserId: context.session.user.id }),
 	),
+	updateToolSelections: protectedProcedure
+		.input(updateToolSelectionsInput)
+		.handler(async ({ context, input }) => {
+			const thinkspace = await getThinkspace(context.db, {
+				ownerUserId: context.session.user.id,
+				thinkspaceId: input.thinkspaceId,
+			});
+
+			if (!thinkspace) {
+				throw toNotFound();
+			}
+
+			if (thinkspace.status === "archived") {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Archived Thinkspaces cannot change tool enablement.",
+				});
+			}
+
+			const updated = await updateThinkspaceConfiguration(context.db, {
+				ownerUserId: context.session.user.id,
+				patch: {
+					approvalDefaults: JSON.stringify(DEFAULT_APPROVAL_POLICY),
+					enabledToolIds: serializeThinkspaceToolSelections(input.selections),
+					requestedPermissions: JSON.stringify(
+						input.selections.map((selection) => createToolPermissionPlaceholder(selection)),
+					),
+					updatedAt: new Date(),
+				},
+				thinkspaceId: input.thinkspaceId,
+			});
+
+			if (!updated) {
+				throw toNotFound();
+			}
+
+			return updated;
+		}),
 };


### PR DESCRIPTION
## Problem / Intent

Better Agent needs to prove that product-level MCP catalogs and Connected Accounts do not automatically grant Thinkspace Agent access, while making tool, Permission, and Approval boundaries visible in the Thinkspace detail shell.

## Approach

Add a pure Permission/Approval policy module, a protected Thinkspace tool-selection mutation that records explicit tool selections and generated Permission placeholders in existing Thinkspace configuration fields, and update the detail UI to show scoped tool selection, Permission placeholders, and Approval holdpoints without executing any external tools.
