### PR TITLE
Back the Model Catalog read surface with models.dev

### DIFF
--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -2,6 +2,8 @@ import { createAuth } from "@better-agent/auth";
 import { createDb } from "@better-agent/db";
 import type { CloudflareEnv } from "@better-agent/env/types";
 
+import { createProductModelCatalog } from "./models/models-dev";
+
 export type ControlPlaneEnv = CloudflareEnv;
 
 export interface CreateContextOptions {
@@ -21,6 +23,7 @@ export const createContext = async ({ env, executionCtx, headers }: CreateContex
 		env,
 		executionCtx,
 		headers,
+		modelCatalog: createProductModelCatalog(env),
 		session,
 	};
 };

--- a/packages/api/src/models/fixtures/models-dev-api.json
+++ b/packages/api/src/models/fixtures/models-dev-api.json
@@ -1,0 +1,398 @@
+{
+	"anthropic": {
+		"id": "anthropic",
+		"env": [
+			"ANTHROPIC_API_KEY"
+		],
+		"npm": "@ai-sdk/anthropic",
+		"name": "Anthropic",
+		"doc": "https://docs.anthropic.com/en/docs/about-claude/models",
+		"models": {
+			"claude-sonnet-4-5-20250929": {
+				"id": "claude-sonnet-4-5-20250929",
+				"name": "Claude Sonnet 4.5",
+				"family": "claude-sonnet",
+				"attachment": true,
+				"reasoning": true,
+				"reasoning_options": [
+					{
+						"type": "budget_tokens",
+						"min": 1024
+					}
+				],
+				"tool_call": true,
+				"temperature": true,
+				"knowledge": "2025-07-31",
+				"release_date": "2025-09-29",
+				"last_updated": "2025-09-29",
+				"modalities": {
+					"input": [
+						"text",
+						"image",
+						"pdf"
+					],
+					"output": [
+						"text"
+					]
+				},
+				"open_weights": false,
+				"limit": {
+					"context": 200000,
+					"output": 64000
+				},
+				"cost": {
+					"input": 3,
+					"output": 15,
+					"cache_read": 0.3,
+					"cache_write": 3.75
+				}
+			},
+			"claude-3-opus-20240229": {
+				"id": "claude-3-opus-20240229",
+				"name": "Claude Opus 3",
+				"family": "claude-opus",
+				"attachment": true,
+				"reasoning": false,
+				"tool_call": true,
+				"temperature": true,
+				"knowledge": "2023-08-31",
+				"release_date": "2024-02-29",
+				"last_updated": "2024-02-29",
+				"modalities": {
+					"input": [
+						"text",
+						"image",
+						"pdf"
+					],
+					"output": [
+						"text"
+					]
+				},
+				"open_weights": false,
+				"limit": {
+					"context": 200000,
+					"output": 4096
+				},
+				"status": "deprecated",
+				"cost": {
+					"input": 15,
+					"output": 75,
+					"cache_read": 1.5,
+					"cache_write": 18.75
+				}
+			}
+		}
+	},
+	"google": {
+		"id": "google",
+		"env": [
+			"GOOGLE_API_KEY",
+			"GOOGLE_GENERATIVE_AI_API_KEY",
+			"GEMINI_API_KEY"
+		],
+		"npm": "@ai-sdk/google",
+		"name": "Google",
+		"doc": "https://ai.google.dev/gemini-api/docs/models",
+		"models": {
+			"gemini-2.5-flash-lite": {
+				"id": "gemini-2.5-flash-lite",
+				"name": "Gemini 2.5 Flash-Lite",
+				"family": "gemini-flash-lite",
+				"attachment": true,
+				"reasoning": true,
+				"reasoning_options": [
+					{
+						"type": "toggle"
+					},
+					{
+						"type": "budget_tokens",
+						"min": 512,
+						"max": 24576
+					}
+				],
+				"tool_call": true,
+				"structured_output": true,
+				"temperature": true,
+				"knowledge": "2025-01",
+				"release_date": "2025-06-17",
+				"last_updated": "2025-06-17",
+				"modalities": {
+					"input": [
+						"text",
+						"image",
+						"audio",
+						"video",
+						"pdf"
+					],
+					"output": [
+						"text"
+					]
+				},
+				"open_weights": false,
+				"limit": {
+					"context": 1048576,
+					"output": 65536
+				},
+				"cost": {
+					"input": 0.1,
+					"output": 0.4,
+					"cache_read": 0.01,
+					"input_audio": 0.3
+				}
+			},
+			"gemini-2.5-pro": {
+				"id": "gemini-2.5-pro",
+				"name": "Gemini 2.5 Pro",
+				"family": "gemini-pro",
+				"attachment": true,
+				"reasoning": true,
+				"reasoning_options": [
+					{
+						"type": "budget_tokens",
+						"min": 128,
+						"max": 32768
+					}
+				],
+				"tool_call": true,
+				"structured_output": true,
+				"temperature": true,
+				"knowledge": "2025-01",
+				"release_date": "2025-03-20",
+				"last_updated": "2025-06-05",
+				"modalities": {
+					"input": [
+						"text",
+						"image",
+						"audio",
+						"video",
+						"pdf"
+					],
+					"output": [
+						"text"
+					]
+				},
+				"open_weights": false,
+				"limit": {
+					"context": 1048576,
+					"output": 65536
+				},
+				"cost": {
+					"input": 1.25,
+					"output": 10,
+					"cache_read": 0.125,
+					"tiers": [
+						{
+							"input": 2.5,
+							"output": 15,
+							"cache_read": 0.25,
+							"tier": {
+								"type": "context",
+								"size": 200000
+							}
+						}
+					],
+					"context_over_200k": {
+						"input": 2.5,
+						"output": 15,
+						"cache_read": 0.25
+					}
+				}
+			},
+			"gemini-2.0-flash": {
+				"id": "gemini-2.0-flash",
+				"name": "Gemini 2.0 Flash",
+				"family": "gemini-flash",
+				"attachment": true,
+				"reasoning": false,
+				"tool_call": true,
+				"structured_output": true,
+				"temperature": true,
+				"knowledge": "2024-06",
+				"release_date": "2024-12-11",
+				"last_updated": "2024-12-11",
+				"modalities": {
+					"input": [
+						"text",
+						"image",
+						"audio",
+						"video",
+						"pdf"
+					],
+					"output": [
+						"text"
+					]
+				},
+				"open_weights": false,
+				"limit": {
+					"context": 1048576,
+					"output": 8192
+				},
+				"status": "deprecated",
+				"cost": {
+					"input": 0.1,
+					"output": 0.4,
+					"cache_read": 0.025
+				}
+			}
+		}
+	},
+	"mistral": {
+		"id": "mistral",
+		"env": [
+			"MISTRAL_API_KEY"
+		],
+		"npm": "@ai-sdk/mistral",
+		"name": "Mistral",
+		"doc": "https://docs.mistral.ai/getting-started/models/",
+		"models": {
+			"mistral-large-2411": {
+				"id": "mistral-large-2411",
+				"name": "Mistral Large 2.1",
+				"family": "mistral-large",
+				"attachment": false,
+				"reasoning": false,
+				"tool_call": true,
+				"temperature": true,
+				"knowledge": "2024-11",
+				"release_date": "2024-11-01",
+				"last_updated": "2024-11-04",
+				"modalities": {
+					"input": [
+						"text"
+					],
+					"output": [
+						"text"
+					]
+				},
+				"open_weights": true,
+				"limit": {
+					"context": 131072,
+					"output": 16384
+				},
+				"cost": {
+					"input": 2,
+					"output": 6
+				}
+			}
+		}
+	},
+	"openai": {
+		"id": "openai",
+		"env": [
+			"OPENAI_API_KEY"
+		],
+		"npm": "@ai-sdk/openai",
+		"name": "OpenAI",
+		"doc": "https://platform.openai.com/docs/models",
+		"models": {
+			"gpt-4.1": {
+				"id": "gpt-4.1",
+				"name": "GPT-4.1",
+				"family": "gpt",
+				"attachment": true,
+				"reasoning": false,
+				"tool_call": true,
+				"structured_output": true,
+				"temperature": true,
+				"knowledge": "2024-04",
+				"release_date": "2025-04-14",
+				"last_updated": "2025-04-14",
+				"modalities": {
+					"input": [
+						"text",
+						"image",
+						"pdf"
+					],
+					"output": [
+						"text"
+					]
+				},
+				"open_weights": false,
+				"limit": {
+					"context": 1047576,
+					"output": 32768
+				},
+				"cost": {
+					"input": 2,
+					"output": 8,
+					"cache_read": 0.5
+				}
+			},
+			"o4-mini": {
+				"id": "o4-mini",
+				"name": "o4-mini",
+				"family": "o-mini",
+				"attachment": true,
+				"reasoning": true,
+				"reasoning_options": [
+					{
+						"type": "effort",
+						"values": [
+							"low",
+							"medium",
+							"high"
+						]
+					}
+				],
+				"tool_call": true,
+				"structured_output": true,
+				"temperature": false,
+				"knowledge": "2024-05",
+				"release_date": "2025-04-16",
+				"last_updated": "2025-04-16",
+				"modalities": {
+					"input": [
+						"text",
+						"image"
+					],
+					"output": [
+						"text"
+					]
+				},
+				"open_weights": false,
+				"limit": {
+					"context": 200000,
+					"output": 100000
+				},
+				"cost": {
+					"input": 1.1,
+					"output": 4.4,
+					"cache_read": 0.275
+				}
+			},
+			"gpt-4o-mini": {
+				"id": "gpt-4o-mini",
+				"name": "GPT-4o mini",
+				"family": "gpt-mini",
+				"attachment": true,
+				"reasoning": false,
+				"tool_call": true,
+				"structured_output": true,
+				"temperature": true,
+				"knowledge": "2023-09",
+				"release_date": "2024-07-18",
+				"last_updated": "2024-07-18",
+				"modalities": {
+					"input": [
+						"text",
+						"image",
+						"pdf"
+					],
+					"output": [
+						"text"
+					]
+				},
+				"open_weights": false,
+				"limit": {
+					"context": 128000,
+					"output": 16384
+				},
+				"cost": {
+					"input": 0.15,
+					"output": 0.6,
+					"cache_read": 0.075
+				}
+			}
+		}
+	}
+}

