### PR TITLE
Add runtime-safe model readiness for Thinkspace Agent turns

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,6 +8,11 @@
 		"compile": "bun build --compile --minify --sourcemap --bytecode ./src/index.ts --outfile server"
 	},
 	"dependencies": {
+		"@ai-sdk/anthropic": "^3.0.81",
+		"@ai-sdk/google": "^3.0.80",
+		"@ai-sdk/openai": "^3.0.68",
+		"@ai-sdk/provider": "^3.0.0",
+		"@ai-sdk/provider-utils": "^4.0.27",
 		"@better-agent/api": "workspace:*",
 		"@better-agent/auth": "workspace:*",
 		"@better-agent/db": "workspace:*",
@@ -20,6 +25,7 @@
 		"ai": "catalog:",
 		"better-auth": "catalog:",
 		"dotenv": "catalog:",
+		"eventsource-parser": "^3.0.8",
 		"hono": "catalog:",
 		"zod": "catalog:"
 	},

--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -57,6 +57,9 @@ const RouteComponent = () => {
 	const runtimeReadinessQuery = useSuspenseQuery(
 		context.orpc.thinkspaces.runtimeReadiness.queryOptions({ input: { thinkspaceId } }),
 	);
+	const modelReadinessQuery = useSuspenseQuery(
+		context.orpc.thinkspaces.modelReadiness.queryOptions({ input: { thinkspaceId } }),
+	);
 	const mcpCatalogQuery = useSuspenseQuery(context.orpc.mcp.listCatalog.queryOptions());
 	const archiveMutation = useMutation(
 		context.orpc.thinkspaces.archive.mutationOptions({
@@ -84,6 +87,7 @@ const RouteComponent = () => {
 
 	const thinkspace = thinkspaceQuery.data;
 	const runtimeReadiness = runtimeReadinessQuery.data;
+	const modelReadiness = modelReadinessQuery.data;
 	const isArchived = thinkspace.status === "archived";
 	const enabledTools = parseJsonArray<EnabledToolSelection>(thinkspace.enabledToolIds);
 	const requestedPermissions = parseJsonArray<PermissionPlaceholder>(
@@ -152,17 +156,32 @@ const RouteComponent = () => {
 						runtime identity.
 					</p>
 				</div>
-				<div className="grid gap-2 border border-border p-4">
-					<div className="flex items-center justify-between gap-4">
-						<p className="text-sm font-medium">Runtime readiness</p>
-						<Badge variant="outline">{runtimeReadiness.status}</Badge>
+				<div className="grid gap-4 border border-border p-4">
+					<div className="grid gap-2">
+						<div className="flex items-center justify-between gap-4">
+							<p className="text-sm font-medium">Runtime readiness</p>
+							<Badge variant="outline">{runtimeReadiness.status}</Badge>
+						</div>
+						<p className="text-muted-foreground text-xs">
+							Binding: {runtimeReadiness.bindingName} · Class: {runtimeReadiness.className}
+						</p>
+						<p className="break-all text-muted-foreground text-xs">
+							Runtime identity: {runtimeReadiness.runtimeName}
+						</p>
 					</div>
-					<p className="text-muted-foreground text-xs">
-						Binding: {runtimeReadiness.bindingName} · Class: {runtimeReadiness.className}
-					</p>
-					<p className="break-all text-muted-foreground text-xs">
-						Runtime identity: {runtimeReadiness.runtimeName}
-					</p>
+					<div className="grid gap-2 border-border border-t pt-4">
+						<div className="flex items-center justify-between gap-4">
+							<p className="text-sm font-medium">Model readiness</p>
+							<Badge variant={modelReadiness.status === "ready" ? "default" : "destructive"}>
+								{modelReadiness.status === "ready" ? "ready" : "not ready"}
+							</Badge>
+						</div>
+						<p className="text-muted-foreground text-sm">{modelReadiness.message}</p>
+						<p className="text-muted-foreground text-xs">
+							{modelReadiness.modelName ?? modelReadiness.modelId} ·{" "}
+							{modelReadiness.providerName ?? "Unknown provider"}
+						</p>
+					</div>
 				</div>
 			</section>
 
@@ -305,6 +324,11 @@ export const Route = createFileRoute("/thinkspaces/$thinkspaceId")({
 			),
 			context.queryClient.ensureQueryData(
 				context.orpc.thinkspaces.runtimeReadiness.queryOptions({
+					input: { thinkspaceId: params.thinkspaceId },
+				}),
+			),
+			context.queryClient.ensureQueryData(
+				context.orpc.thinkspaces.modelReadiness.queryOptions({
 					input: { thinkspaceId: params.thinkspaceId },
 				}),
 			),

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,11 @@
     "apps/server": {
       "name": "server",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.81",
+        "@ai-sdk/google": "^3.0.80",
+        "@ai-sdk/openai": "^3.0.68",
+        "@ai-sdk/provider": "^3.0.0",
+        "@ai-sdk/provider-utils": "^4.0.27",
         "@better-agent/api": "workspace:*",
         "@better-agent/auth": "workspace:*",
         "@better-agent/db": "workspace:*",
@@ -35,6 +40,7 @@
         "ai": "catalog:",
         "better-auth": "catalog:",
         "dotenv": "catalog:",
+        "eventsource-parser": "^3.0.8",
         "hono": "catalog:",
         "zod": "catalog:",
       },

--- a/packages/api/src/models/credentials.ts
+++ b/packages/api/src/models/credentials.ts
@@ -1,5 +1,5 @@
 import type { ProductDb } from "@better-agent/db";
-import { schema } from "@better-agent/db";
+import { userProviderCredentials } from "@better-agent/db/schema/settings";
 import { and, eq } from "drizzle-orm";
 
 import type { ModelProviderId } from "./catalog";
@@ -64,7 +64,7 @@ export const upsertProviderCredential = async (
 ) => {
 	const now = new Date();
 	await db
-		.insert(schema.userProviderCredentials)
+		.insert(userProviderCredentials)
 		.values({
 			encryptedCredential: input.encryptedCredential,
 			id: input.id,
@@ -76,15 +76,12 @@ export const upsertProviderCredential = async (
 		})
 		.onConflictDoUpdate({
 			set: { encryptedCredential: input.encryptedCredential, label: input.label, updatedAt: now },
-			target: [schema.userProviderCredentials.userId, schema.userProviderCredentials.providerId],
+			target: [userProviderCredentials.userId, userProviderCredentials.providerId],
 		});
 };
 
 export const listProviderCredentials = async (db: ProductDb, userId: string) =>
-	await db
-		.select()
-		.from(schema.userProviderCredentials)
-		.where(eq(schema.userProviderCredentials.userId, userId));
+	await db.select().from(userProviderCredentials).where(eq(userProviderCredentials.userId, userId));
 
 export const getCredentialMap = async (
 	db: ProductDb,
@@ -102,11 +99,11 @@ export const getDecryptedCredential = async (
 ): Promise<string | null> => {
 	const [row] = await db
 		.select()
-		.from(schema.userProviderCredentials)
+		.from(userProviderCredentials)
 		.where(
 			and(
-				eq(schema.userProviderCredentials.userId, input.userId),
-				eq(schema.userProviderCredentials.providerId, input.providerId),
+				eq(userProviderCredentials.userId, input.userId),
+				eq(userProviderCredentials.providerId, input.providerId),
 			),
 		)
 		.limit(1);

--- a/packages/api/src/models/readiness.test.ts
+++ b/packages/api/src/models/readiness.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+
+import { checkThinkspaceModelReadiness, getOwnedThinkspaceModelReadiness } from "./readiness";
+
+const db = {} as ProductDb;
+
+const createEnv = (overrides: Record<string, string | undefined> = {}) => ({
+	ANTHROPIC_API_KEY: undefined,
+	API_ENCRYPTION_KEY: undefined,
+	BETTER_AUTH_SECRET: "test-secret",
+	GOOGLE_GENERATIVE_AI_API_KEY: "google-app-key",
+	OPENAI_API_KEY: "openai-app-key",
+	...overrides,
+});
+
+const createThinkspace = (requestedPermissions = "[]") => ({
+	id: "thinkspace_model_readiness",
+	requestedPermissions,
+});
+
+const grantedCredentialPermission = (providerId: string): string =>
+	JSON.stringify([
+		{
+			granted: true,
+			providerId,
+			type: "model_provider_credential_permission",
+		},
+	]);
+
+test("reports ready for the default app-provided model when app credentials exist", async () => {
+	const readiness = await checkThinkspaceModelReadiness({
+		db,
+		env: createEnv(),
+		settings: null,
+		thinkspace: createThinkspace(),
+		userId: "user_123",
+	});
+
+	assert.equal(readiness.status, "ready");
+	assert.equal(readiness.modelId, "google:gemini-2.5-flash-lite");
+	assert.equal(readiness.credentialSource, "app_provided");
+	assert.equal(readiness.requiresThinkspacePermission, false);
+});
+
+test("fails closed for unknown configured model ids", async () => {
+	const readiness = await checkThinkspaceModelReadiness({
+		db,
+		env: createEnv(),
+		settings: { defaultModel: "openai:not-real", reasoningEffort: "medium" },
+		thinkspace: createThinkspace(),
+		userId: "user_123",
+	});
+
+	assert.equal(readiness.status, "not_ready");
+	assert.equal(readiness.reason, "unknown_model");
+	assert.equal(readiness.message, "The selected model is not in the supported model catalog.");
+});
+
+test("fails closed when app-provided provider credentials are missing", async () => {
+	const readiness = await checkThinkspaceModelReadiness({
+		db,
+		env: createEnv({ GOOGLE_GENERATIVE_AI_API_KEY: undefined }),
+		settings: null,
+		thinkspace: createThinkspace(),
+		userId: "user_123",
+	});
+
+	assert.equal(readiness.status, "not_ready");
+	assert.equal(readiness.reason, "missing_app_credential");
+	assert.equal(readiness.message, "The app-provided credential for this model is not configured.");
+});
+
+test("requires Thinkspace Permission before resolving BYOK credentials", async () => {
+	let credentialLoadCount = 0;
+	const readiness = await checkThinkspaceModelReadiness({
+		db,
+		env: createEnv(),
+		getUserCredential: () => {
+			credentialLoadCount += 1;
+			return Promise.resolve("sk-test");
+		},
+		settings: { defaultModel: "openai:gpt-4.1", reasoningEffort: "medium" },
+		thinkspace: createThinkspace(),
+		userId: "user_123",
+	});
+
+	assert.equal(readiness.status, "not_ready");
+	assert.equal(readiness.reason, "permission_required");
+	assert.equal(readiness.requiresThinkspacePermission, true);
+	assert.equal(credentialLoadCount, 0);
+});
+
+test("reports ready for BYOK only after the Thinkspace credential Permission is granted", async () => {
+	const readiness = await checkThinkspaceModelReadiness({
+		db,
+		env: createEnv(),
+		getUserCredential: (_db, input) => {
+			assert.equal(input.providerId, "openai");
+			assert.equal(input.userId, "user_123");
+			return Promise.resolve("sk-test");
+		},
+		settings: { defaultModel: "openai:gpt-4.1", reasoningEffort: "medium" },
+		thinkspace: createThinkspace(grantedCredentialPermission("openai")),
+		userId: "user_123",
+	});
+
+	assert.equal(readiness.status, "ready");
+	assert.equal(readiness.credentialSource, "user_byok");
+	assert.equal(readiness.requiresThinkspacePermission, true);
+});
+
+test("owner-gated model readiness reports readiness for owned Thinkspaces", async () => {
+	const readiness = await getOwnedThinkspaceModelReadiness({
+		db,
+		env: createEnv(),
+		getThinkspaceByOwner: (_db, input) => {
+			assert.equal(input.ownerUserId, "owner_user");
+			assert.equal(input.thinkspaceId, "thinkspace_owned");
+			return Promise.resolve(createThinkspace());
+		},
+		getUserSettings: () => Promise.resolve(null),
+		ownerUserId: "owner_user",
+		thinkspaceId: "thinkspace_owned",
+	});
+
+	assert.equal(readiness?.status, "ready");
+	assert.equal(readiness?.modelId, "google:gemini-2.5-flash-lite");
+});
+
+test("owner-gated model readiness returns null for non-owned Thinkspaces", async () => {
+	const readiness = await getOwnedThinkspaceModelReadiness({
+		db,
+		env: createEnv(),
+		getThinkspaceByOwner: (_db, input) => {
+			assert.equal(input.ownerUserId, "other_user");
+			return Promise.resolve(null);
+		},
+		getUserSettings: () => Promise.resolve(null),
+		ownerUserId: "other_user",
+		thinkspaceId: "thinkspace_owned",
+	});
+
+	assert.equal(readiness, null);
+});

--- a/packages/api/src/models/readiness.ts
+++ b/packages/api/src/models/readiness.ts
@@ -1,0 +1,341 @@
+import type { ProductDb } from "@better-agent/db";
+import { userProductSettings } from "@better-agent/db/schema/settings";
+import type { Thinkspace } from "@better-agent/db/schema/thinkspaces";
+import type { CloudflareEnv } from "@better-agent/env/types";
+import { eq } from "drizzle-orm";
+
+import { DEFAULT_MODEL_ID, getModelDefinition, MODEL_PROVIDER_IDS } from "./catalog";
+import type { ModelCatalogEntry, ModelProviderId } from "./catalog";
+import { getDecryptedCredential } from "./credentials";
+import { getThinkspace } from "../thinkspaces/repository";
+import { ModelResolutionError, resolveLanguageModel } from "./resolver";
+import type { ReasoningEffort, ThinkspaceModelPolicy } from "./resolver";
+
+export type ModelReadinessStatus = "ready" | "not_ready";
+export type ModelReadinessReason =
+	| "unknown_model"
+	| "missing_app_credential"
+	| "missing_user_credential"
+	| "permission_required"
+	| "resolution_failed";
+
+export interface ModelReadinessUserSettings {
+	defaultModel: string | null;
+	reasoningEffort: string;
+}
+
+export interface ModelReadinessReady {
+	credentialSource: "app_provided" | "user_byok";
+	message: string;
+	modelId: string;
+	modelName: string;
+	providerId: ModelProviderId;
+	providerName: string;
+	reasoningEffort: ReasoningEffort;
+	requiresThinkspacePermission: boolean;
+	status: "ready";
+}
+
+export interface ModelReadinessNotReady {
+	message: string;
+	modelId: string;
+	modelName?: string;
+	providerId?: ModelProviderId;
+	providerName?: string;
+	reason: ModelReadinessReason;
+	reasoningEffort: ReasoningEffort;
+	requiresThinkspacePermission: boolean;
+	status: "not_ready";
+}
+
+export type ThinkspaceModelReadiness = ModelReadinessReady | ModelReadinessNotReady;
+
+export interface GetOwnedThinkspaceModelReadinessInput {
+	db: ProductDb;
+	env: ModelReadinessEnv;
+	getThinkspaceByOwner?: GetThinkspaceByOwner;
+	getUserSettings?: GetUserSettings;
+	getUserCredential?: GetUserCredential;
+	ownerUserId: string;
+	thinkspaceId: string;
+}
+
+export interface CheckThinkspaceModelReadinessInput {
+	db: ProductDb;
+	env: ModelReadinessEnv;
+	getUserCredential?: GetUserCredential;
+	settings: ModelReadinessUserSettings | null;
+	thinkspace: Pick<Thinkspace, "id" | "requestedPermissions">;
+	userId: string;
+}
+
+type ModelReadinessEnv = Pick<
+	CloudflareEnv,
+	| "ANTHROPIC_API_KEY"
+	| "API_ENCRYPTION_KEY"
+	| "BETTER_AUTH_SECRET"
+	| "GOOGLE_GENERATIVE_AI_API_KEY"
+	| "OPENAI_API_KEY"
+>;
+
+type GetThinkspaceByOwner = (
+	db: ProductDb,
+	input: { ownerUserId: string; thinkspaceId: string },
+) => Promise<Pick<Thinkspace, "id" | "requestedPermissions"> | null>;
+
+type GetUserSettings = (
+	db: ProductDb,
+	userId: string,
+) => Promise<ModelReadinessUserSettings | null>;
+
+type GetUserCredential = (
+	db: ProductDb,
+	input: { providerId: ModelProviderId; secret: string; userId: string },
+) => Promise<string | null>;
+
+const REASONING_EFFORTS = ["low", "medium", "high"] as const satisfies ReasoningEffort[];
+
+const isReasoningEffort = (value: string): value is ReasoningEffort =>
+	REASONING_EFFORTS.includes(value as ReasoningEffort);
+
+const encryptionSecret = (env: ModelReadinessEnv): string =>
+	env.API_ENCRYPTION_KEY ?? env.BETTER_AUTH_SECRET;
+
+const getAppCredentials = (
+	env: ModelReadinessEnv,
+): Partial<Record<ModelProviderId, string | undefined>> => ({
+	anthropic: env.ANTHROPIC_API_KEY,
+	google: env.GOOGLE_GENERATIVE_AI_API_KEY,
+	openai: env.OPENAI_API_KEY,
+});
+
+const parsePermissions = (requestedPermissions: string): unknown[] => {
+	try {
+		const parsed = JSON.parse(requestedPermissions) as unknown;
+		return Array.isArray(parsed) ? parsed : [];
+	} catch {
+		return [];
+	}
+};
+
+const isProviderId = (value: unknown): value is ModelProviderId =>
+	typeof value === "string" && MODEL_PROVIDER_IDS.includes(value as ModelProviderId);
+
+const hasGrantedModelCredentialPermission = (
+	thinkspace: Pick<Thinkspace, "requestedPermissions">,
+	providerId: ModelProviderId,
+): boolean =>
+	parsePermissions(thinkspace.requestedPermissions).some((permission) => {
+		if (!(permission && typeof permission === "object")) {
+			return false;
+		}
+
+		const candidate = permission as {
+			granted?: unknown;
+			providerId?: unknown;
+			status?: unknown;
+			type?: unknown;
+		};
+
+		return (
+			candidate.type === "model_provider_credential_permission" &&
+			isProviderId(candidate.providerId) &&
+			candidate.providerId === providerId &&
+			(candidate.granted === true || candidate.status === "granted")
+		);
+	});
+
+const getReasoningEffort = (settings: ModelReadinessUserSettings | null): ReasoningEffort => {
+	const effort = settings?.reasoningEffort ?? "medium";
+	return isReasoningEffort(effort) ? effort : "medium";
+};
+
+const getConfiguredModelId = (settings: ModelReadinessUserSettings | null): string =>
+	settings?.defaultModel?.trim() || DEFAULT_MODEL_ID;
+
+const notReady = ({
+	message,
+	modelDefinition,
+	modelId,
+	reason,
+	reasoningEffort,
+}: {
+	message: string;
+	modelDefinition?: ModelCatalogEntry | null;
+	modelId: string;
+	reason: ModelReadinessReason;
+	reasoningEffort: ReasoningEffort;
+}): ThinkspaceModelReadiness => ({
+	message,
+	modelId,
+	modelName: modelDefinition?.name,
+	providerId: modelDefinition?.providerId,
+	providerName: modelDefinition?.providerName,
+	reason,
+	reasoningEffort,
+	requiresThinkspacePermission: modelDefinition?.access === "byok",
+	status: "not_ready",
+});
+
+const productSafeResolutionFailure = ({
+	error,
+	modelDefinition,
+	modelId,
+	reasoningEffort,
+}: {
+	error: ModelResolutionError;
+	modelDefinition: ModelCatalogEntry;
+	modelId: string;
+	reasoningEffort: ReasoningEffort;
+}): ThinkspaceModelReadiness => {
+	if (modelDefinition.access === "byok" && error.message.includes("Permission")) {
+		return notReady({
+			message: "This Thinkspace needs Permission before using a saved provider credential.",
+			modelDefinition,
+			modelId,
+			reason: "permission_required",
+			reasoningEffort,
+		});
+	}
+
+	if (modelDefinition.access === "byok") {
+		return notReady({
+			message: "The saved provider credential for this model is not available.",
+			modelDefinition,
+			modelId,
+			reason: "missing_user_credential",
+			reasoningEffort,
+		});
+	}
+
+	if (error.message.startsWith("Missing ")) {
+		return notReady({
+			message: "The app-provided credential for this model is not configured.",
+			modelDefinition,
+			modelId,
+			reason: "missing_app_credential",
+			reasoningEffort,
+		});
+	}
+
+	return notReady({
+		message: "The selected model configuration could not be resolved.",
+		modelDefinition,
+		modelId,
+		reason: "resolution_failed",
+		reasoningEffort,
+	});
+};
+
+export const getUserProductModelSettings = async (
+	db: ProductDb,
+	userId: string,
+): Promise<ModelReadinessUserSettings | null> => {
+	const [settings] = await db
+		.select({
+			defaultModel: userProductSettings.defaultModel,
+			reasoningEffort: userProductSettings.reasoningEffort,
+		})
+		.from(userProductSettings)
+		.where(eq(userProductSettings.userId, userId))
+		.limit(1);
+
+	return settings ?? null;
+};
+
+export const checkThinkspaceModelReadiness = async ({
+	db,
+	env,
+	getUserCredential = getDecryptedCredential,
+	settings,
+	thinkspace,
+	userId,
+}: CheckThinkspaceModelReadinessInput): Promise<ThinkspaceModelReadiness> => {
+	const modelId = getConfiguredModelId(settings);
+	const reasoningEffort = getReasoningEffort(settings);
+	const modelDefinition = getModelDefinition(modelId);
+
+	if (!modelDefinition) {
+		return notReady({
+			message: "The selected model is not in the supported model catalog.",
+			modelId,
+			reason: "unknown_model",
+			reasoningEffort,
+		});
+	}
+
+	const credentialPermission = hasGrantedModelCredentialPermission(
+		thinkspace,
+		modelDefinition.providerId,
+	)
+		? "granted"
+		: "not_granted";
+	const policy: ThinkspaceModelPolicy = { credentialPermission, modelId, reasoningEffort };
+	const userCredential =
+		modelDefinition.access === "byok" && credentialPermission === "granted"
+			? await getUserCredential(db, {
+					providerId: modelDefinition.providerId,
+					secret: encryptionSecret(env),
+					userId,
+				})
+			: null;
+
+	try {
+		const resolved = resolveLanguageModel({
+			appCredentials: getAppCredentials(env),
+			policy,
+			userCredentials: userCredential
+				? { [modelDefinition.providerId]: userCredential }
+				: undefined,
+		});
+
+		return {
+			credentialSource: resolved.credentialSource,
+			message: "Model configuration is ready for a Thinkspace Agent turn.",
+			modelId,
+			modelName: modelDefinition.name,
+			providerId: modelDefinition.providerId,
+			providerName: modelDefinition.providerName,
+			reasoningEffort,
+			requiresThinkspacePermission: resolved.requiresThinkspacePermission,
+			status: "ready",
+		};
+	} catch (error) {
+		if (error instanceof ModelResolutionError) {
+			return productSafeResolutionFailure({ error, modelDefinition, modelId, reasoningEffort });
+		}
+
+		return notReady({
+			message: "The selected model configuration could not be resolved.",
+			modelDefinition,
+			modelId,
+			reason: "resolution_failed",
+			reasoningEffort,
+		});
+	}
+};
+
+export const getOwnedThinkspaceModelReadiness = async ({
+	db,
+	env,
+	getThinkspaceByOwner = getThinkspace,
+	getUserCredential = getDecryptedCredential,
+	getUserSettings = getUserProductModelSettings,
+	ownerUserId,
+	thinkspaceId,
+}: GetOwnedThinkspaceModelReadinessInput): Promise<ThinkspaceModelReadiness | null> => {
+	const thinkspace = await getThinkspaceByOwner(db, { ownerUserId, thinkspaceId });
+
+	if (!thinkspace) {
+		return null;
+	}
+
+	return await checkThinkspaceModelReadiness({
+		db,
+		env,
+		getUserCredential: async (_db, input) => await getUserCredential(db, input),
+		settings: await getUserSettings(db, ownerUserId),
+		thinkspace,
+		userId: ownerUserId,
+	});
+};

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -1,6 +1,7 @@
 import { ORPCError } from "@orpc/server";
 import { z } from "zod";
 
+import { getOwnedThinkspaceModelReadiness } from "../models/readiness";
 import { protectedProcedure } from "../procedures";
 import {
 	createToolPermissionPlaceholder,
@@ -120,6 +121,22 @@ export const thinkspacesRouter = {
 		async ({ context }) =>
 			await listThinkspaces(context.db, { ownerUserId: context.session.user.id }),
 	),
+	modelReadiness: protectedProcedure
+		.input(thinkspaceIdInput)
+		.handler(async ({ context, input }) => {
+			const readiness = await getOwnedThinkspaceModelReadiness({
+				db: context.db,
+				env: context.env,
+				ownerUserId: context.session.user.id,
+				thinkspaceId: input.thinkspaceId,
+			});
+
+			if (!readiness) {
+				throw toNotFound();
+			}
+
+			return readiness;
+		}),
 	runtimeReadiness: protectedProcedure
 		.input(thinkspaceIdInput)
 		.handler(async ({ context, input }) => {


### PR DESCRIPTION
Closes #32

## What

Adds an end-to-end model readiness preflight path for Thinkspace Agent turns, so an authenticated Thinkspace owner can check whether the Agent has a usable model configuration before submitting work.

## Changes

- **Runtime-safe readiness seam** (`packages/api/src/models/readiness.ts`): resolves the configured model (user product setting or `DEFAULT_MODEL_ID`) through the existing catalog/resolver, converting resolver failures into product-safe readiness results. No oRPC router/transport imports.
- **Fail-closed policy**: unknown model ids, missing app-provided credentials, BYOK without a granted Thinkspace-scoped credential Permission, and missing BYOK credentials all return `not_ready` with product-safe messages. User credentials are never loaded before the Permission check passes.
- **Owner-gated API operation** `thinkspaces.modelReadiness` (`packages/api/src/thinkspaces/router.ts`): protected procedure that returns 404-equivalent for non-owned Thinkspaces.
- **Thinkspace detail surface** (`apps/web/src/routes/thinkspaces.$thinkspaceId.tsx`): shows model readiness (ready/not-ready badge, message, model and provider) alongside runtime readiness.
- **Test-friendliness fix**: `credentials.ts` now imports schema from `@better-agent/db/schema/settings` directly, avoiding `cloudflare:workers` import failures in node tests.
- **Build fix**: added explicit AI SDK provider dependencies to `apps/server` so the bundled model resolver builds in production.

## Verification

- `bun test packages/api/src/models/readiness.test.ts packages/api/src/models/resolver.test.ts packages/api/src/thinkspaces/runtime.test.ts packages/api/src/thinkspaces/lifecycle.test.ts packages/api/src/thinkspaces/policy.test.ts packages/api/src/mcp/url-policy.test.ts` — 28 pass
- `bun run check-types` — pass
- `bun run build` — pass (pre-existing Vite chunk-size warning only)
- `bun x ultracite check` — pass