### PR TITLE
Add owner-gated inspection and rendering for Thinkspace Agent turn status

### DIFF
--- a/apps/server/src/agents/thinkspace-agent.ts
+++ b/apps/server/src/agents/thinkspace-agent.ts
@@ -3,6 +3,16 @@ import {
 	ThinkspaceTurnModelUnavailableError,
 } from "@better-agent/api/models/readiness";
 import {
+	extractThinkspaceTurnResultText,
+	mapThinkspaceTurnInspection,
+	markThinkspaceTurnProductSafeError,
+	validateThinkspaceTurnSubmissionId,
+} from "@better-agent/api/thinkspaces/inspect";
+import type {
+	ThinkspaceTurnInspection,
+	ThinkspaceTurnInspectionRequest,
+} from "@better-agent/api/thinkspaces/inspect";
+import {
 	createThinkspaceRuntimeToolSet,
 	createThinkspaceRuntimeTurnConfig,
 	THINKSPACE_RUNTIME_POLICY,
@@ -81,6 +91,24 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 		};
 	}
 
+	async inspectTurnSubmission(
+		request: ThinkspaceTurnInspectionRequest,
+	): Promise<ThinkspaceTurnInspection> {
+		const submissionId = validateThinkspaceTurnSubmissionId(request.submissionId);
+		const snapshot = await this.inspectSubmission(submissionId);
+		const resultText =
+			snapshot?.status === "completed"
+				? extractThinkspaceTurnResultText(await this.getMessages())
+				: null;
+
+		return mapThinkspaceTurnInspection({
+			resultText,
+			snapshot,
+			submissionId,
+			thinkspaceId: request.thinkspaceId,
+		});
+	}
+
 	override getModel(): LanguageModel {
 		return this.turnModelPlaceholder;
 	}
@@ -97,7 +125,7 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 		const turnContext = await this.ctx.storage.get<ThinkspaceTurnContext>(TURN_CONTEXT_STORAGE_KEY);
 
 		if (!turnContext) {
-			throw new Error(MISSING_TURN_CONTEXT_MESSAGE);
+			throw new Error(markThinkspaceTurnProductSafeError(MISSING_TURN_CONTEXT_MESSAGE));
 		}
 
 		const resolved = await this.resolveTurnModel(turnContext);
@@ -124,11 +152,11 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 				error instanceof ThinkspaceTurnModelUnavailableError
 					? error.message
 					: MISSING_THINKSPACE_MESSAGE;
-			throw new Error(productSafeMessage, { cause: error });
+			throw new Error(markThinkspaceTurnProductSafeError(productSafeMessage), { cause: error });
 		}
 
 		if (!resolved) {
-			throw new Error(MISSING_THINKSPACE_MESSAGE);
+			throw new Error(markThinkspaceTurnProductSafeError(MISSING_THINKSPACE_MESSAGE));
 		}
 
 		return resolved.model;

--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -1,9 +1,10 @@
 import { Badge } from "@better-agent/ui/components/badge";
 import { Button } from "@better-agent/ui/components/button";
+import { Input } from "@better-agent/ui/components/input";
 import { Label } from "@better-agent/ui/components/label";
 import { Separator } from "@better-agent/ui/components/separator";
 import { Textarea } from "@better-agent/ui/components/textarea";
-import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, getRouteApi, Link, redirect } from "@tanstack/react-router";
 import { useState } from "react";
 
@@ -48,6 +49,107 @@ const parseJsonArray = <T,>(value: string): T[] => {
 	} catch {
 		return [];
 	}