--- a/packages/api/src/models/model-catalog.ts
+++ b/packages/api/src/models/model-catalog.ts
@@ -59,26 +59,6 @@ export const createMemoryModelCatalog = (entries: ModelCatalogEntry[]): ModelCat
 	sourceId: "static_reviewed",
 });
 
-const MODELS_DEV_NOT_IMPLEMENTED_MESSAGE =
-	"The models.dev model catalog adapter is not implemented yet.";
-
-/**
- * Future production adapter that keeps the catalog current from the
- * models.dev API. Architecture slot only: every method fails with a typed
- * ModelCatalogError until the behavior slice implements it.
- */
-export const createModelsDevModelCatalog = (): ModelCatalog => ({
-	getModel: () =>
-		Promise.reject(
-			new ModelCatalogError("catalog_unavailable", MODELS_DEV_NOT_IMPLEMENTED_MESSAGE),
-		),
-	listModels: () =>
-		Promise.reject(
-			new ModelCatalogError("catalog_unavailable", MODELS_DEV_NOT_IMPLEMENTED_MESSAGE),
-		),
-	sourceId: "models_dev",
-});
-
 /**
  * Edge validator: narrows a raw string to a CatalogModelId by looking it up
  * in the given catalog, or throws a typed ModelCatalogError.

--- a/packages/api/src/models/models-dev.test.ts
+++ b/packages/api/src/models/models-dev.test.ts
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { getModelCatalog } from "./catalog";
+import { createMemoryModelCatalog, ModelCatalogError } from "./model-catalog";
+import type { ModelCatalog } from "./model-catalog";
+import {
+	createModelsDevModelCatalog,
+	MODEL_CATALOG_CACHE_KEY,
+	MODEL_CATALOG_CACHE_TTL_SECONDS,
+} from "./models-dev";
+import type { ModelCatalogCache } from "./models-dev";
+
+const FIXTURE_TIME = Date.parse("2026-06-10T12:00:00Z");
+
+const FIXTURE_PATH = path.join(import.meta.dirname, "fixtures/models-dev-api.json");
+
+const loadRecordedPayload = async (): Promise<unknown> =>
+	JSON.parse(await readFile(FIXTURE_PATH, "utf-8"));
+
+interface MemoryCache extends ModelCatalogCache {
+	puts: { expirationTtl?: number; key: string; value: string }[];
+}
+
+const createMemoryCache = (): MemoryCache => {
+	const store = new Map<string, string>();
+	const puts: MemoryCache["puts"] = [];
+
+	return {
+		get: (key) => Promise.resolve(store.get(key) ?? null),
+		put: (key, value, options) => {
+			store.set(key, value);
+			puts.push({ expirationTtl: options?.expirationTtl, key, value });
+			return Promise.resolve();
+		},
+		puts,
+	};
+};
+
+const failingCatalog: ModelCatalog = {
+	getModel: () => Promise.reject(new Error("fallback unavailable")),
+	listModels: () => Promise.reject(new Error("fallback unavailable")),
+	sourceId: "static_reviewed",
+};
+
+const createRecordedCatalog = async ({
+	cache,
+	fallbackCatalog,
+}: { cache?: ModelCatalogCache; fallbackCatalog?: ModelCatalog } = {}) => {
+	const payload = await loadRecordedPayload();
+	let fetchCount = 0;
+
+	const catalog = createModelsDevModelCatalog({
+		cache,
+		fallbackCatalog,
+		fetchCatalogPayload: () => {
+			fetchCount += 1;
+			return Promise.resolve(payload);
+		},
+		now: () => FIXTURE_TIME,
+	});
+
+	return { catalog, fetchCount: () => fetchCount };
+};
+
+test("maps the recorded models.dev payload into catalog entries", async () => {
+	const { catalog } = await createRecordedCatalog();
+	const entries = await catalog.listModels();
+
+	const flashLite = entries.find((entry) => entry.id === "google:gemini-2.5-flash-lite");
+	assert.ok(flashLite);
+	assert.equal(flashLite.name, "Gemini 2.5 Flash-Lite");
+	assert.equal(flashLite.providerId, "google");
+	assert.equal(flashLite.providerName, "Google");
+	assert.equal(flashLite.reasoning, "google_thinking_config");
+	assert.equal(flashLite.contextWindow, 1_048_576);
+	assert.equal(flashLite.maxOutputTokens, 65_536);
+	assert.deepEqual(flashLite.costPer1MTokens, { input: 0.1, output: 0.4 });
+	assert.deepEqual(flashLite.capabilities, [
+		"text",
+		"tools",
+		"images",
+		"audio",
+		"video",
+		"pdf",
+		"reasoning",
+	]);
+
+	const o4Mini = entries.find((entry) => entry.id === "openai:o4-mini");
+	assert.equal(o4Mini?.reasoning, "openai_reasoning_effort");
+
+	const sonnet = entries.find((entry) => entry.id === "anthropic:claude-sonnet-4-5-20250929");
+	assert.equal(sonnet?.reasoning, "anthropic_thinking");
+
+	const gpt41 = entries.find((entry) => entry.id === "openai:gpt-4.1");
+	assert.equal(gpt41?.reasoning, "none");
+});
+
+test("drops unsupported providers and deprecated models", async () => {
+	const { catalog } = await createRecordedCatalog();
+	const entries = await catalog.listModels();
+	const ids = entries.map((entry) => entry.id);
+
+	assert.ok(ids.every((id) => !id.startsWith("mistral:")));
+	assert.ok(!ids.includes("anthropic:claude-3-opus-20240229"));
+	assert.ok(!ids.includes("google:gemini-2.0-flash"));
+	assert.deepEqual(ids, [...ids].toSorted());
+});
+
+test("drops alpha models", async () => {
+	const catalog = createModelsDevModelCatalog({
+		fetchCatalogPayload: () =>
+			Promise.resolve({
+				openai: {
+					id: "openai",
+					models: {
+						"gpt-alpha": {
+							id: "gpt-alpha",
+							limit: { context: 1000, output: 100 },
+							name: "GPT Alpha",
+							reasoning: false,
+							status: "alpha",
+							tool_call: true,
+						},
+						"gpt-stable": {
+							id: "gpt-stable",
+							limit: { context: 1000, output: 100 },
+							name: "GPT Stable",
+							reasoning: false,
+							tool_call: true,
+						},
+					},
+					name: "OpenAI",
+				},
+			}),
+		now: () => FIXTURE_TIME,
+	});
+
+	const entries = await catalog.listModels();
+	assert.deepEqual(
+		entries.map((entry) => entry.id),
+		["openai:gpt-stable"],
+	);
+});
+
+test("serves from the KV cache within the TTL window without refetching", async () => {
+	const cache = createMemoryCache();
+	const { catalog, fetchCount } = await createRecordedCatalog({ cache });
+
+	const first = await catalog.listModels();
+	const second = await catalog.listModels();
+	const model = await catalog.getModel("google:gemini-2.5-flash-lite");
+
+	assert.equal(fetchCount(), 1);
+	assert.deepEqual(second, first);
+	assert.ok(model);
+	assert.equal(cache.puts.length, 1);
+	assert.equal(cache.puts[0]?.key, MODEL_CATALOG_CACHE_KEY);
+	assert.equal(cache.puts[0]?.expirationTtl, MODEL_CATALOG_CACHE_TTL_SECONDS);
+});
+
+test("a second adapter instance reads the shared KV cache instead of fetching", async () => {
+	const cache = createMemoryCache();
+	const { catalog, fetchCount } = await createRecordedCatalog({ cache });
+	await catalog.listModels();
+
+	const second = createModelsDevModelCatalog({
+		cache,
+		fetchCatalogPayload: () => Promise.reject(new Error("must not fetch within TTL")),
+		now: () => FIXTURE_TIME,
+	});
+
+	const entries = await second.listModels();
+	assert.equal(fetchCount(), 1);
+	assert.ok(entries.length > 0);
+	assert.equal(second.sourceId, "models_dev");
+});
+
+test("falls back to the reviewed static catalog when the fetch fails", async () => {
+	const cache = createMemoryCache();
+	const catalog = createModelsDevModelCatalog({
+		cache,
+		fetchCatalogPayload: () => Promise.reject(new Error("network down")),
+		now: () => FIXTURE_TIME,
+	});
+
+	const entries = await catalog.listModels();
+	assert.deepEqual(entries, getModelCatalog());
+	assert.equal(cache.puts.length, 0);
+});
+
+test("falls back to the reviewed static catalog when the payload does not validate", async () => {
+	const catalog = createModelsDevModelCatalog({
+		fetchCatalogPayload: () => Promise.resolve({ openai: "not-a-provider" }),
+		now: () => FIXTURE_TIME,
+	});
+
+	const entries = await catalog.listModels();
+	assert.deepEqual(entries, getModelCatalog());
+});
+
+test("surfaces a typed ModelCatalogError only when both sources are unavailable", async () => {
+	const catalog = createModelsDevModelCatalog({
+		fallbackCatalog: failingCatalog,
+		fetchCatalogPayload: () => Promise.reject(new Error("network down")),
+		now: () => FIXTURE_TIME,
+	});
+
+	await assert.rejects(catalog.listModels(), (error: unknown) => {
+		assert.ok(error instanceof ModelCatalogError);
+		assert.equal(error.kind, "catalog_unavailable");
+		return true;
+	});
+});
+
+test("getModel resolves known ids and returns null for unknown ids", async () => {
+	const { catalog } = await createRecordedCatalog();
+
+	const known = await catalog.getModel("openai:gpt-4o-mini");
+	assert.equal(known?.name, "GPT-4o mini");
+
+	const unknown = await catalog.getModel("openai:not-real");
+	assert.equal(unknown, null);
+});
+
+test("memory catalog adapter stays aligned with the entry contract", async () => {
+	const { catalog } = await createRecordedCatalog();
+	const memory = createMemoryModelCatalog(await catalog.listModels());
+
+	const entry = await memory.getModel("anthropic:claude-sonnet-4-5-20250929");
+	assert.equal(entry?.providerName, "Anthropic");
+});

--- a/packages/api/src/models/models-dev.ts
+++ b/packages/api/src/models/models-dev.ts
@@ -1,0 +1,281 @@
+import type { CloudflareEnv } from "@better-agent/env/types";
+import { z } from "zod";
+
+import { MODEL_PROVIDER_IDS } from "./catalog";
+import type { ModelCapability, ModelCatalogEntry, ModelProviderId } from "./catalog";
+import { createStaticModelCatalog, ModelCatalogError } from "./model-catalog";
+import type { ModelCatalog } from "./model-catalog";
+
+export const MODELS_DEV_API_URL = "https://models.dev/api.json";
+export const MODEL_CATALOG_CACHE_KEY = "models-dev:catalog:v1";
+export const MODEL_CATALOG_CACHE_TTL_SECONDS = 3600;
+
+const MODELS_DEV_SOURCE = `models.dev API catalog (${MODELS_DEV_API_URL}).`;
+const CATALOG_UNAVAILABLE_MESSAGE =
+	"The model catalog is temporarily unavailable. Try again shortly.";
+
+/**
+ * Structural subset of a Workers KV namespace used to cache the mapped
+ * catalog. A dedicated `MODEL_CATALOG_KV` binding satisfies this in
+ * production; tests inject an in-memory implementation.
+ */
+export interface ModelCatalogCache {
+	get: (key: string) => Promise<string | null>;
+	put: (key: string, value: string, options?: { expirationTtl?: number }) => Promise<void>;
+}
+
+const modelsDevModelSchema = z.looseObject({
+	cost: z.looseObject({ input: z.number(), output: z.number() }).optional(),
+	id: z.string(),
+	limit: z.looseObject({ context: z.number(), output: z.number().optional() }),
+	modalities: z.looseObject({ input: z.array(z.string()), output: z.array(z.string()) }).optional(),
+	name: z.string(),
+	reasoning: z.boolean(),
+	status: z.string().optional(),
+	tool_call: z.boolean(),
+});
+
+const modelsDevProviderSchema = z.looseObject({
+	id: z.string(),
+	models: z.record(z.string(), modelsDevModelSchema),
+	name: z.string(),
+});
+
+const modelsDevPayloadSchema = z.record(z.string(), modelsDevProviderSchema);
+
+type ModelsDevModel = z.infer<typeof modelsDevModelSchema>;
+type ModelsDevPayload = z.infer<typeof modelsDevPayloadSchema>;
+
+const providerIdSchema = z.enum(MODEL_PROVIDER_IDS);
+
+const cachedCatalogEntrySchema = z.object({
+	capabilities: z.array(z.enum(["text", "tools", "images", "audio", "video", "pdf", "reasoning"])),
+	contextWindow: z.number(),
+	costPer1MTokens: z.object({ input: z.number(), output: z.number() }).optional(),
+	description: z.string(),
+	id: z.string(),
+	maxOutputTokens: z.number().optional(),
+	name: z.string(),
+	providerId: providerIdSchema,
+	providerName: z.string(),
+	reasoning: z.enum([
+		"none",
+		"openai_reasoning_effort",
+		"anthropic_thinking",
+		"google_thinking_config",
+	]),
+	reviewedAt: z.string(),
+	source: z.string(),
+});
+
+const cachedCatalogSchema = z.object({ entries: z.array(cachedCatalogEntrySchema) });
+
+const REASONING_KIND_BY_PROVIDER: Record<ModelProviderId, ModelCatalogEntry["reasoning"]> = {
+	anthropic: "anthropic_thinking",
+	google: "google_thinking_config",
+	openai: "openai_reasoning_effort",
+};
+
+const MODALITY_CAPABILITIES: Record<string, ModelCapability> = {
+	audio: "audio",
+	image: "images",
+	pdf: "pdf",
+	video: "video",
+};
+
+const EXCLUDED_MODEL_STATUSES = new Set(["alpha", "deprecated"]);
+
+const toCapabilities = (model: ModelsDevModel): ModelCapability[] => {
+	const capabilities: ModelCapability[] = ["text"];
+
+	if (model.tool_call) {
+		capabilities.push("tools");
+	}
+
+	for (const modality of model.modalities?.input ?? []) {
+		const capability = MODALITY_CAPABILITIES[modality];
+		if (capability && !capabilities.includes(capability)) {
+			capabilities.push(capability);
+		}
+	}
+
+	if (model.reasoning) {
+		capabilities.push("reasoning");
+	}
+
+	return capabilities;
+};
+
+const toCatalogEntry = ({
+	model,
+	modelKey,
+	providerId,
+	providerName,
+	reviewedAt,
+}: {
+	model: ModelsDevModel;
+	modelKey: string;
+	providerId: ModelProviderId;
+	providerName: string;
+	reviewedAt: string;
+}): ModelCatalogEntry => ({
+	capabilities: toCapabilities(model),
+	contextWindow: model.limit.context,
+	costPer1MTokens: model.cost ? { input: model.cost.input, output: model.cost.output } : undefined,
+	description: `${model.name} from ${providerName}, listed in the models.dev catalog.`,
+	id: `${providerId}:${modelKey}`,
+	maxOutputTokens: model.limit.output,
+	name: model.name,
+	providerId,
+	providerName,
+	reasoning: model.reasoning ? REASONING_KIND_BY_PROVIDER[providerId] : "none",
+	reviewedAt,
+	source: MODELS_DEV_SOURCE,
+});
+
+/**
+ * Maps a validated models.dev payload onto ModelCatalogEntry values:
+ * providers without an AI SDK factory in `MODEL_PROVIDER_IDS` are dropped,
+ * as are models whose status is `deprecated` or `alpha`.
+ */
+export const mapModelsDevPayload = (
+	payload: ModelsDevPayload,
+	reviewedAt: string,
+): ModelCatalogEntry[] => {
+	const entries: ModelCatalogEntry[] = [];
+
+	for (const providerId of MODEL_PROVIDER_IDS) {
+		const provider = payload[providerId];
+		if (!provider) {
+			continue;
+		}
+
+		for (const [modelKey, model] of Object.entries(provider.models)) {
+			if (model.status && EXCLUDED_MODEL_STATUSES.has(model.status)) {
+				continue;
+			}
+
+			entries.push(
+				toCatalogEntry({
+					model,
+					modelKey,
+					providerId,
+					providerName: provider.name,
+					reviewedAt,
+				}),
+			);
+		}
+	}
+
+	return entries.toSorted((a, b) => a.id.localeCompare(b.id));
+};
+
+const defaultFetchCatalogPayload = async (): Promise<unknown> => {
+	const response = await fetch(MODELS_DEV_API_URL);
+
+	if (!response.ok) {
+		throw new ModelCatalogError(
+			"catalog_unavailable",
+			`models.dev responded with status ${response.status}.`,
+		);
+	}
+
+	return await response.json();
+};
+
+export interface ModelsDevModelCatalogOptions {
+	cache?: ModelCatalogCache;
+	cacheTtlSeconds?: number;
+	fallbackCatalog?: ModelCatalog;
+	fetchCatalogPayload?: () => Promise<unknown>;
+	now?: () => number;
+}
+
+/**
+ * Production ModelCatalog adapter backed by the models.dev API: the mapped
+ * catalog is cached in a dedicated KV namespace for ~1 hour, and the
+ * reviewed static catalog serves as the bundled snapshot fallback whenever
+ * the fetch fails or the payload does not validate. A typed
+ * ModelCatalogError surfaces only when both sources are unavailable.
+ */
+export const createModelsDevModelCatalog = ({
+	cache,
+	cacheTtlSeconds = MODEL_CATALOG_CACHE_TTL_SECONDS,
+	fallbackCatalog = createStaticModelCatalog(),
+	fetchCatalogPayload = defaultFetchCatalogPayload,
+	now = Date.now,
+}: ModelsDevModelCatalogOptions = {}): ModelCatalog => {
+	const readCachedEntries = async (): Promise<ModelCatalogEntry[] | null> => {
+		if (!cache) {
+			return null;
+		}
+
+		try {
+			const cached = await cache.get(MODEL_CATALOG_CACHE_KEY);
+			if (!cached) {
+				return null;
+			}
+
+			const parsed = cachedCatalogSchema.parse(JSON.parse(cached));
+			return parsed.entries.filter((entry) =>
+				entry.id.startsWith(`${entry.providerId}:`),
+			) as ModelCatalogEntry[];
+		} catch {
+			return null;
+		}
+	};
+
+	const fetchAndCacheEntries = async (): Promise<ModelCatalogEntry[]> => {
+		const payload = modelsDevPayloadSchema.parse(await fetchCatalogPayload());
+		const reviewedAt = new Date(now()).toISOString().slice(0, 10);
+		const entries = mapModelsDevPayload(payload, reviewedAt);
+
+		if (entries.length === 0) {
+			throw new ModelCatalogError(
+				"catalog_unavailable",
+				"The models.dev payload contained no supported models.",
+			);
+		}
+
+		await cache?.put(MODEL_CATALOG_CACHE_KEY, JSON.stringify({ entries }), {
+			expirationTtl: cacheTtlSeconds,
+		});
+
+		return entries;
+	};
+
+	const listModels = async (): Promise<ModelCatalogEntry[]> => {
+		const cached = await readCachedEntries();
+		if (cached) {
+			return cached;
+		}
+
+		try {
+			return await fetchAndCacheEntries();
+		} catch {
+			try {
+				return await fallbackCatalog.listModels();
+			} catch {
+				throw new ModelCatalogError("catalog_unavailable", CATALOG_UNAVAILABLE_MESSAGE);
+			}
+		}
+	};
+
+	return {
+		getModel: async (modelId) => {
+			const entries = await listModels();
+			return entries.find((entry) => entry.id === modelId) ?? null;
+		},
+		listModels,
+		sourceId: "models_dev",
+	};
+};
+
+/**
+ * The product's ModelCatalog: models.dev kept current via the dedicated
+ * `MODEL_CATALOG_KV` cache, with the reviewed static catalog as the
+ * snapshot fallback.
+ */
+export const createProductModelCatalog = (
+	env: Pick<CloudflareEnv, "MODEL_CATALOG_KV">,
+): ModelCatalog => createModelsDevModelCatalog({ cache: env.MODEL_CATALOG_KV });

