### PR TITLE
Add no-tools safety policy for the first Thinkspace Agent runtime

### DIFF
--- a/apps/server/src/agents/thinkspace-agent.ts
+++ b/apps/server/src/agents/thinkspace-agent.ts
@@ -1,13 +1,18 @@
+import {
+	createThinkspaceRuntimeToolSet,
+	createThinkspaceRuntimeTurnConfig,
+	THINKSPACE_RUNTIME_POLICY,
+} from "@better-agent/api/thinkspaces/runtime-policy";
 import { Think } from "@cloudflare/think";
 import type { LanguageModel, ToolSet } from "ai";
 
 export class ThinkspaceAgent extends Think {
 	private readonly modelReadinessErrorMessage =
 		"Thinkspace Agent model execution is deferred until model readiness is implemented.";
-	private readonly runtimeToolSet: ToolSet = {};
+	private readonly runtimeToolSet: ToolSet = createThinkspaceRuntimeToolSet();
 
-	override maxSteps = 1;
-	override workspaceBash = false;
+	override maxSteps = THINKSPACE_RUNTIME_POLICY.maxSteps;
+	override workspaceBash = THINKSPACE_RUNTIME_POLICY.workspaceBash;
 
 	override getModel(): LanguageModel {
 		throw new Error(this.modelReadinessErrorMessage);
@@ -19,7 +24,7 @@ export class ThinkspaceAgent extends Think {
 
 	override beforeTurn() {
 		return {
-			activeTools: [],
+			...createThinkspaceRuntimeTurnConfig(),
 			maxSteps: this.maxSteps,
 		};
 	}

--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -60,6 +60,9 @@ const RouteComponent = () => {
 	const modelReadinessQuery = useSuspenseQuery(
 		context.orpc.thinkspaces.modelReadiness.queryOptions({ input: { thinkspaceId } }),
 	);
+	const runtimePolicyQuery = useSuspenseQuery(
+		context.orpc.thinkspaces.runtimePolicy.queryOptions({ input: { thinkspaceId } }),
+	);
 	const mcpCatalogQuery = useSuspenseQuery(context.orpc.mcp.listCatalog.queryOptions());
 	const archiveMutation = useMutation(
 		context.orpc.thinkspaces.archive.mutationOptions({
@@ -88,6 +91,7 @@ const RouteComponent = () => {
 	const thinkspace = thinkspaceQuery.data;
 	const runtimeReadiness = runtimeReadinessQuery.data;
 	const modelReadiness = modelReadinessQuery.data;
+	const runtimePolicy = runtimePolicyQuery.data;
 	const isArchived = thinkspace.status === "archived";
 	const enabledTools = parseJsonArray<EnabledToolSelection>(thinkspace.enabledToolIds);
 	const requestedPermissions = parseJsonArray<PermissionPlaceholder>(
@@ -181,6 +185,26 @@ const RouteComponent = () => {
 							{modelReadiness.modelName ?? modelReadiness.modelId} ·{" "}
 							{modelReadiness.providerName ?? "Unknown provider"}
 						</p>
+					</div>
+					<div className="grid gap-2 border-border border-t pt-4">
+						<div className="flex items-center justify-between gap-4">
+							<p className="text-sm font-medium">Runtime safety policy</p>
+							<Badge variant="outline">
+								{runtimePolicy.mode === "model_only" ? "model-only" : runtimePolicy.mode}
+							</Badge>
+						</div>
+						<p className="text-muted-foreground text-sm">{runtimePolicy.message}</p>
+						<ul className="grid gap-1">
+							{runtimePolicy.capabilities.map((capability) => (
+								<li
+									className="flex items-center justify-between gap-4 text-muted-foreground text-xs"
+									key={capability.id}
+								>
+									<span>{capability.label}</span>
+									<span>{capability.enabled ? "enabled" : "disabled"}</span>
+								</li>
+							))}
+						</ul>
 					</div>
 				</div>
 			</section>
@@ -329,6 +353,11 @@ export const Route = createFileRoute("/thinkspaces/$thinkspaceId")({
 			),
 			context.queryClient.ensureQueryData(
 				context.orpc.thinkspaces.modelReadiness.queryOptions({
+					input: { thinkspaceId: params.thinkspaceId },
+				}),
+			),
+			context.queryClient.ensureQueryData(
+				context.orpc.thinkspaces.runtimePolicy.queryOptions({
 					input: { thinkspaceId: params.thinkspaceId },
 				}),
 			),

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -24,6 +24,7 @@ import {
 	getOwnedThinkspaceAgentRuntimeReadiness,
 	ThinkspaceRuntimeResolutionError,
 } from "./runtime";
+import { getOwnedThinkspaceRuntimePolicy } from "./runtime-policy";
 
 const createThinkspaceInput = z.object({
 	configurationSummary: z.string().optional(),
@@ -137,6 +138,19 @@ export const thinkspacesRouter = {
 
 			return readiness;
 		}),
+	runtimePolicy: protectedProcedure.input(thinkspaceIdInput).handler(async ({ context, input }) => {
+		const policy = await getOwnedThinkspaceRuntimePolicy({
+			db: context.db,
+			ownerUserId: context.session.user.id,
+			thinkspaceId: input.thinkspaceId,
+		});
+
+		if (!policy) {
+			throw toNotFound();
+		}
+
+		return policy;
+	}),
 	runtimeReadiness: protectedProcedure
 		.input(thinkspaceIdInput)
 		.handler(async ({ context, input }) => {

--- a/packages/api/src/thinkspaces/runtime-policy.test.ts
+++ b/packages/api/src/thinkspaces/runtime-policy.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+
+import {
+	createThinkspaceRuntimeToolSet,
+	createThinkspaceRuntimeTurnConfig,
+	getOwnedThinkspaceRuntimePolicy,
+	isThinkspaceRuntimeCapabilityEnabled,
+	THINKSPACE_RUNTIME_CAPABILITY_IDS,
+	THINKSPACE_RUNTIME_POLICY,
+} from "./runtime-policy";
+
+test("disables workspace Bash for the first Thinkspace Agent runtime", () => {
+	assert.equal(THINKSPACE_RUNTIME_POLICY.workspaceBash, false);
+	assert.equal(
+		isThinkspaceRuntimeCapabilityEnabled(THINKSPACE_RUNTIME_POLICY, "workspace_bash"),
+		false,
+	);
+});
+
+test("disables every unsafe capability in the no-tools baseline", () => {
+	const expectedCapabilityIds = [
+		"workspace_bash",
+		"workspace_mutations",
+		"mcp_tools",
+		"connected_account_tools",
+		"external_mutations",
+		"memory_writes",
+		"artifact_publishing",
+	];
+
+	assert.deepEqual([...THINKSPACE_RUNTIME_CAPABILITY_IDS], expectedCapabilityIds);
+	assert.equal(THINKSPACE_RUNTIME_POLICY.capabilities.length, expectedCapabilityIds.length);
+
+	for (const capability of THINKSPACE_RUNTIME_POLICY.capabilities) {
+		assert.equal(capability.enabled, false, `${capability.id} must be disabled`);
+		assert.equal(
+			isThinkspaceRuntimeCapabilityEnabled(THINKSPACE_RUNTIME_POLICY, capability.id),
+			false,
+		);
+	}
+});
+
+test("declares a model-only runtime mode with a bounded step count", () => {
+	assert.equal(THINKSPACE_RUNTIME_POLICY.mode, "model_only");
+	assert.equal(THINKSPACE_RUNTIME_POLICY.policyId, "no_tools_v1");
+	assert.equal(THINKSPACE_RUNTIME_POLICY.maxSteps, 1);
+});
+
+test("creates an empty runtime toolset", () => {
+	assert.deepEqual(createThinkspaceRuntimeToolSet(), {});
+	assert.deepEqual(Object.keys(createThinkspaceRuntimeToolSet()), []);
+});
+
+test("creates a turn config with no active tools and the policy step bound", () => {
+	const turnConfig = createThinkspaceRuntimeTurnConfig();
+
+	assert.deepEqual(turnConfig.activeTools, []);
+	assert.equal(turnConfig.maxSteps, THINKSPACE_RUNTIME_POLICY.maxSteps);
+});
+
+test("reports the runtime policy only after Thinkspace ownership is confirmed", async () => {
+	const requestedOwnershipChecks: { ownerUserId: string; thinkspaceId: string }[] = [];
+	const getThinkspaceByOwner = (
+		_db: ProductDb,
+		input: { ownerUserId: string; thinkspaceId: string },
+	) => {
+		requestedOwnershipChecks.push(input);
+
+		if (input.ownerUserId !== "owner_user") {
+			return Promise.resolve(null);
+		}
+
+		return Promise.resolve({ id: input.thinkspaceId });
+	};
+
+	const ownerPolicy = await getOwnedThinkspaceRuntimePolicy({
+		db: {} as ProductDb,
+		getThinkspaceByOwner,
+		ownerUserId: "owner_user",
+		thinkspaceId: "thinkspace_owned",
+	});
+	const nonOwnerPolicy = await getOwnedThinkspaceRuntimePolicy({
+		db: {} as ProductDb,
+		getThinkspaceByOwner,
+		ownerUserId: "other_user",
+		thinkspaceId: "thinkspace_owned",
+	});
+
+	assert.equal(ownerPolicy?.thinkspaceId, "thinkspace_owned");
+	assert.equal(ownerPolicy?.policyId, "no_tools_v1");
+	assert.equal(ownerPolicy?.workspaceBash, false);
+	assert.equal(nonOwnerPolicy, null);
+	assert.deepEqual(requestedOwnershipChecks, [
+		{ ownerUserId: "owner_user", thinkspaceId: "thinkspace_owned" },
+		{ ownerUserId: "other_user", thinkspaceId: "thinkspace_owned" },
+	]);
+});

--- a/packages/api/src/thinkspaces/runtime-policy.ts
+++ b/packages/api/src/thinkspaces/runtime-policy.ts
@@ -1,0 +1,108 @@
+import type { ProductDb } from "@better-agent/db";
+import type { Thinkspace } from "@better-agent/db/schema/thinkspaces";
+
+import { getThinkspace } from "./repository";
+
+export const THINKSPACE_RUNTIME_POLICY_ID = "no_tools_v1" as const;
+export const THINKSPACE_RUNTIME_POLICY_MODE = "model_only" as const;
+export const THINKSPACE_RUNTIME_MAX_STEPS = 1 as const;
+
+export const THINKSPACE_RUNTIME_CAPABILITY_IDS = [
+	"workspace_bash",
+	"workspace_mutations",
+	"mcp_tools",
+	"connected_account_tools",
+	"external_mutations",
+	"memory_writes",
+	"artifact_publishing",
+] as const;
+
+export type ThinkspaceRuntimeCapabilityId = (typeof THINKSPACE_RUNTIME_CAPABILITY_IDS)[number];
+
+export interface ThinkspaceRuntimeCapability {
+	enabled: false;
+	id: ThinkspaceRuntimeCapabilityId;
+	label: string;
+}
+
+export interface ThinkspaceRuntimePolicy {
+	capabilities: readonly ThinkspaceRuntimeCapability[];
+	maxSteps: typeof THINKSPACE_RUNTIME_MAX_STEPS;
+	message: string;
+	mode: typeof THINKSPACE_RUNTIME_POLICY_MODE;
+	policyId: typeof THINKSPACE_RUNTIME_POLICY_ID;
+	workspaceBash: false;
+}
+
+export interface ThinkspaceRuntimePolicyReport extends ThinkspaceRuntimePolicy {
+	thinkspaceId: string;
+}
+
+export interface ThinkspaceRuntimeTurnConfig {
+	activeTools: string[];
+	maxSteps: typeof THINKSPACE_RUNTIME_MAX_STEPS;
+}
+
+export interface GetOwnedThinkspaceRuntimePolicyInput {
+	db: ProductDb;
+	getThinkspaceByOwner?: GetThinkspaceByOwner;
+	ownerUserId: string;
+	thinkspaceId: string;
+}
+
+type GetThinkspaceByOwner = (
+	db: ProductDb,
+	input: { ownerUserId: string; thinkspaceId: string },
+) => Promise<Pick<Thinkspace, "id"> | null>;
+
+const CAPABILITY_LABELS: Record<ThinkspaceRuntimeCapabilityId, string> = {
+	artifact_publishing: "Artifact publishing",
+	connected_account_tools: "Connected Account tools",
+	external_mutations: "External mutation tools",
+	mcp_tools: "MCP tools",
+	memory_writes: "Product Memory writes",
+	workspace_bash: "Workspace Bash",
+	workspace_mutations: "Mutating workspace tools",
+};
+
+export const THINKSPACE_RUNTIME_POLICY: ThinkspaceRuntimePolicy = {
+	capabilities: THINKSPACE_RUNTIME_CAPABILITY_IDS.map((id) => ({
+		enabled: false,
+		id,
+		label: CAPABILITY_LABELS[id],
+	})),
+	maxSteps: THINKSPACE_RUNTIME_MAX_STEPS,
+	message:
+		"This Thinkspace Agent runs model-only. No tools are enabled in this slice; future tool use requires Thinkspace-scoped Permission policy.",
+	mode: THINKSPACE_RUNTIME_POLICY_MODE,
+	policyId: THINKSPACE_RUNTIME_POLICY_ID,
+	workspaceBash: false,
+} as const;
+
+export const isThinkspaceRuntimeCapabilityEnabled = (
+	policy: ThinkspaceRuntimePolicy,
+	capabilityId: ThinkspaceRuntimeCapabilityId,
+): boolean =>
+	policy.capabilities.some((capability) => capability.id === capabilityId && capability.enabled);
+
+export const createThinkspaceRuntimeToolSet = (): Record<string, never> => ({});
+
+export const createThinkspaceRuntimeTurnConfig = (): ThinkspaceRuntimeTurnConfig => ({
+	activeTools: [],
+	maxSteps: THINKSPACE_RUNTIME_POLICY.maxSteps,
+});
+
+export const getOwnedThinkspaceRuntimePolicy = async ({
+	db,
+	getThinkspaceByOwner = getThinkspace,
+	ownerUserId,
+	thinkspaceId,
+}: GetOwnedThinkspaceRuntimePolicyInput): Promise<ThinkspaceRuntimePolicyReport | null> => {
+	const thinkspace = await getThinkspaceByOwner(db, { ownerUserId, thinkspaceId });
+
+	if (!thinkspace) {
+		return null;
+	}
+
+	return { ...THINKSPACE_RUNTIME_POLICY, thinkspaceId: thinkspace.id };
+};


### PR DESCRIPTION
Closes #33

## What

Adds the first runtime safety policy for the Thinkspace Agent: a model-only, no-tools baseline that makes it verifiable that workspace Bash, mutating workspace tools, MCP tools, Connected Account tools, external mutation tools, product Memory writes, and Artifact publishing are unavailable in this slice.

## Changes

- **Pure runtime-safe policy seam** (`packages/api/src/thinkspaces/runtime-policy.ts`): `THINKSPACE_RUNTIME_POLICY` (`no_tools_v1`, `model_only`, `workspaceBash: false`, bounded `maxSteps: 1`) with an explicit disabled-capability list covering all seven prohibitions; `createThinkspaceRuntimeToolSet()` / `createThinkspaceRuntimeTurnConfig()` helpers; owner-gated `getOwnedThinkspaceRuntimePolicy` following the existing ownership-then-derive pattern. No oRPC router/transport imports, safe inside the Durable Object.
- **Runtime wiring** (`apps/server/src/agents/thinkspace-agent.ts`): `ThinkspaceAgent` now derives `workspaceBash`, `maxSteps`, its empty toolset, and its `beforeTurn` turn config (`activeTools: []`) from the shared policy seam instead of inline literals, so the runtime and inspection path cannot drift.
- **Owner-gated inspection** (`packages/api/src/thinkspaces/router.ts`): new `thinkspaces.runtimePolicy` protected operation; non-owners and missing Thinkspaces get `NOT_FOUND`, unauthenticated requests are rejected by `protectedProcedure`.
- **Thinkspace surface** (`apps/web/src/routes/thinkspaces.$thinkspaceId.tsx`): a "Runtime safety policy" block in the runtime card showing the model-only mode, policy message, and each disabled capability; loader prefetches the query.
- **Tests** (`packages/api/src/thinkspaces/runtime-policy.test.ts`): prove workspace Bash is disabled, every unsafe capability (workspace mutations, MCP, Connected Accounts, external mutations, Memory writes, Artifact publishing) is disabled, the toolset and active tools are empty, the step count is bounded, and the report is only available after ownership is confirmed.

No MCP servers are registered in the runtime (`addMcpServer` is not called anywhere in `apps/server`).

## Verification

- `bun test packages/api/src/thinkspaces/runtime-policy.test.ts packages/api/src/models/readiness.test.ts packages/api/src/models/resolver.test.ts packages/api/src/thinkspaces/runtime.test.ts packages/api/src/thinkspaces/lifecycle.test.ts packages/api/src/thinkspaces/policy.test.ts packages/api/src/mcp/url-policy.test.ts` — 34 pass
- `bun run check-types` — pass
- `bun run build` — pass
- `bun x ultracite check` — pass