### PR TITLE
Add durable accepted submission for model-only Thinkspace Agent turns

### DIFF
--- a/apps/server/src/agents/thinkspace-agent.ts
+++ b/apps/server/src/agents/thinkspace-agent.ts
@@ -1,31 +1,136 @@
 import {
+	resolveOwnedThinkspaceTurnModel,
+	ThinkspaceTurnModelUnavailableError,
+} from "@better-agent/api/models/readiness";
+import {
 	createThinkspaceRuntimeToolSet,
 	createThinkspaceRuntimeTurnConfig,
 	THINKSPACE_RUNTIME_POLICY,
 } from "@better-agent/api/thinkspaces/runtime-policy";
+import {
+	THINKSPACE_TURN_SOURCE,
+	validateThinkspaceTurnIdempotencyKey,
+	validateThinkspaceTurnInstruction,
+} from "@better-agent/api/thinkspaces/turns";
+import type {
+	ThinkspaceTurnAcceptance,
+	ThinkspaceTurnSubmissionRequest,
+} from "@better-agent/api/thinkspaces/turns";
+import { createDb } from "@better-agent/db";
+import type { CloudflareEnv } from "@better-agent/env/types";
 import { Think } from "@cloudflare/think";
-import type { LanguageModel, ToolSet } from "ai";
+import type { LanguageModel, ToolSet, UIMessage } from "ai";
 
-export class ThinkspaceAgent extends Think {
-	private readonly modelReadinessErrorMessage =
-		"Thinkspace Agent model execution is deferred until model readiness is implemented.";
+const TURN_CONTEXT_STORAGE_KEY = "better-agent:turn-context";
+
+/**
+ * Placeholder returned by getModel(). Never used for inference: beforeTurn
+ * always resolves the governed model from product configuration and
+ * overrides it, or fails the turn with a product-safe error first.
+ */
+const UNRESOLVED_TURN_MODEL = "better-agent:turn-model-resolved-in-before-turn";
+
+const MISSING_TURN_CONTEXT_MESSAGE =
+	"This Thinkspace Agent turn is missing its Thinkspace context.";
+const MISSING_THINKSPACE_MESSAGE =
+	"This Thinkspace Agent turn could not verify its Thinkspace configuration.";
+
+interface ThinkspaceTurnContext {
+	ownerUserId: string;
+	thinkspaceId: string;
+}
+
+export class ThinkspaceAgent extends Think<CloudflareEnv> {
 	private readonly runtimeToolSet: ToolSet = createThinkspaceRuntimeToolSet();
+	private readonly turnModelPlaceholder: LanguageModel = UNRESOLVED_TURN_MODEL;
+	private readonly turnSystemPrompt =
+		"You are a Thinkspace Agent for Better Agent. Complete the user's bounded instruction directly and concisely. You have no tools available in this slice; respond with model output only.";
 
 	override maxSteps = THINKSPACE_RUNTIME_POLICY.maxSteps;
 	override workspaceBash = THINKSPACE_RUNTIME_POLICY.workspaceBash;
 
+	async acceptTurnSubmission(
+		request: ThinkspaceTurnSubmissionRequest,
+	): Promise<ThinkspaceTurnAcceptance> {
+		const instruction = validateThinkspaceTurnInstruction(request.instruction);
+		const idempotencyKey = validateThinkspaceTurnIdempotencyKey(request.idempotencyKey);
+		const turnContext: ThinkspaceTurnContext = {
+			ownerUserId: request.ownerUserId,
+			thinkspaceId: request.thinkspaceId,
+		};
+
+		await this.ctx.storage.put(TURN_CONTEXT_STORAGE_KEY, turnContext);
+
+		const message: UIMessage = {
+			id: crypto.randomUUID(),
+			parts: [{ text: instruction, type: "text" }],
+			role: "user",
+		};
+		const result = await this.submitMessages([message], {
+			idempotencyKey,
+			metadata: { source: THINKSPACE_TURN_SOURCE, thinkspaceId: request.thinkspaceId },
+		});
+
+		return {
+			acceptedAt: result.createdAt,
+			deduplicated: !result.accepted,
+			idempotencyKey,
+			status: "accepted",
+			submissionId: result.submissionId,
+			thinkspaceId: request.thinkspaceId,
+		};
+	}
+
 	override getModel(): LanguageModel {
-		throw new Error(this.modelReadinessErrorMessage);
+		return this.turnModelPlaceholder;
+	}
+
+	override getSystemPrompt(): string {
+		return this.turnSystemPrompt;
 	}
 
 	override getTools(): ToolSet {
 		return this.runtimeToolSet;
 	}
 
-	override beforeTurn() {
+	override async beforeTurn() {
+		const turnContext = await this.ctx.storage.get<ThinkspaceTurnContext>(TURN_CONTEXT_STORAGE_KEY);
+
+		if (!turnContext) {
+			throw new Error(MISSING_TURN_CONTEXT_MESSAGE);
+		}
+
+		const resolved = await this.resolveTurnModel(turnContext);
+
 		return {
 			...createThinkspaceRuntimeTurnConfig(),
 			maxSteps: this.maxSteps,
+			model: resolved,
 		};
+	}
+
+	private async resolveTurnModel(turnContext: ThinkspaceTurnContext): Promise<LanguageModel> {
+		let resolved: Awaited<ReturnType<typeof resolveOwnedThinkspaceTurnModel>>;
+
+		try {
+			resolved = await resolveOwnedThinkspaceTurnModel({
+				db: createDb(this.env.DB),
+				env: this.env,
+				ownerUserId: turnContext.ownerUserId,
+				thinkspaceId: turnContext.thinkspaceId,
+			});
+		} catch (error) {
+			const productSafeMessage =
+				error instanceof ThinkspaceTurnModelUnavailableError
+					? error.message
+					: MISSING_THINKSPACE_MESSAGE;
+			throw new Error(productSafeMessage, { cause: error });
+		}
+
+		if (!resolved) {
+			throw new Error(MISSING_THINKSPACE_MESSAGE);
+		}
+
+		return resolved.model;
 	}
 }

--- a/apps/server/tsdown.config.ts
+++ b/apps/server/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
 		neverBundle: ["cloudflare:workers"],
 		onlyBundle: ["drizzle-orm"],
 	},
+	dts: false,
 	entry: "./src/index.ts",
 	format: "esm",
 	outDir: "./dist",

--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -1,8 +1,11 @@
 import { Badge } from "@better-agent/ui/components/badge";
 import { Button } from "@better-agent/ui/components/button";
+import { Label } from "@better-agent/ui/components/label";
 import { Separator } from "@better-agent/ui/components/separator";
+import { Textarea } from "@better-agent/ui/components/textarea";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, getRouteApi, Link, redirect } from "@tanstack/react-router";
+import { useState } from "react";
 
 import { getUser } from "@/functions/get-user";
 