--- a/packages/api/src/models/router.ts
+++ b/packages/api/src/models/router.ts
@@ -2,7 +2,7 @@ import { ORPCError } from "@orpc/server";
 import { z } from "zod";
 
 import { protectedProcedure, publicProcedure } from "../procedures";
-import { getModelCatalog, MODEL_PROVIDER_IDS } from "./catalog";
+import { MODEL_PROVIDER_IDS } from "./catalog";
 import {
 	encryptCredential,
 	getCredentialMap,
@@ -22,10 +22,13 @@ const encryptionSecret = (env: { API_ENCRYPTION_KEY?: string; BETTER_AUTH_SECRET
 	env.API_ENCRYPTION_KEY ?? env.BETTER_AUTH_SECRET;
 
 export const modelsRouter = {
-	list: publicProcedure.handler(() => getModelCatalog()),
+	list: publicProcedure.handler(async ({ context }) => await context.modelCatalog.listModels()),
 	listAvailable: protectedProcedure.handler(async ({ context }) => {
-		const credentials = await getCredentialMap(context.db, context.session.user.id);
-		return getModelCatalog().map((model) => ({
+		const [models, credentials] = await Promise.all([
+			context.modelCatalog.listModels(),
+			getCredentialMap(context.db, context.session.user.id),
+		]);
+		return models.map((model) => ({
 			...model,
 			availableForAccount: Boolean(credentials[model.providerId]),
 		}));

--- a/packages/env/src/types.ts
+++ b/packages/env/src/types.ts
@@ -5,6 +5,7 @@ export interface CloudflareEnv {
 	DB: D1Database;
 	THINKSPACE_AGENT: DurableObjectNamespace;
 	SESSION_KV?: KVNamespace;
+	MODEL_CATALOG_KV?: KVNamespace;
 	SOURCES_ARTIFACTS?: R2Bucket;
 	API_ENCRYPTION_KEY?: string;
 	VITE_SERVER_URL?: string;

--- a/packages/infra/alchemy.run.ts
+++ b/packages/infra/alchemy.run.ts
@@ -62,6 +62,11 @@ const sessions = await KVNamespace("session-cache", {
 	title: `${prefix}-session-cache`,
 });
 
+const modelCatalogCache = await KVNamespace("model-catalog-cache", {
+	adopt: adoptPersistentResources,
+	title: `${prefix}-model-catalog-cache`,
+});
+
 const sourcesAndArtifacts = await R2Bucket("sources-artifacts", {
 	adopt: adoptPersistentResources,
 	name: `${prefix}-sources-artifacts`,
@@ -78,6 +83,7 @@ const commonBindings = {
 	BETTER_AUTH_URL: requiredEnv(alchemy.env.BETTER_AUTH_URL, "BETTER_AUTH_URL"),
 	CORS_ORIGIN: requiredEnv(alchemy.env.CORS_ORIGIN, "CORS_ORIGIN"),
 	DB: db,
+	MODEL_CATALOG_KV: modelCatalogCache,
 	SESSION_KV: sessions,
 	SOURCES_ARTIFACTS: sourcesAndArtifacts,
 };


### PR DESCRIPTION
## Problem / Intent

The model catalog read surface (`models.list` / `models.listAvailable`) served only the small hand-reviewed static list, so users could not see — or eventually pick — the full set of models their provider credentials unlock. Closes #45.

## Approach

Mirror opencode's split: models.dev is the database of everything that exists, credentials determine availability. A `createModelsDevModelCatalog` adapter behind the existing `ModelCatalog` seam fetches and validates `api.json`, maps it onto `ModelCatalogEntry` values (static AI SDK provider map only; deprecated/alpha models dropped; `provider:model` id convention; per-provider reasoning translation kinds), and caches the mapped result in a dedicated `MODEL_CATALOG_KV` namespace with a ~1h TTL. The reviewed static catalog stays as the bundled snapshot fallback, so a fetch or validation failure never blanks the settings page; a typed `ModelCatalogError` surfaces only if both sources are unavailable. The oRPC read surface reads through a catalog instance on the request context, and tests run against a recorded `api.json` fixture with no live network.
