### PR TITLE
Harden Thinkspace Agent runtime access with adversarial boundary tests

### DIFF
--- a/apps/server/src/agents/thinkspace-agent.ts
+++ b/apps/server/src/agents/thinkspace-agent.ts
@@ -18,6 +18,11 @@ import {
 	THINKSPACE_RUNTIME_POLICY,
 } from "@better-agent/api/thinkspaces/runtime-policy";
 import {
+	bindThinkspaceTurnRuntimeContext,
+	matchesThinkspaceTurnRuntimeContext,
+} from "@better-agent/api/thinkspaces/turn-context";
+import type { ThinkspaceTurnRuntimeContext } from "@better-agent/api/thinkspaces/turn-context";
+import {
 	THINKSPACE_TURN_SOURCE,
 	validateThinkspaceTurnIdempotencyKey,
 	validateThinkspaceTurnInstruction,
@@ -45,11 +50,6 @@ const MISSING_TURN_CONTEXT_MESSAGE =
 const MISSING_THINKSPACE_MESSAGE =
 	"This Thinkspace Agent turn could not verify its Thinkspace configuration.";
 
-interface ThinkspaceTurnContext {
-	ownerUserId: string;
-	thinkspaceId: string;
-}
-
 export class ThinkspaceAgent extends Think<CloudflareEnv> {
 	private readonly runtimeToolSet: ToolSet = createThinkspaceRuntimeToolSet();
 	private readonly turnModelPlaceholder: LanguageModel = UNRESOLVED_TURN_MODEL;
@@ -59,15 +59,31 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 	override maxSteps = THINKSPACE_RUNTIME_POLICY.maxSteps;
 	override workspaceBash = THINKSPACE_RUNTIME_POLICY.workspaceBash;
 
+	/**
+	 * HTTP/WebSocket entry to this runtime stays closed. Project Think serves
+	 * unauthenticated routes (for example `/get-messages`) when a request
+	 * reaches the Durable Object, so the only supported entry points are the
+	 * owner-gated worker RPCs (`acceptTurnSubmission`, `inspectTurnSubmission`).
+	 */
+	// eslint-disable-next-line class-methods-use-this -- must stay an instance override to shadow the Agent HTTP entry point
+	override fetch(_request: Request): Promise<Response> {
+		return Promise.resolve(
+			new Response("This Thinkspace Agent runtime is not directly accessible.", { status: 404 }),
+		);
+	}
+
 	async acceptTurnSubmission(
 		request: ThinkspaceTurnSubmissionRequest,
 	): Promise<ThinkspaceTurnAcceptance> {
 		const instruction = validateThinkspaceTurnInstruction(request.instruction);
 		const idempotencyKey = validateThinkspaceTurnIdempotencyKey(request.idempotencyKey);
-		const turnContext: ThinkspaceTurnContext = {
-			ownerUserId: request.ownerUserId,
-			thinkspaceId: request.thinkspaceId,
-		};
+		const turnContext = bindThinkspaceTurnRuntimeContext({
+			existing: await this.ctx.storage.get<ThinkspaceTurnRuntimeContext>(TURN_CONTEXT_STORAGE_KEY),
+			request: {
+				ownerUserId: request.ownerUserId,
+				thinkspaceId: request.thinkspaceId,
+			},
+		});
 
 		await this.ctx.storage.put(TURN_CONTEXT_STORAGE_KEY, turnContext);
 
@@ -95,6 +111,17 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 		request: ThinkspaceTurnInspectionRequest,
 	): Promise<ThinkspaceTurnInspection> {
 		const submissionId = validateThinkspaceTurnSubmissionId(request.submissionId);
+		const turnContext =
+			await this.ctx.storage.get<ThinkspaceTurnRuntimeContext>(TURN_CONTEXT_STORAGE_KEY);
+
+		if (!matchesThinkspaceTurnRuntimeContext(turnContext, request.thinkspaceId)) {
+			return mapThinkspaceTurnInspection({
+				snapshot: null,
+				submissionId,
+				thinkspaceId: request.thinkspaceId,
+			});
+		}
+
 		const snapshot = await this.inspectSubmission(submissionId);
 		const resultText =
 			snapshot?.status === "completed"
@@ -122,7 +149,8 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 	}
 
 	override async beforeTurn() {
-		const turnContext = await this.ctx.storage.get<ThinkspaceTurnContext>(TURN_CONTEXT_STORAGE_KEY);
+		const turnContext =
+			await this.ctx.storage.get<ThinkspaceTurnRuntimeContext>(TURN_CONTEXT_STORAGE_KEY);
 
 		if (!turnContext) {
 			throw new Error(markThinkspaceTurnProductSafeError(MISSING_TURN_CONTEXT_MESSAGE));
@@ -137,7 +165,9 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 		};
 	}
 
-	private async resolveTurnModel(turnContext: ThinkspaceTurnContext): Promise<LanguageModel> {
+	private async resolveTurnModel(
+		turnContext: ThinkspaceTurnRuntimeContext,
+	): Promise<LanguageModel> {
 		let resolved: Awaited<ReturnType<typeof resolveOwnedThinkspaceTurnModel>>;
 
 		try {

--- a/apps/server/src/worker-routes.test.ts
+++ b/apps/server/src/worker-routes.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+/**
+ * The worker and Durable Object modules import `cloudflare:workers` through
+ * their dependencies, so these guards assert against the source text instead
+ * of loading the modules in a Node test runtime.
+ *
+ * They encode the runtime-access decision from the Thinkspace Agent runtime
+ * PRD: no raw Project Think route is exposed to browsers; the only supported
+ * entry points are the owner-gated oRPC procedures that talk to the Durable
+ * Object by Thinkspace id.
+ */
+const workerSource = readFileSync(new URL("index.ts", import.meta.url).pathname, "utf-8");
+const agentSource = readFileSync(
+	new URL("agents/thinkspace-agent.ts", import.meta.url).pathname,
+	"utf-8",
+);
+
+test("the worker never mounts raw Project Think agent routes", () => {
+	assert.doesNotMatch(workerSource, /routeAgentRequest/u);
+	assert.doesNotMatch(workerSource, /routeAgentEmail/u);
+	assert.doesNotMatch(workerSource, /"\/(?:api\/)?agents/u);
+	assert.doesNotMatch(workerSource, /useAgentChat/u);
+});
+
+test("the worker only exposes known app-owned route prefixes", () => {
+	const mountedRoutes = [
+		...workerSource.matchAll(/app\.(?:use|on|get|post)\(\s*(?:\[[^\]]*\],\s*)?"([^"]+)"/gu),
+	].map((match) => match[1]);
+
+	assert.deepEqual(mountedRoutes, [
+		"/*",
+		"/api/auth/*",
+		"/api/rpc/*",
+		"/api/openapi/*",
+		"/",
+		"/api/health",
+	]);
+});
+
+test("the Thinkspace Agent runtime keeps direct HTTP access fail-closed", () => {
+	assert.match(agentSource, /override fetch\(/u);
+	assert.match(agentSource, /status: 404/u);
+});

--- a/packages/api/src/thinkspaces/inspect.test.ts
+++ b/packages/api/src/thinkspaces/inspect.test.ts
@@ -163,6 +163,38 @@ test("submissions recorded for a different Thinkspace map to unknown", () => {
 	assert.equal(missingContext.status, "unknown");
 });
 
+test("submissions not written by the Better Agent accept path map to unknown", () => {
+	const foreignSource = mapThinkspaceTurnInspection({
+		snapshot: createSnapshot({
+			metadata: { source: "raw-think-client", thinkspaceId: "thinkspace_inspect" },
+		}),
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+	});
+	const missingSource = mapThinkspaceTurnInspection({
+		snapshot: createSnapshot({ metadata: { thinkspaceId: "thinkspace_inspect" } }),
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+	});
+
+	assert.equal(foreignSource.status, "unknown");
+	assert.equal(foreignSource.resultText, null);
+	assert.equal(missingSource.status, "unknown");
+});
+
+test("product-safe markers cannot be unlocked from inside raw error strings", () => {
+	const embeddedMarker = extractThinkspaceTurnProductSafeFailureMessage(
+		`TypeError: fetch failed ${markThinkspaceTurnProductSafeError("sk-ant-secret leaked")}`,
+	);
+	const whitespaceOnlyMarker = extractThinkspaceTurnProductSafeFailureMessage(
+		markThinkspaceTurnProductSafeError("   "),
+	);
+
+	assert.equal(embeddedMarker.includes("sk-ant-secret"), false);
+	assert.equal(embeddedMarker, extractThinkspaceTurnProductSafeFailureMessage());
+	assert.equal(whitespaceOnlyMarker, extractThinkspaceTurnProductSafeFailureMessage());
+});
+
 test("maps runtime submission lifecycle onto product turn states", () => {
 	const accepted = mapThinkspaceTurnInspection({
 		snapshot: createSnapshot(),

--- a/packages/api/src/thinkspaces/inspect.ts
+++ b/packages/api/src/thinkspaces/inspect.ts
@@ -4,7 +4,7 @@ import type { CloudflareEnv } from "@better-agent/env/types";
 
 import { getThinkspace } from "./repository";
 import { resolveThinkspaceAgentRuntime, THINKSPACE_AGENT_BINDING_NAME } from "./runtime";
-import { ThinkspaceTurnValidationError } from "./turns";
+import { THINKSPACE_TURN_SOURCE, ThinkspaceTurnValidationError } from "./turns";
 
 export const THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH = 128;
 export const THINKSPACE_TURN_RESULT_TEXT_MAX_LENGTH = 8000;
@@ -214,7 +214,11 @@ export const mapThinkspaceTurnInspection = ({
 	submissionId: string;
 	thinkspaceId: string;
 }): ThinkspaceTurnInspection => {
-	if (!snapshot || snapshot.metadata?.thinkspaceId !== thinkspaceId) {
+	if (
+		!snapshot ||
+		snapshot.metadata?.thinkspaceId !== thinkspaceId ||
+		snapshot.metadata?.source !== THINKSPACE_TURN_SOURCE
+	) {
 		return createUnknownTurnInspection(submissionId, thinkspaceId);
 	}
 

--- a/packages/api/src/thinkspaces/router.test.ts
+++ b/packages/api/src/thinkspaces/router.test.ts
@@ -1,0 +1,308 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+import { ORPCError, call } from "@orpc/server";
+import type { AnyProcedure } from "@orpc/server";
+
+import type { Context } from "../context";
+import { thinkspacesRouter } from "./router";
+import type { ThinkspaceTurnInspection } from "./inspect";
+import type { ThinkspaceTurnAcceptance } from "./turns";
+
+const OWNED_THINKSPACE_ID = "thinkspace_router";
+
+/**
+ * A db that fails the test if any query is attempted. Used to prove that
+ * rejected requests never reach product storage.
+ */
+const untouchableDb = new Proxy({} as Record<string, unknown>, {
+	get(_target, property) {
+		throw new Error(`Product storage must not be touched (accessed ${String(property)}).`);
+	},
+}) as unknown as ProductDb;
+
+/**
+ * Minimal structural stand-in for the drizzle select chain used by the
+ * Thinkspace repository and model settings reads. Every select resolves to
+ * the configured rows.
+ */
+const createDbReturning = (rows: Record<string, unknown>[]): ProductDb =>
+	({
+		select: () => ({
+			from: () => ({
+				where: () => ({
+					limit: () => Promise.resolve(rows),
+					orderBy: () => Promise.resolve(rows),
+				}),
+			}),
+		}),
+	}) as unknown as ProductDb;
+
+const ownedThinkspaceRow = (): Record<string, unknown> => ({
+	enabledToolIds: "[]",
+	id: OWNED_THINKSPACE_ID,
+	requestedPermissions: "[]",
+	status: "active",
+});
+
+const authenticatedSession = {
+	session: { id: "session_1" },
+	user: { id: "owner_user" },
+};
+
+const createCallContext = ({
+	db,
+	env = {},
+	session = authenticatedSession,
+}: {
+	db: ProductDb;
+	env?: Record<string, unknown>;
+	session?: typeof authenticatedSession | null;
+}): Context =>
+	({
+		db,
+		env,
+		executionCtx: undefined,
+		headers: new Headers(),
+		session,
+	}) as unknown as Context;
+
+interface RuntimeOperationAttempt {
+	input: Record<string, string>;
+	name: string;
+	procedure: AnyProcedure;
+}
+
+const runtimeOperations: readonly RuntimeOperationAttempt[] = [
+	{
+		input: { thinkspaceId: OWNED_THINKSPACE_ID },
+		name: "runtimeReadiness",
+		procedure: thinkspacesRouter.runtimeReadiness,
+	},
+	{
+		input: { thinkspaceId: OWNED_THINKSPACE_ID },
+		name: "runtimePolicy",
+		procedure: thinkspacesRouter.runtimePolicy,
+	},
+	{
+		input: { thinkspaceId: OWNED_THINKSPACE_ID },
+		name: "modelReadiness",
+		procedure: thinkspacesRouter.modelReadiness,
+	},
+	{
+		input: {
+			idempotencyKey: "retry-key-1",
+			instruction: "Summarize the Thinkspace goal.",
+			thinkspaceId: OWNED_THINKSPACE_ID,
+		},
+		name: "submitTurn",
+		procedure: thinkspacesRouter.submitTurn,
+	},
+	{
+		input: { submissionId: "submission_1", thinkspaceId: OWNED_THINKSPACE_ID },
+		name: "inspectTurn",
+		procedure: thinkspacesRouter.inspectTurn,
+	},
+];
+
+const expectCode =
+	(code: string) =>
+	(error: unknown): boolean =>
+		error instanceof ORPCError && error.code === code;
+
+test("unauthenticated requests cannot reach any Thinkspace runtime operation", async () => {
+	for (const operation of runtimeOperations) {
+		await assert.rejects(
+			call(operation.procedure, operation.input, {
+				context: createCallContext({ db: untouchableDb, session: null }),
+			}),
+			expectCode("UNAUTHORIZED"),
+			`${operation.name} must reject unauthenticated requests`,
+		);
+	}
+});
+
+test("authenticated non-owners get NOT_FOUND for every runtime operation before runtime access", async () => {
+	for (const operation of runtimeOperations) {
+		await assert.rejects(
+			call(operation.procedure, operation.input, {
+				context: createCallContext({
+					db: createDbReturning([]),
+					session: { session: { id: "session_2" }, user: { id: "other_user" } },
+				}),
+			}),
+			expectCode("NOT_FOUND"),
+			`${operation.name} must hide other users' Thinkspaces`,
+		);
+	}
+});
+
+test("guessed or missing Thinkspace ids cannot resolve runtime access", async () => {
+	for (const operation of runtimeOperations) {
+		await assert.rejects(
+			call(
+				operation.procedure,
+				{ ...operation.input, thinkspaceId: "thinkspace_guessed" },
+				{ context: createCallContext({ db: createDbReturning([]) }) },
+			),
+			expectCode("NOT_FOUND"),
+			`${operation.name} must not resolve guessed Thinkspace ids`,
+		);
+	}
+});
+
+test("oversized runtime inputs are rejected at the router boundary without touching storage", async () => {
+	const oversized: { input: Record<string, string>; procedure: AnyProcedure }[] = [
+		{
+			input: {
+				idempotencyKey: "k".repeat(129),
+				instruction: "Summarize the Thinkspace goal.",
+				thinkspaceId: OWNED_THINKSPACE_ID,
+			},
+			procedure: thinkspacesRouter.submitTurn,
+		},
+		{
+			input: {
+				idempotencyKey: "retry-key-1",
+				instruction: "x".repeat(4001),
+				thinkspaceId: OWNED_THINKSPACE_ID,
+			},
+			procedure: thinkspacesRouter.submitTurn,
+		},
+		{
+			input: { submissionId: "s".repeat(129), thinkspaceId: OWNED_THINKSPACE_ID },
+			procedure: thinkspacesRouter.inspectTurn,
+		},
+	];
+
+	for (const attempt of oversized) {
+		await assert.rejects(
+			call(attempt.procedure, attempt.input, {
+				context: createCallContext({ db: untouchableDb }),
+			}),
+			expectCode("BAD_REQUEST"),
+		);
+	}
+});
+
+test("runtime resolution failures never expose binding details to the product surface", async () => {
+	const operations: { input: Record<string, string>; procedure: AnyProcedure }[] = [
+		{
+			input: { thinkspaceId: OWNED_THINKSPACE_ID },
+			procedure: thinkspacesRouter.runtimeReadiness,
+		},
+		{
+			input: { submissionId: "submission_1", thinkspaceId: OWNED_THINKSPACE_ID },
+			procedure: thinkspacesRouter.inspectTurn,
+		},
+	];
+
+	for (const operation of operations) {
+		await assert.rejects(
+			call(operation.procedure, operation.input, {
+				context: createCallContext({ db: createDbReturning([ownedThinkspaceRow()]) }),
+			}),
+			(error: unknown) => {
+				assert.ok(error instanceof ORPCError);
+				assert.equal(error.code, "INTERNAL_SERVER_ERROR");
+				assert.doesNotMatch(error.message, /binding/iu);
+				assert.doesNotMatch(error.message, /THINKSPACE_AGENT/u);
+				assert.doesNotMatch(error.message, /durable/iu);
+				return true;
+			},
+		);
+	}
+});
+
+test("missing model credentials fail closed with a product-safe error before runtime acceptance", async () => {
+	await assert.rejects(
+		call(
+			thinkspacesRouter.submitTurn,
+			{
+				idempotencyKey: "retry-key-1",
+				instruction: "Summarize the Thinkspace goal.",
+				thinkspaceId: OWNED_THINKSPACE_ID,
+			},
+			{ context: createCallContext({ db: createDbReturning([ownedThinkspaceRow()]) }) },
+		),
+		(error: unknown) => {
+			assert.ok(error instanceof ORPCError);
+			assert.equal(error.code, "BAD_REQUEST");
+			assert.doesNotMatch(error.message, /API_KEY/u);
+			assert.doesNotMatch(error.message, /sk-/u);
+			assert.doesNotMatch(error.message, /binding/iu);
+			return true;
+		},
+	);
+});
+
+test("owners can still submit and inspect turns through the router with the Thinkspace runtime identity", async () => {
+	const runtimeNames: string[] = [];
+	const acceptance: ThinkspaceTurnAcceptance = {
+		acceptedAt: 1_717_000_000_000,
+		deduplicated: false,
+		idempotencyKey: "retry-key-1",
+		status: "accepted",
+		submissionId: "submission_1",
+		thinkspaceId: OWNED_THINKSPACE_ID,
+	};
+	const inspection: ThinkspaceTurnInspection = {
+		acceptedAt: 1_717_000_000_000,
+		completedAt: null,
+		message: "Accepted. This Thinkspace Agent turn is waiting for the runtime to start it.",
+		resultText: null,
+		startedAt: null,
+		status: "accepted",
+		submissionId: "submission_1",
+		thinkspaceId: OWNED_THINKSPACE_ID,
+	};
+	const env = {
+		GOOGLE_GENERATIVE_AI_API_KEY: "test-google-key",
+		THINKSPACE_AGENT: {
+			get: () => ({
+				acceptTurnSubmission: () => Promise.resolve(acceptance),
+				inspectTurnSubmission: () => Promise.resolve(inspection),
+			}),
+			idFromName: (name: string) => {
+				runtimeNames.push(name);
+				return { toString: () => `durable-object-id:${name}` };
+			},
+		},
+	};
+	const context = createCallContext({ db: createDbReturning([ownedThinkspaceRow()]), env });
+
+	const submitted = await call(
+		thinkspacesRouter.submitTurn,
+		{
+			idempotencyKey: "retry-key-1",
+			instruction: "Summarize the Thinkspace goal.",
+			thinkspaceId: OWNED_THINKSPACE_ID,
+		},
+		{ context },
+	);
+	const inspected = await call(
+		thinkspacesRouter.inspectTurn,
+		{ submissionId: "submission_1", thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context },
+	);
+
+	assert.equal(submitted.status, "accepted");
+	assert.equal(submitted.submissionId, "submission_1");
+	assert.equal(inspected.status, "accepted");
+	assert.ok(runtimeNames.every((name) => name === OWNED_THINKSPACE_ID));
+});
+
+test("Thinkspace control-plane reads still work for owners", async () => {
+	const context = createCallContext({ db: createDbReturning([ownedThinkspaceRow()]) });
+
+	const thinkspace = await call(
+		thinkspacesRouter.get,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context },
+	);
+	const listed = await call(thinkspacesRouter.list, undefined, { context });
+
+	assert.equal(thinkspace.id, OWNED_THINKSPACE_ID);
+	assert.equal(listed.length, 1);
+});

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -70,9 +70,20 @@ const submitTurnInput = z.object({
 
 const createThinkspaceId = (): string => `thinkspace_${crypto.randomUUID()}`;
 
+/**
+ * Runtime resolution failures (missing/misconfigured Durable Object binding)
+ * are infrastructure details. The product surface only learns that the
+ * runtime is unavailable, never which binding or runtime internals failed.
+ */
+const RUNTIME_UNAVAILABLE_MESSAGE =
+	"The Thinkspace Agent runtime is not available right now. Try again shortly.";
+
 const toBadRequest = (
 	error: ThinkspaceLifecycleValidationError,
 ): ORPCError<"BAD_REQUEST", undefined> => new ORPCError("BAD_REQUEST", { message: error.message });
+
+const toRuntimeUnavailable = (): ORPCError<"INTERNAL_SERVER_ERROR", undefined> =>
+	new ORPCError("INTERNAL_SERVER_ERROR", { message: RUNTIME_UNAVAILABLE_MESSAGE });
 
 const toNotFound = (): ORPCError<"NOT_FOUND", undefined> =>
 	new ORPCError("NOT_FOUND", { message: "Thinkspace was not found." });
@@ -160,7 +171,7 @@ export const thinkspacesRouter = {
 			}
 
 			if (error instanceof ThinkspaceRuntimeResolutionError) {
-				throw new ORPCError("INTERNAL_SERVER_ERROR", { message: error.message });
+				throw toRuntimeUnavailable();
 			}
 
 			throw error;
@@ -217,7 +228,7 @@ export const thinkspacesRouter = {
 				return readiness;
 			} catch (error) {
 				if (error instanceof ThinkspaceRuntimeResolutionError) {
-					throw new ORPCError("INTERNAL_SERVER_ERROR", { message: error.message });
+					throw toRuntimeUnavailable();
 				}
 
 				throw error;
@@ -249,7 +260,7 @@ export const thinkspacesRouter = {
 			}
 
 			if (error instanceof ThinkspaceRuntimeResolutionError) {
-				throw new ORPCError("INTERNAL_SERVER_ERROR", { message: error.message });
+				throw toRuntimeUnavailable();
 			}
 
 			throw error;

--- a/packages/api/src/thinkspaces/turn-context.test.ts
+++ b/packages/api/src/thinkspaces/turn-context.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { extractThinkspaceTurnProductSafeFailureMessage } from "./inspect";
+import {
+	bindThinkspaceTurnRuntimeContext,
+	matchesThinkspaceTurnRuntimeContext,
+} from "./turn-context";
+
+test("a runtime binds to the first Thinkspace context it accepts", () => {
+	const bound = bindThinkspaceTurnRuntimeContext({
+		request: { ownerUserId: "owner_user", thinkspaceId: "thinkspace_context" },
+	});
+
+	assert.deepEqual(bound, { ownerUserId: "owner_user", thinkspaceId: "thinkspace_context" });
+});
+
+test("re-accepting work for the same Thinkspace refreshes the bound context", () => {
+	const bound = bindThinkspaceTurnRuntimeContext({
+		existing: { ownerUserId: "owner_user", thinkspaceId: "thinkspace_context" },
+		request: { ownerUserId: "owner_user", thinkspaceId: "thinkspace_context" },
+	});
+
+	assert.deepEqual(bound, { ownerUserId: "owner_user", thinkspaceId: "thinkspace_context" });
+});
+
+test("a runtime already bound to one Thinkspace rejects work for another with a product-safe error", () => {
+	let thrown: unknown;
+
+	try {
+		bindThinkspaceTurnRuntimeContext({
+			existing: { ownerUserId: "owner_user", thinkspaceId: "thinkspace_context" },
+			request: { ownerUserId: "attacker_user", thinkspaceId: "thinkspace_other" },
+		});
+	} catch (error) {
+		thrown = error;
+	}
+
+	assert.ok(thrown instanceof Error);
+	const productSafe = extractThinkspaceTurnProductSafeFailureMessage(thrown.message);
+	assert.match(productSafe, /different Thinkspace/u);
+	assert.doesNotMatch(productSafe, /thinkspace_other/u);
+	assert.doesNotMatch(productSafe, /attacker_user/u);
+});
+
+test("inspection only matches the runtime context bound to the same Thinkspace", () => {
+	const context = { ownerUserId: "owner_user", thinkspaceId: "thinkspace_context" };
+
+	assert.equal(matchesThinkspaceTurnRuntimeContext(context, "thinkspace_context"), true);
+	assert.equal(matchesThinkspaceTurnRuntimeContext(context, "thinkspace_other"), false);
+	assert.equal(matchesThinkspaceTurnRuntimeContext(undefined, "thinkspace_context"), false);
+});

--- a/packages/api/src/thinkspaces/turn-context.ts
+++ b/packages/api/src/thinkspaces/turn-context.ts
@@ -1,0 +1,43 @@
+import { markThinkspaceTurnProductSafeError } from "./inspect";
+
+/**
+ * The Thinkspace context a Thinkspace Agent runtime instance is bound to.
+ * Runtime identity is the Thinkspace id, so one Durable Object instance must
+ * only ever hold work for one Thinkspace. The worker's owner gate is the
+ * authority; this context is defense-in-depth at the runtime boundary.
+ */
+export interface ThinkspaceTurnRuntimeContext {
+	ownerUserId: string;
+	thinkspaceId: string;
+}
+
+const RUNTIME_CONTEXT_MISMATCH_MESSAGE =
+	"This Thinkspace Agent runtime cannot accept work for a different Thinkspace.";
+
+/**
+ * Binds (or re-binds) a runtime instance to its Thinkspace context. A runtime
+ * already bound to one Thinkspace fails closed when asked to accept work for
+ * another, with a product-safe marked error so no identifiers leak.
+ */
+export const bindThinkspaceTurnRuntimeContext = ({
+	existing,
+	request,
+}: {
+	existing?: ThinkspaceTurnRuntimeContext;
+	request: ThinkspaceTurnRuntimeContext;
+}): ThinkspaceTurnRuntimeContext => {
+	if (existing && existing.thinkspaceId !== request.thinkspaceId) {
+		throw new Error(markThinkspaceTurnProductSafeError(RUNTIME_CONTEXT_MISMATCH_MESSAGE));
+	}
+
+	return { ownerUserId: request.ownerUserId, thinkspaceId: request.thinkspaceId };
+};
+
+/**
+ * Fail-closed inspection guard: a stored runtime context only matches the
+ * Thinkspace it was bound to. A runtime with no bound context matches nothing.
+ */
+export const matchesThinkspaceTurnRuntimeContext = (
+	context: ThinkspaceTurnRuntimeContext | undefined,
+	thinkspaceId: string,
+): boolean => context?.thinkspaceId === thinkspaceId;

--- a/packages/api/src/thinkspaces/turns.test.ts
+++ b/packages/api/src/thinkspaces/turns.test.ts
@@ -9,6 +9,7 @@ import type { ThinkspaceModelReadiness } from "../models/readiness";
 import { ThinkspaceRuntimeResolutionError } from "./runtime";
 import {
 	submitOwnedThinkspaceTurn,
+	THINKSPACE_TURN_IDEMPOTENCY_KEY_MAX_LENGTH,
 	THINKSPACE_TURN_INSTRUCTION_MAX_LENGTH,
 	ThinkspaceTurnValidationError,
 	validateThinkspaceTurnIdempotencyKey,
@@ -151,6 +152,63 @@ test("repeated submission with the same idempotency key returns the same handle 
 	assert.equal(retry?.deduplicated, true);
 	assert.equal(first?.submissionId, retry?.submissionId);
 	assert.equal(acceptedKeys.size, 1);
+});
+
+test("whitespace-padded idempotency keys dedupe to the same accepted submission", async () => {
+	const acceptedKeys = new Map<string, ThinkspaceTurnAcceptance>();
+	const submit = (idempotencyKey: string) =>
+		submitOwnedThinkspaceTurn({
+			acceptTurnSubmission: ({ request }) => {
+				const existing = acceptedKeys.get(request.idempotencyKey);
+				if (existing) {
+					return Promise.resolve({ ...existing, deduplicated: true });
+				}
+				const handle = acceptedHandle(request.idempotencyKey);
+				acceptedKeys.set(request.idempotencyKey, handle);
+				return Promise.resolve(handle);
+			},
+			checkModelReadiness: () => Promise.resolve(readyReadiness),
+			db,
+			env: createEnv(),
+			getThinkspaceByOwner: () => Promise.resolve(createOwnedThinkspace()),
+			getUserSettings: () => Promise.resolve(null),
+			idempotencyKey,
+			instruction: "Summarize the Thinkspace goal.",
+			ownerUserId: "owner_user",
+			thinkspaceId: "thinkspace_turns",
+		});
+
+	const first = await submit("retry-key-1");
+	const padded = await submit("  retry-key-1  ");
+
+	assert.equal(first?.deduplicated, false);
+	assert.equal(padded?.deduplicated, true);
+	assert.equal(first?.submissionId, padded?.submissionId);
+	assert.equal(acceptedKeys.size, 1);
+});
+
+test("idempotency keys at the documented bound are accepted and forwarded intact", async () => {
+	const boundaryKey = "k".repeat(THINKSPACE_TURN_IDEMPOTENCY_KEY_MAX_LENGTH);
+	const forwardedKeys: string[] = [];
+
+	const acceptance = await submitOwnedThinkspaceTurn({
+		acceptTurnSubmission: ({ request }) => {
+			forwardedKeys.push(request.idempotencyKey);
+			return Promise.resolve(acceptedHandle(request.idempotencyKey));
+		},
+		checkModelReadiness: () => Promise.resolve(readyReadiness),
+		db,
+		env: createEnv(),
+		getThinkspaceByOwner: () => Promise.resolve(createOwnedThinkspace()),
+		getUserSettings: () => Promise.resolve(null),
+		idempotencyKey: boundaryKey,
+		instruction: "Summarize the Thinkspace goal.",
+		ownerUserId: "owner_user",
+		thinkspaceId: "thinkspace_turns",
+	});
+
+	assert.equal(acceptance?.status, "accepted");
+	assert.deepEqual(forwardedKeys, [boundaryKey]);
 });
 
 test("non-owners cannot submit runtime work to another user's Thinkspace", async () => {


### PR DESCRIPTION
Closes #36

## Summary

Adversarial hardening pass for the first Thinkspace Agent runtime boundary: new attack-path tests at the oRPC router seam, the pure inspection/turn seams, and the worker source, plus four small fail-closed fixes at the product boundary.

## Criteria-mapped changes

- **Unauthenticated access blocked**: `packages/api/src/thinkspaces/router.test.ts` calls `runtimeReadiness`, `runtimePolicy`, `modelReadiness`, `submitTurn`, and `inspectTurn` through the real router with no session and proves `UNAUTHORIZED` before product storage is ever touched (db is a throwing proxy).
- **Non-owner access blocked**: router tests prove every runtime operation returns `NOT_FOUND` for another user's Thinkspace, with no runtime binding configured — proving the ownership gate precedes runtime resolution.
- **Guessed/missing Thinkspace ids**: same five operations return `NOT_FOUND` for unknown ids; oversized instruction/idempotency-key/submission-handle inputs are rejected at the router boundary without touching storage.
- **Raw Project Think routes absent/private/gated**:
  - `apps/server/src/worker-routes.test.ts` guards that the worker never mounts `routeAgentRequest`/`/agents` routes and only exposes the known app-owned prefixes.
  - `ThinkspaceAgent` now overrides `fetch` to fail closed (404). Project Think serves unauthenticated HTTP (e.g. `/get-messages` returns all runtime messages) whenever a request reaches the Durable Object; the only supported entry points are the owner-gated worker RPCs.
- **Archived Thinkspaces**: existing seam test (`archived Thinkspaces reject new turns`) still covers the block; CRUD-path archived gating unchanged.
- **Idempotency edge cases**: new seam tests prove whitespace-padded keys dedupe to the same accepted submission and boundary-length (128) keys are forwarded intact.
- **Missing credentials fail closed**: router-level test proves `submitTurn` fails `BAD_REQUEST` with a product-safe message (no `API_KEY`, key material, or binding details) before runtime acceptance when no provider credential is configured.
- **No leaked internals**:
  - Router now maps `ThinkspaceRuntimeResolutionError` to a generic "runtime is not available" message instead of echoing the internal binding error (tested: response mentions no binding/Durable Object details).
  - Inspection gate tightened: a submission is only known if its metadata carries both the matching `thinkspaceId` **and** `source: "better-agent"` — raw Think-written submissions map to `unknown`.
  - New tests prove product-safe markers cannot be unlocked from inside raw error strings.
  - New `turn-context` seam (`packages/api/src/thinkspaces/turn-context.ts`): a Durable Object instance binds to the first Thinkspace context it accepts; mismatched accept attempts throw a marker-wrapped product-safe error, and mismatched inspects map to `unknown` before any submission/message read. Wired into `acceptTurnSubmission`/`inspectTurnSubmission` as defense-in-depth behind the worker's owner gate.
- **Control plane still works**: router tests cover owner submit/inspect end-to-end through the real router glue (stable runtime identity asserted) plus `get`/`list` reads; full suite green.

## Verification

- `bun test packages/api/src/thinkspaces/inspect.test.ts packages/api/src/thinkspaces/turns.test.ts packages/api/src/thinkspaces/router.test.ts packages/api/src/thinkspaces/turn-context.test.ts packages/api/src/models/readiness.test.ts packages/api/src/models/resolver.test.ts packages/api/src/thinkspaces/runtime.test.ts packages/api/src/thinkspaces/runtime-policy.test.ts packages/api/src/thinkspaces/lifecycle.test.ts packages/api/src/thinkspaces/policy.test.ts packages/api/src/mcp/url-policy.test.ts apps/server/src/worker-routes.test.ts` — 79 pass (was 60)
- `bun run check-types` — clean
- `bun run build` — clean (pre-existing Vite chunk-size warning only)
- `bun x ultracite fix` — clean; tests and typecheck re-run after