+};
+
+type TurnInspectionStatus = "accepted" | "completed" | "failed" | "running" | "unknown";
+
+const TURN_STATUS_BADGE_VARIANTS: Record<
+	TurnInspectionStatus,
+	"default" | "destructive" | "outline" | "secondary"
+> = {
+	accepted: "secondary",
+	completed: "default",
+	failed: "destructive",
+	running: "secondary",
+	unknown: "outline",
+};
+
+const TURN_STATUS_POLL_INTERVAL_MS = 2000;
+
+const TurnInspectionPanel = ({
+	initialSubmissionId,
+	thinkspaceId,
+}: {
+	initialSubmissionId: string;
+	thinkspaceId: string;
+}) => {
+	const context = routeApi.useRouteContext();
+	const [submissionIdInput, setSubmissionIdInput] = useState(initialSubmissionId);
+	const [inspectedSubmissionId, setInspectedSubmissionId] = useState(initialSubmissionId);
+	const inspectionQuery = useQuery(
+		context.orpc.thinkspaces.inspectTurn.queryOptions({
+			enabled: Boolean(inspectedSubmissionId),
+			input: { submissionId: inspectedSubmissionId, thinkspaceId },
+			refetchInterval: (query) => {
+				const status = query.state.data?.status;
+				return status === "accepted" || status === "running" ? TURN_STATUS_POLL_INTERVAL_MS : false;
+			},
+		}),
+	);
+	const inspection = inspectionQuery.data;
+
+	return (
+		<div className="grid gap-3 border border-border p-4">
+			<div className="grid gap-1">
+				<p className="text-sm font-medium">Turn status</p>
+				<p className="text-muted-foreground text-xs">
+					Inspect a submitted turn by its submission handle. These runtime diagnostics are for
+					debugging and are not the Audit Trail.
+				</p>
+			</div>
+			<form
+				className="flex items-end gap-2"
+				onSubmit={(event) => {
+					event.preventDefault();
+					setInspectedSubmissionId(submissionIdInput.trim());
+				}}
+			>
+				<div className="grid flex-1 gap-2">
+					<Label htmlFor="turn-submission-id">Submission handle</Label>
+					<Input
+						id="turn-submission-id"
+						maxLength={128}
+						onChange={(event) => setSubmissionIdInput(event.target.value)}
+						placeholder="Paste a submission handle from an accepted turn."
+						value={submissionIdInput}
+					/>
+				</div>
+				<Button
+					disabled={!submissionIdInput.trim() || inspectionQuery.isFetching}
+					type="submit"
+					variant="outline"
+				>
+					Check status
+				</Button>
+			</form>
+			{inspectionQuery.isError ? (
+				<p className="text-destructive text-xs" role="alert">
+					{inspectionQuery.error.message}
+				</p>
+			) : null}
+			{inspection ? (
+				<div className="grid gap-2 border-border border-t pt-3">
+					<div className="flex items-center justify-between gap-4">
+						<p className="break-all text-muted-foreground text-xs">{inspection.submissionId}</p>
+						<Badge variant={TURN_STATUS_BADGE_VARIANTS[inspection.status]}>
+							{inspection.status}
+						</Badge>
+					</div>
+					<p className="text-muted-foreground text-sm">{inspection.message}</p>
+					{inspection.resultText ? (
+						<p className="whitespace-pre-wrap border border-border p-3 text-sm leading-relaxed">
+							{inspection.resultText}
+						</p>
+					) : null}
+					<div className="flex flex-wrap gap-4 text-muted-foreground text-xs">
+						<span>Accepted {formatDateTime(inspection.acceptedAt)}</span>
+						<span>Started {formatDateTime(inspection.startedAt)}</span>
+						<span>Completed {formatDateTime(inspection.completedAt)}</span>
+					</div>
+				</div>
+			) : null}
+		</div>
+	);
 };
 
 const SubmitTurnSection = ({
@@ -145,6 +247,11 @@ const SubmitTurnSection = ({
 					</Button>
 				</div>
 			</form>
+			<TurnInspectionPanel
+				initialSubmissionId={submitTurnMutation.data?.submissionId ?? ""}
+				key={submitTurnMutation.data?.submissionId ?? "no-accepted-turn"}
+				thinkspaceId={thinkspaceId}
+			/>
 		</section>
 	);
 };

--- a/packages/api/src/thinkspaces/inspect.test.ts
+++ b/packages/api/src/thinkspaces/inspect.test.ts
@@ -1,0 +1,356 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+import type { CloudflareEnv } from "@better-agent/env/types";
+
+import {
+	extractThinkspaceTurnProductSafeFailureMessage,
+	extractThinkspaceTurnResultText,
+	inspectOwnedThinkspaceTurn,
+	mapThinkspaceTurnInspection,
+	markThinkspaceTurnProductSafeError,
+	THINKSPACE_TURN_RESULT_TEXT_MAX_LENGTH,
+	THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH,
+	validateThinkspaceTurnSubmissionId,
+} from "./inspect";
+import type { ThinkspaceRuntimeSubmissionSnapshot, ThinkspaceTurnInspection } from "./inspect";
+import { ThinkspaceRuntimeResolutionError } from "./runtime";
+import { ThinkspaceTurnValidationError } from "./turns";
+
+const db = {} as ProductDb;
+
+const createEnv = (): Pick<CloudflareEnv, "THINKSPACE_AGENT"> => ({
+	THINKSPACE_AGENT: {
+		idFromName: (name: string) =>
+			({
+				toString: () => `durable-object-id:${name}`,
+			}) as DurableObjectId,
+	} as DurableObjectNamespace,
+});
+
+const createSnapshot = (
+	overrides: Partial<ThinkspaceRuntimeSubmissionSnapshot> = {},
+): ThinkspaceRuntimeSubmissionSnapshot => ({
+	createdAt: 1_717_000_000_000,
+	metadata: { source: "better-agent", thinkspaceId: "thinkspace_inspect" },
+	status: "pending",
+	submissionId: "submission_1",
+	...overrides,
+});
+
+const unknownInspection = (
+	submissionId = "submission_1",
+): Pick<ThinkspaceTurnInspection, "resultText" | "status" | "submissionId"> => ({
+	resultText: null,
+	status: "unknown",
+	submissionId,
+});
+
+test("validates submission ids as bounded and non-empty", () => {
+	assert.equal(validateThinkspaceTurnSubmissionId("  submission_1  "), "submission_1");
+	assert.throws(() => validateThinkspaceTurnSubmissionId("   "), ThinkspaceTurnValidationError);
+	assert.throws(
+		() =>
+			validateThinkspaceTurnSubmissionId("s".repeat(THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH + 1)),
+		ThinkspaceTurnValidationError,
+	);
+});
+
+test("product-safe failure messages round-trip through the marker", () => {
+	const marked = markThinkspaceTurnProductSafeError(
+		"The selected model is not available for this Thinkspace Agent turn.",
+	);
+
+	assert.equal(
+		extractThinkspaceTurnProductSafeFailureMessage(marked),
+		"The selected model is not available for this Thinkspace Agent turn.",
+	);
+});
+
+test("raw provider or runtime errors are never shown to the product surface", () => {
+	const rawProviderError =
+		"401 Unauthorized: invalid x-api-key sk-ant-secret at https://api.anthropic.com/v1/messages\n  at fetch (provider.js:42)";
+
+	const message = extractThinkspaceTurnProductSafeFailureMessage(rawProviderError);
+
+	assert.equal(message.includes("sk-ant-secret"), false);
+	assert.equal(message.includes("api.anthropic.com"), false);
+	assert.equal(message.includes("provider.js"), false);
+	assert.equal(message, extractThinkspaceTurnProductSafeFailureMessage());
+});
+
+test("extracts the latest assistant text parts as the turn result", () => {
+	const resultText = extractThinkspaceTurnResultText([
+		{
+			parts: [{ text: "First answer.", type: "text" }],
+			role: "assistant",
+		},
+		{
+			parts: [{ text: "Follow-up question.", type: "text" }],
+			role: "user",
+		},
+		{
+			parts: [
+				{ text: "thinking...", type: "reasoning" },
+				{ text: "Latest answer, ", type: "text" },
+				{ text: "joined safely.", type: "text" },
+			],
+			role: "assistant",
+		},
+	]);
+
+	assert.equal(resultText, "Latest answer, joined safely.");
+});
+
+test("returns no result text when the runtime has no assistant response", () => {
+	assert.equal(extractThinkspaceTurnResultText([]), null);
+	assert.equal(
+		extractThinkspaceTurnResultText([
+			{ parts: [{ text: "Hello", type: "text" }], role: "user" },
+			{ parts: [{ text: "", type: "text" }], role: "assistant" },
+		]),
+		null,
+	);
+});
+
+test("bounds completed result text for safe rendering", () => {
+	const resultText = extractThinkspaceTurnResultText([
+		{
+			parts: [{ text: "x".repeat(THINKSPACE_TURN_RESULT_TEXT_MAX_LENGTH + 100), type: "text" }],
+			role: "assistant",
+		},
+	]);
+
+	assert.equal(resultText?.length, THINKSPACE_TURN_RESULT_TEXT_MAX_LENGTH);
+	assert.equal(resultText?.endsWith("…"), true);
+});
+
+test("unknown handles map to a product-safe unknown state", () => {
+	const inspection = mapThinkspaceTurnInspection({
+		snapshot: null,
+		submissionId: "submission_missing",
+		thinkspaceId: "thinkspace_inspect",
+	});
+
+	assert.deepEqual(
+		{
+			resultText: inspection.resultText,
+			status: inspection.status,
+			submissionId: inspection.submissionId,
+		},
+		unknownInspection("submission_missing"),
+	);
+	assert.equal(inspection.thinkspaceId, "thinkspace_inspect");
+	assert.match(inspection.message, /not known to this Thinkspace/u);
+});
+
+test("submissions recorded for a different Thinkspace map to unknown", () => {
+	const mismatched = mapThinkspaceTurnInspection({
+		snapshot: createSnapshot({
+			metadata: { source: "better-agent", thinkspaceId: "thinkspace_other" },
+		}),
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+	});
+	const missingContext = mapThinkspaceTurnInspection({
+		snapshot: createSnapshot({ metadata: undefined }),
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+	});
+
+	assert.equal(mismatched.status, "unknown");
+	assert.equal(missingContext.status, "unknown");
+});
+
+test("maps runtime submission lifecycle onto product turn states", () => {
+	const accepted = mapThinkspaceTurnInspection({
+		snapshot: createSnapshot(),
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+	});
+	const running = mapThinkspaceTurnInspection({
+		snapshot: createSnapshot({ startedAt: 1_717_000_000_500, status: "running" }),
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+	});
+
+	assert.equal(accepted.status, "accepted");
+	assert.equal(accepted.acceptedAt, 1_717_000_000_000);
+	assert.equal(accepted.resultText, null);
+	assert.equal(running.status, "running");
+	assert.equal(running.startedAt, 1_717_000_000_500);
+});
+
+test("completed turns carry the bounded model-only result text", () => {
+	const completed = mapThinkspaceTurnInspection({
+		resultText: "The Thinkspace goal summary.",
+		snapshot: createSnapshot({
+			completedAt: 1_717_000_001_000,
+			startedAt: 1_717_000_000_500,
+			status: "completed",
+		}),
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+	});
+
+	assert.equal(completed.status, "completed");
+	assert.equal(completed.resultText, "The Thinkspace goal summary.");
+	assert.equal(completed.completedAt, 1_717_000_001_000);
+});
+
+test("failed turns keep product-safe messages and drop raw runtime errors", () => {
+	const productSafe = mapThinkspaceTurnInspection({
+		snapshot: createSnapshot({
+			error: markThinkspaceTurnProductSafeError(
+				"Model configuration is missing for this Thinkspace Agent turn.",
+			),
+			status: "error",
+		}),
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+	});
+	const rawError = mapThinkspaceTurnInspection({
+		snapshot: createSnapshot({
+			error: "TypeError: fetch failed sk-ant-secret at provider.js:42",
+			status: "error",
+		}),
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+	});
+	const aborted = mapThinkspaceTurnInspection({
+		snapshot: createSnapshot({ status: "aborted" }),
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+	});
+	const skipped = mapThinkspaceTurnInspection({
+		snapshot: createSnapshot({ status: "skipped" }),
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+	});
+
+	assert.equal(productSafe.status, "failed");
+	assert.equal(
+		productSafe.message,
+		"Model configuration is missing for this Thinkspace Agent turn.",
+	);
+	assert.equal(rawError.status, "failed");
+	assert.equal(rawError.message.includes("sk-ant-secret"), false);
+	assert.equal(rawError.message.includes("provider.js"), false);
+	assert.equal(aborted.status, "failed");
+	assert.equal(skipped.status, "failed");
+	assert.equal(aborted.resultText, null);
+});
+
+test("owner inspection resolves the same Thinkspace runtime identity used for submission", async () => {
+	const runtimeCalls: { runtimeName: string; submissionId: string; thinkspaceId: string }[] = [];
+	const inspection = await inspectOwnedThinkspaceTurn({
+		db,
+		env: createEnv(),
+		getThinkspaceByOwner: (_db, input) => {
+			assert.equal(input.ownerUserId, "owner_user");
+			return Promise.resolve({ id: "thinkspace_inspect" });
+		},
+		inspectTurnSubmission: ({ request, runtimeName }) => {
+			runtimeCalls.push({
+				runtimeName,
+				submissionId: request.submissionId,
+				thinkspaceId: request.thinkspaceId,
+			});
+			return Promise.resolve(
+				mapThinkspaceTurnInspection({
+					snapshot: createSnapshot(),
+					submissionId: request.submissionId,
+					thinkspaceId: request.thinkspaceId,
+				}),
+			);
+		},
+		ownerUserId: "owner_user",
+		submissionId: "  submission_1  ",
+		thinkspaceId: "thinkspace_inspect",
+	});
+
+	assert.equal(inspection?.status, "accepted");
+	assert.equal(inspection?.submissionId, "submission_1");
+	assert.deepEqual(runtimeCalls, [
+		{
+			runtimeName: "thinkspace_inspect",
+			submissionId: "submission_1",
+			thinkspaceId: "thinkspace_inspect",
+		},
+	]);
+});
+
+test("non-owners cannot inspect runtime work for another user's Thinkspace", async () => {
+	let runtimeCallCount = 0;
+	const inspection = await inspectOwnedThinkspaceTurn({
+		db,
+		env: createEnv(),
+		getThinkspaceByOwner: () => Promise.resolve(null),
+		inspectTurnSubmission: ({ request }) => {
+			runtimeCallCount += 1;
+			return Promise.resolve(
+				mapThinkspaceTurnInspection({
+					snapshot: createSnapshot(),
+					submissionId: request.submissionId,
+					thinkspaceId: request.thinkspaceId,
+				}),
+			);
+		},
+		ownerUserId: "other_user",
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+	});
+
+	assert.equal(inspection, null);
+	assert.equal(runtimeCallCount, 0);
+});
+
+test("inspection rejects invalid submission handles before touching the runtime", async () => {
+	let runtimeCallCount = 0;
+	await assert.rejects(
+		inspectOwnedThinkspaceTurn({
+			db,
+			env: createEnv(),
+			getThinkspaceByOwner: () => Promise.resolve({ id: "thinkspace_inspect" }),
+			inspectTurnSubmission: ({ request }) => {
+				runtimeCallCount += 1;
+				return Promise.resolve(
+					mapThinkspaceTurnInspection({
+						snapshot: createSnapshot(),
+						submissionId: request.submissionId,
+						thinkspaceId: request.thinkspaceId,
+					}),
+				);
+			},
+			ownerUserId: "owner_user",
+			submissionId: "   ",
+			thinkspaceId: "thinkspace_inspect",
+		}),
+		ThinkspaceTurnValidationError,
+	);
+
+	assert.equal(runtimeCallCount, 0);
+});
+
+test("missing runtime binding fails inspection with a runtime resolution error", async () => {
+	await assert.rejects(
+		inspectOwnedThinkspaceTurn({
+			db,
+			env: {} as Pick<CloudflareEnv, "THINKSPACE_AGENT">,
+			getThinkspaceByOwner: () => Promise.resolve({ id: "thinkspace_inspect" }),
+			inspectTurnSubmission: ({ request }) =>
+				Promise.resolve(
+					mapThinkspaceTurnInspection({
+						snapshot: createSnapshot(),
+						submissionId: request.submissionId,
+						thinkspaceId: request.thinkspaceId,
+					}),
+				),
+			ownerUserId: "owner_user",
+			submissionId: "submission_1",
+			thinkspaceId: "thinkspace_inspect",
+		}),
+		ThinkspaceRuntimeResolutionError,
+	);
+});

--- a/packages/api/src/thinkspaces/inspect.ts
+++ b/packages/api/src/thinkspaces/inspect.ts
@@ -1,0 +1,290 @@
+import type { ProductDb } from "@better-agent/db";
+import type { Thinkspace } from "@better-agent/db/schema/thinkspaces";
+import type { CloudflareEnv } from "@better-agent/env/types";
+
+import { getThinkspace } from "./repository";
+import { resolveThinkspaceAgentRuntime, THINKSPACE_AGENT_BINDING_NAME } from "./runtime";
+import { ThinkspaceTurnValidationError } from "./turns";
+
+export const THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH = 128;
+export const THINKSPACE_TURN_RESULT_TEXT_MAX_LENGTH = 8000;
+
+/**
+ * Marker prefix for failure messages the Thinkspace Agent runtime throws on
+ * purpose for the product surface. Inspection strips the marker and shows the
+ * message; any unmarked runtime/provider error is replaced with a generic
+ * product-safe message so secrets and raw internals never reach the product.
+ */
+const PRODUCT_SAFE_ERROR_MARKER = "thinkspace-turn-product-safe:";
+
+const UNKNOWN_TURN_MESSAGE =
+	"This Thinkspace Agent turn is not known to this Thinkspace. Check the submission handle and try again.";
+const ACCEPTED_TURN_MESSAGE =
+	"Accepted. This Thinkspace Agent turn is waiting for the runtime to start it.";
+const RUNNING_TURN_MESSAGE = "This Thinkspace Agent turn is running.";
+const COMPLETED_TURN_MESSAGE =
+	"Completed. Showing the Thinkspace Agent's latest model-only response.";
+const COMPLETED_WITHOUT_TEXT_MESSAGE =
+	"Completed. The Thinkspace Agent did not return any text for this turn.";
+const GENERIC_FAILED_TURN_MESSAGE =
+	"This Thinkspace Agent turn failed before completing. Provider and runtime details are not shown here.";
+const ABORTED_TURN_MESSAGE = "This Thinkspace Agent turn was stopped before completing.";
+const SKIPPED_TURN_MESSAGE =
+	"This Thinkspace Agent turn was skipped before running. Submit the turn again.";
+
+export type ThinkspaceRuntimeSubmissionStatus =
+	| "pending"
+	| "running"
+	| "completed"
+	| "aborted"
+	| "skipped"
+	| "error";
+
+/**
+ * Structural snapshot of a runtime submission row. Mirrors what the
+ * Thinkspace Agent runtime can read for a submission without importing
+ * runtime SDK types into this transport-free package.
+ */
+export interface ThinkspaceRuntimeSubmissionSnapshot {
+	completedAt?: number;
+	createdAt: number;
+	error?: string;
+	idempotencyKey?: string;
+	metadata?: Record<string, unknown>;
+	startedAt?: number;
+	status: ThinkspaceRuntimeSubmissionStatus;
+	submissionId: string;
+}
+
+export interface ThinkspaceRuntimeMessagePart {
+	text?: string;
+	type: string;
+}
+
+export interface ThinkspaceRuntimeMessage {
+	parts: readonly ThinkspaceRuntimeMessagePart[];
+	role: string;
+}
+
+export type ThinkspaceTurnInspectionStatus =
+	| "accepted"
+	| "running"
+	| "completed"
+	| "failed"
+	| "unknown";
+
+export interface ThinkspaceTurnInspection {
+	acceptedAt: number | null;
+	completedAt: number | null;
+	message: string;
+	resultText: string | null;
+	startedAt: number | null;
+	status: ThinkspaceTurnInspectionStatus;
+	submissionId: string;
+	thinkspaceId: string;
+}
+
+export interface ThinkspaceTurnInspectionRequest {
+	submissionId: string;
+	thinkspaceId: string;
+}
+
+export interface InspectOwnedThinkspaceTurnInput {
+	db: ProductDb;
+	env: ThinkspaceTurnInspectEnv;
+	getThinkspaceByOwner?: GetThinkspaceByOwner;
+	inspectTurnSubmission?: InspectTurnSubmission;
+	ownerUserId: string;
+	submissionId: string;
+	thinkspaceId: string;
+}
+
+type ThinkspaceTurnInspectEnv = Pick<CloudflareEnv, typeof THINKSPACE_AGENT_BINDING_NAME>;
+
+type GetThinkspaceByOwner = (
+	db: ProductDb,
+	input: { ownerUserId: string; thinkspaceId: string },
+) => Promise<Pick<Thinkspace, "id"> | null>;
+
+type InspectTurnSubmission = (input: {
+	env: ThinkspaceTurnInspectEnv;
+	request: ThinkspaceTurnInspectionRequest;
+	runtimeName: string;
+}) => Promise<ThinkspaceTurnInspection>;
+
+interface ThinkspaceAgentInspectStub {
+	inspectTurnSubmission: (
+		request: ThinkspaceTurnInspectionRequest,
+	) => Promise<ThinkspaceTurnInspection>;
+}
+
+export const validateThinkspaceTurnSubmissionId = (submissionId: string): string => {
+	const bounded = submissionId.trim();
+
+	if (!bounded) {
+		throw new ThinkspaceTurnValidationError(
+			"Inspecting a Thinkspace Agent turn needs a non-empty submission handle.",
+		);
+	}
+
+	if (bounded.length > THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH) {
+		throw new ThinkspaceTurnValidationError(
+			`A Thinkspace Agent turn submission handle is limited to ${THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH} characters.`,
+		);
+	}
+
+	return bounded;
+};
+
+export const markThinkspaceTurnProductSafeError = (message: string): string =>
+	message.startsWith(PRODUCT_SAFE_ERROR_MARKER)
+		? message
+		: `${PRODUCT_SAFE_ERROR_MARKER}${message}`;
+
+export const extractThinkspaceTurnProductSafeFailureMessage = (error?: string): string => {
+	if (!error?.startsWith(PRODUCT_SAFE_ERROR_MARKER)) {
+		return GENERIC_FAILED_TURN_MESSAGE;
+	}
+
+	const message = error.slice(PRODUCT_SAFE_ERROR_MARKER.length).trim();
+
+	return message || GENERIC_FAILED_TURN_MESSAGE;
+};
+
+export const extractThinkspaceTurnResultText = (
+	messages: readonly ThinkspaceRuntimeMessage[],
+): string | null => {
+	const lastAssistantMessage = messages.findLast((message) => message.role === "assistant");
+
+	if (!lastAssistantMessage) {
+		return null;
+	}
+
+	const resultText = lastAssistantMessage.parts
+		.filter((part) => part.type === "text" && typeof part.text === "string")
+		.map((part) => part.text)
+		.join("")
+		.trim();
+
+	if (!resultText) {
+		return null;
+	}
+
+	if (resultText.length > THINKSPACE_TURN_RESULT_TEXT_MAX_LENGTH) {
+		return `${resultText.slice(0, THINKSPACE_TURN_RESULT_TEXT_MAX_LENGTH - 1)}…`;
+	}
+
+	return resultText;
+};
+
+const createUnknownTurnInspection = (
+	submissionId: string,
+	thinkspaceId: string,
+): ThinkspaceTurnInspection => ({
+	acceptedAt: null,
+	completedAt: null,
+	message: UNKNOWN_TURN_MESSAGE,
+	resultText: null,
+	startedAt: null,
+	status: "unknown",
+	submissionId,
+	thinkspaceId,
+});
+
+const createFailureMessage = (snapshot: ThinkspaceRuntimeSubmissionSnapshot): string => {
+	if (snapshot.status === "aborted") {
+		return ABORTED_TURN_MESSAGE;
+	}
+
+	if (snapshot.status === "skipped") {
+		return SKIPPED_TURN_MESSAGE;
+	}
+
+	return extractThinkspaceTurnProductSafeFailureMessage(snapshot.error);
+};
+
+export const mapThinkspaceTurnInspection = ({
+	resultText = null,
+	snapshot,
+	submissionId,
+	thinkspaceId,
+}: {
+	resultText?: string | null;
+	snapshot: ThinkspaceRuntimeSubmissionSnapshot | null;
+	submissionId: string;
+	thinkspaceId: string;
+}): ThinkspaceTurnInspection => {
+	if (!snapshot || snapshot.metadata?.thinkspaceId !== thinkspaceId) {
+		return createUnknownTurnInspection(submissionId, thinkspaceId);
+	}
+
+	const base = {
+		acceptedAt: snapshot.createdAt,
+		completedAt: snapshot.completedAt ?? null,
+		resultText: null,
+		startedAt: snapshot.startedAt ?? null,
+		submissionId: snapshot.submissionId,
+		thinkspaceId,
+	};
+
+	if (snapshot.status === "pending") {
+		return { ...base, message: ACCEPTED_TURN_MESSAGE, status: "accepted" };
+	}
+
+	if (snapshot.status === "running") {
+		return { ...base, message: RUNNING_TURN_MESSAGE, status: "running" };
+	}
+
+	if (snapshot.status === "completed") {
+		return {
+			...base,
+			message: resultText ? COMPLETED_TURN_MESSAGE : COMPLETED_WITHOUT_TEXT_MESSAGE,
+			resultText,
+			status: "completed",
+		};
+	}
+
+	return { ...base, message: createFailureMessage(snapshot), status: "failed" };
+};
+
+const inspectViaThinkspaceAgentRuntime: InspectTurnSubmission = async ({
+	env,
+	request,
+	runtimeName,
+}) => {
+	const namespace = env[THINKSPACE_AGENT_BINDING_NAME];
+	const stub = namespace.get(
+		namespace.idFromName(runtimeName),
+	) as unknown as ThinkspaceAgentInspectStub;
+
+	return await stub.inspectTurnSubmission(request);
+};
+
+export const inspectOwnedThinkspaceTurn = async ({
+	db,
+	env,
+	getThinkspaceByOwner = getThinkspace,
+	inspectTurnSubmission = inspectViaThinkspaceAgentRuntime,
+	ownerUserId,
+	submissionId,
+	thinkspaceId,
+}: InspectOwnedThinkspaceTurnInput): Promise<ThinkspaceTurnInspection | null> => {
+	const boundedSubmissionId = validateThinkspaceTurnSubmissionId(submissionId);
+
+	const thinkspace = await getThinkspaceByOwner(db, { ownerUserId, thinkspaceId });
+
+	if (!thinkspace) {
+		return null;
+	}
+
+	const runtime = resolveThinkspaceAgentRuntime({ env, thinkspaceId: thinkspace.id });
+
+	return await inspectTurnSubmission({
+		env,
+		request: {
+			submissionId: boundedSubmissionId,
+			thinkspaceId: thinkspace.id,
+		},
+		runtimeName: runtime.runtimeName,
+	});
+};

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -6,6 +6,7 @@ import {
 	ThinkspaceTurnModelUnavailableError,
 } from "../models/readiness";
 import { protectedProcedure } from "../procedures";
+import { inspectOwnedThinkspaceTurn, THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH } from "./inspect";
 import {
 	createToolPermissionPlaceholder,
 	DEFAULT_APPROVAL_POLICY,
@@ -53,6 +54,11 @@ const toolSelectionSchema = z.object({
 
 const updateToolSelectionsInput = z.object({
 	selections: z.array(toolSelectionSchema),
+	thinkspaceId: z.string().min(1),
+});
+
+const inspectTurnInput = z.object({
+	submissionId: z.string().min(1).max(THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH),
 	thinkspaceId: z.string().min(1),
 });
 
@@ -132,6 +138,33 @@ export const thinkspacesRouter = {
 		}
 
 		return thinkspace;
+	}),
+	inspectTurn: protectedProcedure.input(inspectTurnInput).handler(async ({ context, input }) => {
+		try {
+			const inspection = await inspectOwnedThinkspaceTurn({
+				db: context.db,
+				env: context.env,
+				ownerUserId: context.session.user.id,
+				submissionId: input.submissionId,
+				thinkspaceId: input.thinkspaceId,
+			});
+
+			if (!inspection) {
+				throw toNotFound();
+			}
+
+			return inspection;
+		} catch (error) {
+			if (error instanceof ThinkspaceTurnValidationError) {
+				throw new ORPCError("BAD_REQUEST", { message: error.message });
+			}
+
+			if (error instanceof ThinkspaceRuntimeResolutionError) {
+				throw new ORPCError("INTERNAL_SERVER_ERROR", { message: error.message });
+			}
+
+			throw error;
+		}
 	}),
 	list: protectedProcedure.handler(
 		async ({ context }) =>


### PR DESCRIPTION
Closes #35

## What this adds

The first inspection and rendering path for a submitted Thinkspace Agent turn. An authenticated owner can take the acceptance handle from submission and inspect the same Thinkspace Agent runtime for a product-safe state and result.

### Pure seam (`packages/api/src/thinkspaces/inspect.ts`)

- `inspectOwnedThinkspaceTurn` follows the ownership-then-act pattern from `submitTurn`: injectable `getThinkspaceByOwner` (null → router `NOT_FOUND`), runtime addressing via `resolveThinkspaceAgentRuntime` (same `idFromName(thinkspaceId)` identity used for submission), and an injectable runtime gateway.
- `mapThinkspaceTurnInspection` maps Think submission statuses to product states: `pending` → accepted, `running` → running, `completed` → completed, `aborted`/`skipped`/`error` → failed, missing row or Thinkspace-context mismatch → unknown.
- Product-safe failure messages: the agent marks its intentional errors with a `thinkspace-turn-product-safe:` prefix; inspection strips the marker and shows the message. Any unmarked runtime/provider error (raw stack traces, provider URLs, keys) is replaced with a generic product-safe message and never crosses the RPC boundary.
- `extractThinkspaceTurnResultText` renders completed model-only results safely: latest assistant message, text parts only, bounded to 8000 chars.

### DO wiring (`apps/server/src/agents/thinkspace-agent.ts`)

- New `inspectTurnSubmission` RPC wrapping Think's `inspectSubmission` + `getMessages`, mapping inside the Durable Object so raw errors never leave it.
- `beforeTurn`/model-resolution failures are now marked product-safe so inspection can distinguish them from raw provider errors.

### Router (`thinkspaces.inspectTurn`)

- Protected, owner-gated, alphabetized between `get` and `list`; error mapping mirrors `submitTurn` (validation → `BAD_REQUEST`, runtime resolution → `INTERNAL_SERVER_ERROR`, non-owner/missing Thinkspace → `NOT_FOUND`).

### Web surface

- `TurnInspectionPanel` on the Thinkspace detail route, prefilled from the last acceptance handle, with a manual check for any pasted handle and 2s polling while a turn is accepted/running. Copy explicitly distinguishes these runtime diagnostics from the user-facing Audit Trail.

## Acceptance criteria mapping

- Owner inspects by Thinkspace id + handle: `inspectOwnedThinkspaceTurn` + `thinkspaces.inspectTurn` + panel.
- Same runtime identity as submission: `resolveThinkspaceAgentRuntime` reuse, asserted in tests.
- Accepted/running/completed/failed/unknown states: `ThinkspaceTurnInspectionStatus` + mapping tests.
- Completed model-only results render safely: bounded text extraction + panel rendering.
- Failed states are product-safe: marker round-trip + raw-error redaction tests.
- Unauthenticated users blocked: `protectedProcedure`.
- Non-owners blocked: owner gate returns null → `NOT_FOUND`; covered by tests.
- Unknown handles: product-safe unknown state for missing rows and cross-Thinkspace handles.
- Diagnostics distinct from Audit Trail: UI copy; no Audit Trail claims.
- Tests: 15 new node tests covering owner inspection, rejection paths, and state mapping.

## Verification

- `bun test` across api suites: 60 pass (45 existing + 15 new)
- `bun run check-types`
- `bun run build` (pre-existing Vite large-chunk warning only)
- `bun x ultracite fix` clean; `routeTree.gen.ts` reverted