@@ -45,6 +48,105 @@ const parseJsonArray = <T,>(value: string): T[] => {
 	} catch {
 		return [];
 	}
+};
+
+const SubmitTurnSection = ({
+	isArchived,
+	modelReady,
+	thinkspaceId,
+}: {
+	isArchived: boolean;
+	modelReady: boolean;
+	thinkspaceId: string;
+}) => {
+	const context = routeApi.useRouteContext();
+	const [turnInstruction, setTurnInstruction] = useState("");
+	const [turnIdempotencyKey, setTurnIdempotencyKey] = useState(() => crypto.randomUUID());
+	const submitTurnMutation = useMutation(
+		context.orpc.thinkspaces.submitTurn.mutationOptions({
+			onSuccess: () => {
+				setTurnInstruction("");
+				setTurnIdempotencyKey(crypto.randomUUID());
+			},
+		}),
+	);
+	const submitDisabled =
+		isArchived || !modelReady || !turnInstruction.trim() || submitTurnMutation.isPending;
+
+	return (
+		<section aria-labelledby="submit-turn-heading" className="grid gap-4">
+			<div className="grid gap-1">
+				<h2 className="text-lg font-semibold tracking-tight" id="submit-turn-heading">
+					Submit a turn
+				</h2>
+				<p className="text-muted-foreground text-sm">
+					Send a bounded instruction to this Thinkspace Agent. Work is durably accepted and can be
+					inspected later; acceptance is separate from completion.
+				</p>
+			</div>
+			<form
+				className="grid gap-3 border border-border p-4"
+				onSubmit={(event) => {
+					event.preventDefault();
+					if (submitDisabled) {
+						return;
+					}
+					submitTurnMutation.mutate({
+						idempotencyKey: turnIdempotencyKey,
+						instruction: turnInstruction,
+						thinkspaceId,
+					});
+				}}
+			>
+				<div className="grid gap-2">
+					<Label htmlFor="turn-instruction">Instruction</Label>
+					<Textarea
+						disabled={isArchived || !modelReady}
+						id="turn-instruction"
+						maxLength={4000}
+						onChange={(event) => setTurnInstruction(event.target.value)}
+						placeholder="Describe one bounded piece of work for this Thinkspace Agent."
+						rows={3}
+						value={turnInstruction}
+					/>
+				</div>
+				{isArchived ? (
+					<p className="text-muted-foreground text-xs">
+						Archived Thinkspaces cannot accept new Thinkspace Agent turns.
+					</p>
+				) : null}
+				{isArchived || modelReady ? null : (
+					<p className="text-muted-foreground text-xs">
+						Model configuration must be ready before submitting a turn.
+					</p>
+				)}
+				{submitTurnMutation.isError ? (
+					<p className="text-destructive text-xs">{submitTurnMutation.error.message}</p>
+				) : null}
+				{submitTurnMutation.data ? (
+					<div className="grid gap-1 border-border border-t pt-3">
+						<div className="flex items-center justify-between gap-4">
+							<p className="text-sm font-medium">Last accepted turn</p>
+							<Badge variant={submitTurnMutation.data.deduplicated ? "outline" : "default"}>
+								{submitTurnMutation.data.deduplicated ? "already accepted" : "accepted"}
+							</Badge>
+						</div>
+						<p className="break-all text-muted-foreground text-xs">
+							Submission: {submitTurnMutation.data.submissionId}
+						</p>
+						<p className="text-muted-foreground text-xs">
+							Accepted {formatDateTime(submitTurnMutation.data.acceptedAt)}
+						</p>
+					</div>
+				) : null}
+				<div>
+					<Button disabled={submitDisabled} type="submit">
+						{submitTurnMutation.isPending ? "Submitting…" : "Submit turn"}
+					</Button>
+				</div>
+			</form>
+		</section>
+	);
 };
 
 const RouteComponent = () => {
@@ -208,6 +310,14 @@ const RouteComponent = () => {
 					</div>
 				</div>
 			</section>
+
+			<Separator />
+
+			<SubmitTurnSection
+				isArchived={isArchived}
+				modelReady={modelReadiness.status === "ready"}
+				thinkspaceId={thinkspaceId}
+			/>
 
 			<Separator />
 

--- a/packages/api/src/models/readiness.test.ts
+++ b/packages/api/src/models/readiness.test.ts
@@ -3,7 +3,12 @@ import test from "node:test";
 
 import type { ProductDb } from "@better-agent/db";
 
-import { checkThinkspaceModelReadiness, getOwnedThinkspaceModelReadiness } from "./readiness";
+import {
+	checkThinkspaceModelReadiness,
+	getOwnedThinkspaceModelReadiness,
+	resolveOwnedThinkspaceTurnModel,
+	ThinkspaceTurnModelUnavailableError,
+} from "./readiness";
 
 const db = {} as ProductDb;
 
@@ -128,6 +133,53 @@ test("owner-gated model readiness reports readiness for owned Thinkspaces", asyn
 
 	assert.equal(readiness?.status, "ready");
 	assert.equal(readiness?.modelId, "google:gemini-2.5-flash-lite");
+});
+
+test("resolves a usable turn model for ready owned Thinkspaces", async () => {
+	const resolved = await resolveOwnedThinkspaceTurnModel({
+		db,
+		env: createEnv(),
+		getThinkspaceByOwner: () => Promise.resolve(createThinkspace()),
+		getUserSettings: () => Promise.resolve(null),
+		ownerUserId: "owner_user",
+		thinkspaceId: "thinkspace_owned",
+	});
+
+	assert.equal(resolved?.readiness.status, "ready");
+	assert.equal(resolved?.readiness.modelId, "google:gemini-2.5-flash-lite");
+	assert.ok(resolved?.model);
+});
+
+test("turn model resolution fails closed with a product-safe error when not ready", async () => {
+	await assert.rejects(
+		resolveOwnedThinkspaceTurnModel({
+			db,
+			env: createEnv({ GOOGLE_GENERATIVE_AI_API_KEY: undefined }),
+			getThinkspaceByOwner: () => Promise.resolve(createThinkspace()),
+			getUserSettings: () => Promise.resolve(null),
+			ownerUserId: "owner_user",
+			thinkspaceId: "thinkspace_owned",
+		}),
+		(error: unknown) => {
+			assert.ok(error instanceof ThinkspaceTurnModelUnavailableError);
+			assert.equal(error.readiness.reason, "missing_app_credential");
+			assert.equal(error.message, "The app-provided credential for this model is not configured.");
+			return true;
+		},
+	);
+});
+
+test("turn model resolution returns null for non-owned Thinkspaces", async () => {
+	const resolved = await resolveOwnedThinkspaceTurnModel({
+		db,
+		env: createEnv(),
+		getThinkspaceByOwner: () => Promise.resolve(null),
+		getUserSettings: () => Promise.resolve(null),
+		ownerUserId: "other_user",
+		thinkspaceId: "thinkspace_owned",
+	});
+
+	assert.equal(resolved, null);
 });
 
 test("owner-gated model readiness returns null for non-owned Thinkspaces", async () => {

--- a/packages/api/src/models/readiness.ts
+++ b/packages/api/src/models/readiness.ts
@@ -1,3 +1,4 @@
+import type { LanguageModelV3 } from "@ai-sdk/provider";
 import type { ProductDb } from "@better-agent/db";
 import { userProductSettings } from "@better-agent/db/schema/settings";
 import type { Thinkspace } from "@better-agent/db/schema/thinkspaces";
@@ -49,6 +50,26 @@ export interface ModelReadinessNotReady {
 }
 
 export type ThinkspaceModelReadiness = ModelReadinessReady | ModelReadinessNotReady;
+
+interface ThinkspaceModelEvaluation {
+	model?: LanguageModelV3;
+	readiness: ThinkspaceModelReadiness;
+}
+
+export interface ResolvedThinkspaceTurnModel {
+	model: LanguageModelV3;
+	readiness: ModelReadinessReady;
+}
+
+export class ThinkspaceTurnModelUnavailableError extends Error {
+	readonly readiness: ModelReadinessNotReady;
+
+	constructor(readiness: ModelReadinessNotReady) {
+		super(readiness.message);
+		this.name = "ThinkspaceTurnModelUnavailableError";
+		this.readiness = readiness;
+	}
+}
 
 export interface GetOwnedThinkspaceModelReadinessInput {
 	db: ProductDb;
@@ -243,25 +264,27 @@ export const getUserProductModelSettings = async (
 	return settings ?? null;
 };
 
-export const checkThinkspaceModelReadiness = async ({
+const evaluateThinkspaceModel = async ({
 	db,
 	env,
 	getUserCredential = getDecryptedCredential,
 	settings,
 	thinkspace,
 	userId,
-}: CheckThinkspaceModelReadinessInput): Promise<ThinkspaceModelReadiness> => {
+}: CheckThinkspaceModelReadinessInput): Promise<ThinkspaceModelEvaluation> => {
 	const modelId = getConfiguredModelId(settings);
 	const reasoningEffort = getReasoningEffort(settings);
 	const modelDefinition = getModelDefinition(modelId);
 
 	if (!modelDefinition) {
-		return notReady({
-			message: "The selected model is not in the supported model catalog.",
-			modelId,
-			reason: "unknown_model",
-			reasoningEffort,
-		});
+		return {
+			readiness: notReady({
+				message: "The selected model is not in the supported model catalog.",
+				modelId,
+				reason: "unknown_model",
+				reasoningEffort,
+			}),
+		};
 	}
 
 	const credentialPermission = hasGrantedModelCredentialPermission(
@@ -290,32 +313,51 @@ export const checkThinkspaceModelReadiness = async ({
 		});
 
 		return {
-			credentialSource: resolved.credentialSource,
-			message: "Model configuration is ready for a Thinkspace Agent turn.",
-			modelId,
-			modelName: modelDefinition.name,
-			providerId: modelDefinition.providerId,
-			providerName: modelDefinition.providerName,
-			reasoningEffort,
-			requiresThinkspacePermission: resolved.requiresThinkspacePermission,
-			status: "ready",
+			model: resolved.model,
+			readiness: {
+				credentialSource: resolved.credentialSource,
+				message: "Model configuration is ready for a Thinkspace Agent turn.",
+				modelId,
+				modelName: modelDefinition.name,
+				providerId: modelDefinition.providerId,
+				providerName: modelDefinition.providerName,
+				reasoningEffort,
+				requiresThinkspacePermission: resolved.requiresThinkspacePermission,
+				status: "ready",
+			},
 		};
 	} catch (error) {
 		if (error instanceof ModelResolutionError) {
-			return productSafeResolutionFailure({ error, modelDefinition, modelId, reasoningEffort });
+			return {
+				readiness: productSafeResolutionFailure({
+					error,
+					modelDefinition,
+					modelId,
+					reasoningEffort,
+				}),
+			};
 		}
 
-		return notReady({
-			message: "The selected model configuration could not be resolved.",
-			modelDefinition,
-			modelId,
-			reason: "resolution_failed",
-			reasoningEffort,
-		});
+		return {
+			readiness: notReady({
+				message: "The selected model configuration could not be resolved.",
+				modelDefinition,
+				modelId,
+				reason: "resolution_failed",
+				reasoningEffort,
+			}),
+		};
 	}
 };
 
-export const getOwnedThinkspaceModelReadiness = async ({
+export const checkThinkspaceModelReadiness = async (
+	input: CheckThinkspaceModelReadinessInput,
+): Promise<ThinkspaceModelReadiness> => {
+	const evaluation = await evaluateThinkspaceModel(input);
+	return evaluation.readiness;
+};
+
+const evaluateOwnedThinkspaceModel = async ({
 	db,
 	env,
 	getThinkspaceByOwner = getThinkspace,
@@ -323,14 +365,14 @@ export const getOwnedThinkspaceModelReadiness = async ({
 	getUserSettings = getUserProductModelSettings,
 	ownerUserId,
 	thinkspaceId,
-}: GetOwnedThinkspaceModelReadinessInput): Promise<ThinkspaceModelReadiness | null> => {
+}: GetOwnedThinkspaceModelReadinessInput): Promise<ThinkspaceModelEvaluation | null> => {
 	const thinkspace = await getThinkspaceByOwner(db, { ownerUserId, thinkspaceId });
 
 	if (!thinkspace) {
 		return null;
 	}
 
-	return await checkThinkspaceModelReadiness({
+	return await evaluateThinkspaceModel({
 		db,
 		env,
 		getUserCredential: async (_db, input) => await getUserCredential(db, input),
@@ -338,4 +380,38 @@ export const getOwnedThinkspaceModelReadiness = async ({
 		thinkspace,
 		userId: ownerUserId,
 	});
+};
+
+export const getOwnedThinkspaceModelReadiness = async (
+	input: GetOwnedThinkspaceModelReadinessInput,
+): Promise<ThinkspaceModelReadiness | null> => {
+	const evaluation = await evaluateOwnedThinkspaceModel(input);
+	return evaluation?.readiness ?? null;
+};
+
+export const resolveOwnedThinkspaceTurnModel = async (
+	input: GetOwnedThinkspaceModelReadinessInput,
+): Promise<ResolvedThinkspaceTurnModel | null> => {
+	const evaluation = await evaluateOwnedThinkspaceModel(input);
+
+	if (!evaluation) {
+		return null;
+	}
+
+	if (evaluation.readiness.status !== "ready" || !evaluation.model) {
+		const readiness =
+			evaluation.readiness.status === "ready"
+				? {
+						message: "The selected model configuration could not be resolved.",
+						modelId: evaluation.readiness.modelId,
+						reason: "resolution_failed" as const,
+						reasoningEffort: evaluation.readiness.reasoningEffort,
+						requiresThinkspacePermission: evaluation.readiness.requiresThinkspacePermission,
+						status: "not_ready" as const,
+					}
+				: evaluation.readiness;
+		throw new ThinkspaceTurnModelUnavailableError(readiness);
+	}
+
+	return { model: evaluation.model, readiness: evaluation.readiness };
 };

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -1,7 +1,10 @@
 import { ORPCError } from "@orpc/server";
 import { z } from "zod";
 
-import { getOwnedThinkspaceModelReadiness } from "../models/readiness";
+import {
+	getOwnedThinkspaceModelReadiness,
+	ThinkspaceTurnModelUnavailableError,
+} from "../models/readiness";
 import { protectedProcedure } from "../procedures";
 import {
 	createToolPermissionPlaceholder,
@@ -25,6 +28,12 @@ import {
 	ThinkspaceRuntimeResolutionError,
 } from "./runtime";
 import { getOwnedThinkspaceRuntimePolicy } from "./runtime-policy";
+import {
+	submitOwnedThinkspaceTurn,
+	THINKSPACE_TURN_IDEMPOTENCY_KEY_MAX_LENGTH,
+	THINKSPACE_TURN_INSTRUCTION_MAX_LENGTH,
+	ThinkspaceTurnValidationError,
+} from "./turns";
 
 const createThinkspaceInput = z.object({
 	configurationSummary: z.string().optional(),
@@ -44,6 +53,12 @@ const toolSelectionSchema = z.object({
 
 const updateToolSelectionsInput = z.object({
 	selections: z.array(toolSelectionSchema),
+	thinkspaceId: z.string().min(1),
+});
+
+const submitTurnInput = z.object({
+	idempotencyKey: z.string().min(1).max(THINKSPACE_TURN_IDEMPOTENCY_KEY_MAX_LENGTH),
+	instruction: z.string().min(1).max(THINKSPACE_TURN_INSTRUCTION_MAX_LENGTH),
 	thinkspaceId: z.string().min(1),
 });
 
@@ -175,6 +190,38 @@ export const thinkspacesRouter = {
 				throw error;
 			}
 		}),
+	submitTurn: protectedProcedure.input(submitTurnInput).handler(async ({ context, input }) => {
+		try {
+			const acceptance = await submitOwnedThinkspaceTurn({
+				db: context.db,
+				env: context.env,
+				idempotencyKey: input.idempotencyKey,
+				instruction: input.instruction,
+				ownerUserId: context.session.user.id,
+				thinkspaceId: input.thinkspaceId,
+			});
+
+			if (!acceptance) {
+				throw toNotFound();
+			}
+
+			return acceptance;
+		} catch (error) {
+			if (error instanceof ThinkspaceTurnValidationError) {
+				throw new ORPCError("BAD_REQUEST", { message: error.message });
+			}
+
+			if (error instanceof ThinkspaceTurnModelUnavailableError) {
+				throw new ORPCError("BAD_REQUEST", { message: error.message });
+			}
+
+			if (error instanceof ThinkspaceRuntimeResolutionError) {
+				throw new ORPCError("INTERNAL_SERVER_ERROR", { message: error.message });
+			}
+
+			throw error;
+		}
+	}),
 	updateToolSelections: protectedProcedure
 		.input(updateToolSelectionsInput)
 		.handler(async ({ context, input }) => {

--- a/packages/api/src/thinkspaces/turns.test.ts
+++ b/packages/api/src/thinkspaces/turns.test.ts
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+import type { CloudflareEnv } from "@better-agent/env/types";
+
+import { ThinkspaceTurnModelUnavailableError } from "../models/readiness";
+import type { ThinkspaceModelReadiness } from "../models/readiness";
+import { ThinkspaceRuntimeResolutionError } from "./runtime";
+import {
+	submitOwnedThinkspaceTurn,
+	THINKSPACE_TURN_INSTRUCTION_MAX_LENGTH,
+	ThinkspaceTurnValidationError,
+	validateThinkspaceTurnIdempotencyKey,
+	validateThinkspaceTurnInstruction,
+} from "./turns";
+import type { ThinkspaceTurnAcceptance } from "./turns";
+
+const db = {} as ProductDb;
+
+const createEnv = (): Pick<CloudflareEnv, "BETTER_AUTH_SECRET" | "THINKSPACE_AGENT"> & {
+	API_ENCRYPTION_KEY?: string;
+} => ({
+	BETTER_AUTH_SECRET: "test-secret",
+	THINKSPACE_AGENT: {
+		idFromName: (name: string) =>
+			({
+				toString: () => `durable-object-id:${name}`,
+			}) as DurableObjectId,
+	} as DurableObjectNamespace,
+});
+
+const readyReadiness: ThinkspaceModelReadiness = {
+	credentialSource: "app_provided",
+	message: "Model configuration is ready for a Thinkspace Agent turn.",
+	modelId: "google:gemini-2.5-flash-lite",
+	modelName: "Gemini 2.5 Flash Lite",
+	providerId: "google",
+	providerName: "Google",
+	reasoningEffort: "medium",
+	requiresThinkspacePermission: false,
+	status: "ready",
+};
+
+const notReadyReadiness: ThinkspaceModelReadiness = {
+	message: "The app-provided credential for this model is not configured.",
+	modelId: "google:gemini-2.5-flash-lite",
+	reason: "missing_app_credential",
+	reasoningEffort: "medium",
+	requiresThinkspacePermission: false,
+	status: "not_ready",
+};
+
+const createOwnedThinkspace = (status: "active" | "archived" = "active") => ({
+	id: "thinkspace_turns",
+	requestedPermissions: "[]",
+	status,
+});
+
+const acceptedHandle = (idempotencyKey: string): ThinkspaceTurnAcceptance => ({
+	acceptedAt: 1_717_000_000_000,
+	deduplicated: false,
+	idempotencyKey,
+	status: "accepted",
+	submissionId: "submission_1",
+	thinkspaceId: "thinkspace_turns",
+});
+
+test("validates turn instructions as bounded and non-empty", () => {
+	assert.equal(validateThinkspaceTurnInstruction("  Summarize the goal.  "), "Summarize the goal.");
+	assert.throws(() => validateThinkspaceTurnInstruction("   "), ThinkspaceTurnValidationError);
+	assert.throws(
+		() => validateThinkspaceTurnInstruction("x".repeat(THINKSPACE_TURN_INSTRUCTION_MAX_LENGTH + 1)),
+		ThinkspaceTurnValidationError,
+	);
+});
+
+test("validates idempotency keys as bounded and non-empty", () => {
+	assert.equal(validateThinkspaceTurnIdempotencyKey(" retry-key-1 "), "retry-key-1");
+	assert.throws(() => validateThinkspaceTurnIdempotencyKey(""), ThinkspaceTurnValidationError);
+	assert.throws(
+		() => validateThinkspaceTurnIdempotencyKey("k".repeat(129)),
+		ThinkspaceTurnValidationError,
+	);
+});
+
+test("owner submission is durably accepted through the Thinkspace runtime identity", async () => {
+	const runtimeCalls: { idempotencyKey: string; instruction: string; runtimeName: string }[] = [];
+	const acceptance = await submitOwnedThinkspaceTurn({
+		acceptTurnSubmission: ({ request, runtimeName }) => {
+			runtimeCalls.push({
+				idempotencyKey: request.idempotencyKey,
+				instruction: request.instruction,
+				runtimeName,
+			});
+			return Promise.resolve(acceptedHandle(request.idempotencyKey));
+		},
+		checkModelReadiness: () => Promise.resolve(readyReadiness),
+		db,
+		env: createEnv(),
+		getThinkspaceByOwner: (_db, input) => {
+			assert.equal(input.ownerUserId, "owner_user");
+			return Promise.resolve(createOwnedThinkspace());
+		},
+		getUserSettings: () => Promise.resolve(null),
+		idempotencyKey: "  retry-key-1  ",
+		instruction: "  Summarize the Thinkspace goal.  ",
+		ownerUserId: "owner_user",
+		thinkspaceId: "thinkspace_turns",
+	});
+
+	assert.equal(acceptance?.status, "accepted");
+	assert.equal(acceptance?.submissionId, "submission_1");
+	assert.deepEqual(runtimeCalls, [
+		{
+			idempotencyKey: "retry-key-1",
+			instruction: "Summarize the Thinkspace goal.",
+			runtimeName: "thinkspace_turns",
+		},
+	]);
+});
+
+test("repeated submission with the same idempotency key returns the same handle without new work", async () => {
+	const acceptedKeys = new Map<string, ThinkspaceTurnAcceptance>();
+	const submit = (idempotencyKey: string) =>
+		submitOwnedThinkspaceTurn({
+			acceptTurnSubmission: ({ request }) => {
+				const existing = acceptedKeys.get(request.idempotencyKey);
+				if (existing) {
+					return Promise.resolve({ ...existing, deduplicated: true });
+				}
+				const handle = acceptedHandle(request.idempotencyKey);
+				acceptedKeys.set(request.idempotencyKey, handle);
+				return Promise.resolve(handle);
+			},
+			checkModelReadiness: () => Promise.resolve(readyReadiness),
+			db,
+			env: createEnv(),
+			getThinkspaceByOwner: () => Promise.resolve(createOwnedThinkspace()),
+			getUserSettings: () => Promise.resolve(null),
+			idempotencyKey,
+			instruction: "Summarize the Thinkspace goal.",
+			ownerUserId: "owner_user",
+			thinkspaceId: "thinkspace_turns",
+		});
+
+	const first = await submit("retry-key-1");
+	const retry = await submit("retry-key-1");
+
+	assert.equal(first?.deduplicated, false);
+	assert.equal(retry?.deduplicated, true);
+	assert.equal(first?.submissionId, retry?.submissionId);
+	assert.equal(acceptedKeys.size, 1);
+});
+
+test("non-owners cannot submit runtime work to another user's Thinkspace", async () => {
+	let runtimeCallCount = 0;
+	const acceptance = await submitOwnedThinkspaceTurn({
+		acceptTurnSubmission: ({ request }) => {
+			runtimeCallCount += 1;
+			return Promise.resolve(acceptedHandle(request.idempotencyKey));
+		},
+		checkModelReadiness: () => Promise.resolve(readyReadiness),
+		db,
+		env: createEnv(),
+		getThinkspaceByOwner: () => Promise.resolve(null),
+		getUserSettings: () => Promise.resolve(null),
+		idempotencyKey: "retry-key-1",
+		instruction: "Summarize the Thinkspace goal.",
+		ownerUserId: "other_user",
+		thinkspaceId: "thinkspace_turns",
+	});
+
+	assert.equal(acceptance, null);
+	assert.equal(runtimeCallCount, 0);
+});
+
+test("archived Thinkspaces reject new turns", async () => {
+	await assert.rejects(
+		submitOwnedThinkspaceTurn({
+			acceptTurnSubmission: ({ request }) =>
+				Promise.resolve(acceptedHandle(request.idempotencyKey)),
+			checkModelReadiness: () => Promise.resolve(readyReadiness),
+			db,
+			env: createEnv(),
+			getThinkspaceByOwner: () => Promise.resolve(createOwnedThinkspace("archived")),
+			getUserSettings: () => Promise.resolve(null),
+			idempotencyKey: "retry-key-1",
+			instruction: "Summarize the Thinkspace goal.",
+			ownerUserId: "owner_user",
+			thinkspaceId: "thinkspace_turns",
+		}),
+		ThinkspaceTurnValidationError,
+	);
+});
+
+test("missing or disallowed model configuration fails closed before runtime acceptance", async () => {
+	let runtimeCallCount = 0;
+	await assert.rejects(
+		submitOwnedThinkspaceTurn({
+			acceptTurnSubmission: ({ request }) => {
+				runtimeCallCount += 1;
+				return Promise.resolve(acceptedHandle(request.idempotencyKey));
+			},
+			checkModelReadiness: () => Promise.resolve(notReadyReadiness),
+			db,
+			env: createEnv(),
+			getThinkspaceByOwner: () => Promise.resolve(createOwnedThinkspace()),
+			getUserSettings: () => Promise.resolve(null),
+			idempotencyKey: "retry-key-1",
+			instruction: "Summarize the Thinkspace goal.",
+			ownerUserId: "owner_user",
+			thinkspaceId: "thinkspace_turns",
+		}),
+		ThinkspaceTurnModelUnavailableError,
+	);
+
+	assert.equal(runtimeCallCount, 0);
+});
+
+test("missing runtime binding fails with a runtime resolution error", async () => {
+	await assert.rejects(
+		submitOwnedThinkspaceTurn({
+			acceptTurnSubmission: ({ request }) =>
+				Promise.resolve(acceptedHandle(request.idempotencyKey)),
+			checkModelReadiness: () => Promise.resolve(readyReadiness),
+			db,
+			env: { BETTER_AUTH_SECRET: "test-secret" } as Pick<
+				CloudflareEnv,
+				"BETTER_AUTH_SECRET" | "THINKSPACE_AGENT"
+			>,
+			getThinkspaceByOwner: () => Promise.resolve(createOwnedThinkspace()),
+			getUserSettings: () => Promise.resolve(null),
+			idempotencyKey: "retry-key-1",
+			instruction: "Summarize the Thinkspace goal.",
+			ownerUserId: "owner_user",
+			thinkspaceId: "thinkspace_turns",
+		}),
+		ThinkspaceRuntimeResolutionError,
+	);
+});

--- a/packages/api/src/thinkspaces/turns.ts
+++ b/packages/api/src/thinkspaces/turns.ts
@@ -1,0 +1,190 @@
+import type { ProductDb } from "@better-agent/db";
+import type { Thinkspace } from "@better-agent/db/schema/thinkspaces";
+import type { CloudflareEnv } from "@better-agent/env/types";
+
+import {
+	checkThinkspaceModelReadiness,
+	getUserProductModelSettings,
+	ThinkspaceTurnModelUnavailableError,
+} from "../models/readiness";
+import type {
+	CheckThinkspaceModelReadinessInput,
+	ThinkspaceModelReadiness,
+} from "../models/readiness";
+import { getThinkspace } from "./repository";
+import { resolveThinkspaceAgentRuntime, THINKSPACE_AGENT_BINDING_NAME } from "./runtime";
+
+export const THINKSPACE_TURN_INSTRUCTION_MAX_LENGTH = 4000;
+export const THINKSPACE_TURN_IDEMPOTENCY_KEY_MAX_LENGTH = 128;
+export const THINKSPACE_TURN_SOURCE = "better-agent" as const;
+
+export interface ThinkspaceTurnSubmissionRequest {
+	idempotencyKey: string;
+	instruction: string;
+	ownerUserId: string;
+	thinkspaceId: string;
+}
+
+export interface ThinkspaceTurnAcceptance {
+	acceptedAt: number;
+	deduplicated: boolean;
+	idempotencyKey: string;
+	status: "accepted";
+	submissionId: string;
+	thinkspaceId: string;
+}
+
+export interface SubmitOwnedThinkspaceTurnInput {
+	acceptTurnSubmission?: AcceptTurnSubmission;
+	checkModelReadiness?: CheckModelReadiness;
+	db: ProductDb;
+	env: ThinkspaceTurnEnv;
+	getThinkspaceByOwner?: GetThinkspaceByOwner;
+	getUserSettings?: GetUserSettings;
+	idempotencyKey: string;
+	instruction: string;
+	ownerUserId: string;
+	thinkspaceId: string;
+}
+
+type ThinkspaceTurnEnv = Pick<
+	CloudflareEnv,
+	| "ANTHROPIC_API_KEY"
+	| "API_ENCRYPTION_KEY"
+	| "BETTER_AUTH_SECRET"
+	| "GOOGLE_GENERATIVE_AI_API_KEY"
+	| "OPENAI_API_KEY"
+	| typeof THINKSPACE_AGENT_BINDING_NAME
+>;
+
+type GetThinkspaceByOwner = (
+	db: ProductDb,
+	input: { ownerUserId: string; thinkspaceId: string },
+) => Promise<Pick<Thinkspace, "id" | "requestedPermissions" | "status"> | null>;
+
+type GetUserSettings = typeof getUserProductModelSettings;
+
+type CheckModelReadiness = (
+	input: CheckThinkspaceModelReadinessInput,
+) => Promise<ThinkspaceModelReadiness>;
+
+type AcceptTurnSubmission = (input: {
+	env: ThinkspaceTurnEnv;
+	request: ThinkspaceTurnSubmissionRequest;
+	runtimeName: string;
+}) => Promise<ThinkspaceTurnAcceptance>;
+
+interface ThinkspaceAgentTurnStub {
+	acceptTurnSubmission: (
+		request: ThinkspaceTurnSubmissionRequest,
+	) => Promise<ThinkspaceTurnAcceptance>;
+}
+
+export class ThinkspaceTurnValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ThinkspaceTurnValidationError";
+	}
+}
+
+export const validateThinkspaceTurnInstruction = (instruction: string): string => {
+	const bounded = instruction.trim();
+
+	if (!bounded) {
+		throw new ThinkspaceTurnValidationError(
+			"A Thinkspace Agent turn needs a non-empty instruction.",
+		);
+	}
+
+	if (bounded.length > THINKSPACE_TURN_INSTRUCTION_MAX_LENGTH) {
+		throw new ThinkspaceTurnValidationError(
+			`A Thinkspace Agent turn instruction is limited to ${THINKSPACE_TURN_INSTRUCTION_MAX_LENGTH} characters.`,
+		);
+	}
+
+	return bounded;
+};
+
+export const validateThinkspaceTurnIdempotencyKey = (idempotencyKey: string): string => {
+	const bounded = idempotencyKey.trim();
+
+	if (!bounded) {
+		throw new ThinkspaceTurnValidationError(
+			"A Thinkspace Agent turn needs a non-empty idempotency key.",
+		);
+	}
+
+	if (bounded.length > THINKSPACE_TURN_IDEMPOTENCY_KEY_MAX_LENGTH) {
+		throw new ThinkspaceTurnValidationError(
+			`A Thinkspace Agent turn idempotency key is limited to ${THINKSPACE_TURN_IDEMPOTENCY_KEY_MAX_LENGTH} characters.`,
+		);
+	}
+
+	return bounded;
+};
+
+const acceptViaThinkspaceAgentRuntime: AcceptTurnSubmission = async ({
+	env,
+	request,
+	runtimeName,
+}) => {
+	const namespace = env[THINKSPACE_AGENT_BINDING_NAME];
+	const stub = namespace.get(
+		namespace.idFromName(runtimeName),
+	) as unknown as ThinkspaceAgentTurnStub;
+
+	return await stub.acceptTurnSubmission(request);
+};
+
+export const submitOwnedThinkspaceTurn = async ({
+	acceptTurnSubmission = acceptViaThinkspaceAgentRuntime,
+	checkModelReadiness = checkThinkspaceModelReadiness,
+	db,
+	env,
+	getThinkspaceByOwner = getThinkspace,
+	getUserSettings = getUserProductModelSettings,
+	idempotencyKey,
+	instruction,
+	ownerUserId,
+	thinkspaceId,
+}: SubmitOwnedThinkspaceTurnInput): Promise<ThinkspaceTurnAcceptance | null> => {
+	const boundedInstruction = validateThinkspaceTurnInstruction(instruction);
+	const boundedIdempotencyKey = validateThinkspaceTurnIdempotencyKey(idempotencyKey);
+
+	const thinkspace = await getThinkspaceByOwner(db, { ownerUserId, thinkspaceId });
+
+	if (!thinkspace) {
+		return null;
+	}
+
+	if (thinkspace.status === "archived") {
+		throw new ThinkspaceTurnValidationError(
+			"Archived Thinkspaces cannot accept new Thinkspace Agent turns.",
+		);
+	}
+
+	const readiness = await checkModelReadiness({
+		db,
+		env,
+		settings: await getUserSettings(db, ownerUserId),
+		thinkspace,
+		userId: ownerUserId,
+	});
+
+	if (readiness.status !== "ready") {
+		throw new ThinkspaceTurnModelUnavailableError(readiness);
+	}
+
+	const runtime = resolveThinkspaceAgentRuntime({ env, thinkspaceId: thinkspace.id });
+
+	return await acceptTurnSubmission({
+		env,
+		request: {
+			idempotencyKey: boundedIdempotencyKey,
+			instruction: boundedInstruction,
+			ownerUserId,
+			thinkspaceId: thinkspace.id,
+		},
+		runtimeName: runtime.runtimeName,
+	});
+};


### PR DESCRIPTION
Closes #34

## What

Adds the first durable submission path for a model-only Thinkspace Agent turn. An authenticated Thinkspace owner can submit a bounded instruction by Thinkspace id, have the work durably accepted by the Thinkspace Agent runtime, and receive an inspectable handle. Acceptance is explicitly separate from completion, and submission is idempotent for safe retries.

## Changes

- **Submission seam** (`packages/api/src/thinkspaces/turns.ts`): `submitOwnedThinkspaceTurn` validates the bounded instruction (≤4000 chars) and idempotency key (≤128 chars), enforces ownership (null → `NOT_FOUND`), rejects archived Thinkspaces, preflights model readiness (fails closed with the product-safe readiness message before any runtime work), resolves the runtime by stable Thinkspace id, and calls the Durable Object's `acceptTurnSubmission` RPC. All dependencies are injectable for tests; no transport imports.
- **Turn-time model resolution** (`packages/api/src/models/readiness.ts`): the readiness evaluation core now also yields the resolved `LanguageModelV3`. New `resolveOwnedThinkspaceTurnModel` returns a usable turn model for ready owned Thinkspaces, throws `ThinkspaceTurnModelUnavailableError` (product-safe message) when not ready, and returns null for non-owned Thinkspaces. `checkThinkspaceModelReadiness` / `getOwnedThinkspaceModelReadiness` behavior is unchanged.
- **ThinkspaceAgent** (`apps/server/src/agents/thinkspace-agent.ts`): new `acceptTurnSubmission` RPC stores the turn context in DO storage and calls Think's durable `submitMessages` with the idempotency key and Better Agent metadata — repeated keys return the same `submissionId` with `deduplicated: true`. `beforeTurn` now asynchronously resolves the governed model from product configuration (D1 remains the authority) and still applies the no-tools turn config (`activeTools: []`, bounded `maxSteps`); `getModel()` returns a never-used placeholder. Model/runtime failures surface only product-safe messages.
- **API operation** `thinkspaces.submitTurn` (`packages/api/src/thinkspaces/router.ts`): owner-gated protected procedure; validation and model-not-ready map to `BAD_REQUEST`, runtime resolution failures to `INTERNAL_SERVER_ERROR`, non-owned/missing Thinkspaces to `NOT_FOUND`.
- **Thinkspace surface**: a "Submit a turn" section with a bounded instruction form, client-generated idempotency key reused across retries and rotated after success, disabled states for archived/not-ready, and the last accepted handle (submission id, accepted/already-accepted, accepted-at).
- **Build fix**: disabled tsdown d.ts emission for the server worker bundle (`apps/server/tsdown.config.ts`) — an app bundle needs no declarations and the dts bundler failed on workspace type-only imports.

## Verification

- `bun test` over turns, readiness, resolver, runtime, runtime-policy, lifecycle, policy, and url-policy suites — 45 pass
- `bun run check-types` — pass
- `bun run build` — pass
- `bun x ultracite check` — pass