### PR TITLE
Resolve turn models through the ModelCatalog seam

### DIFF
--- a/packages/api/src/models/readiness.test.ts
+++ b/packages/api/src/models/readiness.test.ts
@@ -3,6 +3,10 @@ import test from "node:test";
 
 import type { ProductDb } from "@better-agent/db";
 
+import { getModelCatalog } from "./catalog";
+import type { ModelCatalogEntry } from "./catalog";
+import { createMemoryModelCatalog, ModelCatalogError } from "./model-catalog";
+import type { ModelCatalog } from "./model-catalog";
 import {
 	checkThinkspaceModelReadiness,
 	getOwnedThinkspaceModelReadiness,
@@ -16,6 +20,34 @@ const createEnv = () => ({
 	API_ENCRYPTION_KEY: undefined,
 	BETTER_AUTH_SECRET: "test-secret",
 });
+
+/**
+ * Memory ModelCatalog over the reviewed static entries, plus a models.dev-only
+ * entry that the static catalog does not know about. No live network in tests.
+ */
+const modelsDevOnlyEntry: ModelCatalogEntry = {
+	capabilities: ["text", "tools", "reasoning"],
+	contextWindow: 1_048_576,
+	description: "Gemini catalog-only test model from the models.dev catalog.",
+	id: "google:gemini-catalog-only",
+	maxOutputTokens: 65_536,
+	name: "Gemini Catalog Only",
+	providerId: "google",
+	providerName: "Google",
+	reasoning: "google_thinking_config",
+	reviewedAt: "2026-06-10",
+	source: "models.dev API catalog (https://models.dev/api.json).",
+};
+
+const modelCatalog = createMemoryModelCatalog([...getModelCatalog(), modelsDevOnlyEntry]);
+
+const unavailableCatalog: ModelCatalog = {
+	getModel: () =>
+		Promise.reject(new ModelCatalogError("catalog_unavailable", "both sources unavailable")),
+	listModels: () =>
+		Promise.reject(new ModelCatalogError("catalog_unavailable", "both sources unavailable")),
+	sourceId: "models_dev",
+};
 
 const createThinkspace = (requestedPermissions = "[]") => ({
 	id: "thinkspace_model_readiness",
@@ -40,6 +72,7 @@ test("reports ready for the default model once the credential Permission is gran
 			assert.equal(input.userId, "user_123");
 			return Promise.resolve("google-test-key");
 		},
+		modelCatalog,
 		settings: null,
 		thinkspace: createThinkspace(grantedCredentialPermission("google")),
 		userId: "user_123",
@@ -53,6 +86,7 @@ test("fails closed for unknown configured model ids", async () => {
 	const readiness = await checkThinkspaceModelReadiness({
 		db,
 		env: createEnv(),
+		modelCatalog,
 		settings: { defaultModel: "openai:not-real", reasoningEffort: "medium" },
 		thinkspace: createThinkspace(),
 		userId: "user_123",
@@ -68,6 +102,7 @@ test("fails closed when the user has no saved provider credential", async () => 
 		db,
 		env: createEnv(),
 		getUserCredential: () => Promise.resolve(null),
+		modelCatalog,
 		settings: null,
 		thinkspace: createThinkspace(grantedCredentialPermission("google")),
 		userId: "user_123",
@@ -87,6 +122,7 @@ test("requires Thinkspace Permission before resolving any saved credential", asy
 			credentialLoadCount += 1;
 			return Promise.resolve("sk-test");
 		},
+		modelCatalog,
 		settings: { defaultModel: "openai:gpt-4.1", reasoningEffort: "medium" },
 		thinkspace: createThinkspace(),
 		userId: "user_123",
@@ -106,6 +142,7 @@ test("reports ready only after the Thinkspace credential Permission is granted",
 			assert.equal(input.userId, "user_123");
 			return Promise.resolve("sk-test");
 		},
+		modelCatalog,
 		settings: { defaultModel: "openai:gpt-4.1", reasoningEffort: "medium" },
 		thinkspace: createThinkspace(grantedCredentialPermission("openai")),
 		userId: "user_123",
@@ -126,6 +163,7 @@ test("owner-gated model readiness reports readiness for owned Thinkspaces", asyn
 		},
 		getUserCredential: () => Promise.resolve("google-test-key"),
 		getUserSettings: () => Promise.resolve(null),
+		modelCatalog,
 		ownerUserId: "owner_user",
 		thinkspaceId: "thinkspace_owned",
 	});
@@ -142,6 +180,7 @@ test("resolves a usable turn model for ready owned Thinkspaces", async () => {
 			Promise.resolve(createThinkspace(grantedCredentialPermission("google"))),
 		getUserCredential: () => Promise.resolve("google-test-key"),
 		getUserSettings: () => Promise.resolve(null),
+		modelCatalog,
 		ownerUserId: "owner_user",
 		thinkspaceId: "thinkspace_owned",
 	});
@@ -160,6 +199,7 @@ test("turn model resolution fails closed with a product-safe error when not read
 				Promise.resolve(createThinkspace(grantedCredentialPermission("google"))),
 			getUserCredential: () => Promise.resolve(null),
 			getUserSettings: () => Promise.resolve(null),
+			modelCatalog,
 			ownerUserId: "owner_user",
 			thinkspaceId: "thinkspace_owned",
 		}),
@@ -178,6 +218,7 @@ test("turn model resolution returns null for non-owned Thinkspaces", async () =>
 		env: createEnv(),
 		getThinkspaceByOwner: () => Promise.resolve(null),
 		getUserSettings: () => Promise.resolve(null),
+		modelCatalog,
 		ownerUserId: "other_user",
 		thinkspaceId: "thinkspace_owned",
 	});
@@ -194,9 +235,62 @@ test("owner-gated model readiness returns null for non-owned Thinkspaces", async
 			return Promise.resolve(null);
 		},
 		getUserSettings: () => Promise.resolve(null),
+		modelCatalog,
 		ownerUserId: "other_user",
 		thinkspaceId: "thinkspace_owned",
 	});
 
 	assert.equal(readiness, null);
+});
+
+test("reports ready for a models.dev-only model from a credentialed, Permission-granted provider", async () => {
+	const readiness = await checkThinkspaceModelReadiness({
+		db,
+		env: createEnv(),
+		getUserCredential: () => Promise.resolve("google-test-key"),
+		modelCatalog,
+		settings: { defaultModel: "google:gemini-catalog-only", reasoningEffort: "medium" },
+		thinkspace: createThinkspace(grantedCredentialPermission("google")),
+		userId: "user_123",
+	});
+
+	assert.equal(readiness.status, "ready");
+	assert.equal(readiness.modelId, "google:gemini-catalog-only");
+	assert.equal(readiness.modelName, "Gemini Catalog Only");
+});
+
+test("resolves a usable turn model for a models.dev-only model id", async () => {
+	const resolved = await resolveOwnedThinkspaceTurnModel({
+		db,
+		env: createEnv(),
+		getThinkspaceByOwner: () =>
+			Promise.resolve(createThinkspace(grantedCredentialPermission("google"))),
+		getUserCredential: () => Promise.resolve("google-test-key"),
+		getUserSettings: () =>
+			Promise.resolve({ defaultModel: "google:gemini-catalog-only", reasoningEffort: "medium" }),
+		modelCatalog,
+		ownerUserId: "owner_user",
+		thinkspaceId: "thinkspace_owned",
+	});
+
+	assert.equal(resolved?.readiness.status, "ready");
+	assert.equal(resolved?.readiness.modelId, "google:gemini-catalog-only");
+	assert.ok(resolved?.model);
+});
+
+test("catalog unavailability fails closed with a product-safe readiness", async () => {
+	const readiness = await checkThinkspaceModelReadiness({
+		db,
+		env: createEnv(),
+		getUserCredential: () => Promise.resolve("google-test-key"),
+		modelCatalog: unavailableCatalog,
+		settings: null,
+		thinkspace: createThinkspace(grantedCredentialPermission("google")),
+		userId: "user_123",
+	});
+
+	assert.equal(readiness.status, "not_ready");
+	assert.equal(readiness.reason, "resolution_failed");
+	assert.doesNotMatch(readiness.message, /unavailable catalog|fetch|sources/iu);
+	assert.match(readiness.message, /model catalog is temporarily unavailable/u);
 });

--- a/packages/api/src/models/readiness.ts
+++ b/packages/api/src/models/readiness.ts
@@ -5,9 +5,11 @@ import type { Thinkspace } from "@better-agent/db/schema/thinkspaces";
 import type { CloudflareEnv } from "@better-agent/env/types";
 import { eq } from "drizzle-orm";
 
-import { DEFAULT_MODEL_ID, getModelDefinition, MODEL_PROVIDER_IDS } from "./catalog";
+import { DEFAULT_MODEL_ID, MODEL_PROVIDER_IDS } from "./catalog";
 import type { ModelCatalogEntry, ModelProviderId } from "./catalog";
 import { getDecryptedCredential } from "./credentials";
+import type { ModelCatalog } from "./model-catalog";
+import { createProductModelCatalog } from "./models-dev";
 import { getThinkspace } from "../thinkspaces/repository";
 import { ModelResolutionError, resolveLanguageModel } from "./resolver";
 import type { ReasoningEffort, ThinkspaceModelPolicy } from "./resolver";
@@ -73,6 +75,7 @@ export interface GetOwnedThinkspaceModelReadinessInput {
 	getThinkspaceByOwner?: GetThinkspaceByOwner;
 	getUserSettings?: GetUserSettings;
 	getUserCredential?: GetUserCredential;
+	modelCatalog?: ModelCatalog;
 	ownerUserId: string;
 	thinkspaceId: string;
 }
@@ -81,12 +84,19 @@ export interface CheckThinkspaceModelReadinessInput {
 	db: ProductDb;
 	env: ModelReadinessEnv;
 	getUserCredential?: GetUserCredential;
+	modelCatalog?: ModelCatalog;
 	settings: ModelReadinessUserSettings | null;
 	thinkspace: Pick<Thinkspace, "id" | "requestedPermissions">;
 	userId: string;
 }
 
-type ModelReadinessEnv = Pick<CloudflareEnv, "API_ENCRYPTION_KEY" | "BETTER_AUTH_SECRET">;
+type ModelReadinessEnv = Pick<
+	CloudflareEnv,
+	"API_ENCRYPTION_KEY" | "BETTER_AUTH_SECRET" | "MODEL_CATALOG_KV"
+>;
+
+const CATALOG_UNAVAILABLE_READINESS_MESSAGE =
+	"The model catalog is temporarily unavailable, so the selected model could not be resolved. Try again shortly.";
 
 type GetThinkspaceByOwner = (
 	db: ProductDb,
@@ -238,13 +248,28 @@ const evaluateThinkspaceModel = async ({
 	db,
 	env,
 	getUserCredential = getDecryptedCredential,
+	modelCatalog,
 	settings,
 	thinkspace,
 	userId,
 }: CheckThinkspaceModelReadinessInput): Promise<ThinkspaceModelEvaluation> => {
 	const modelId = getConfiguredModelId(settings);
 	const reasoningEffort = getReasoningEffort(settings);
-	const modelDefinition = getModelDefinition(modelId);
+	const catalog = modelCatalog ?? createProductModelCatalog(env);
+
+	let modelDefinition: ModelCatalogEntry | null;
+	try {
+		modelDefinition = await catalog.getModel(modelId);
+	} catch {
+		return {
+			readiness: notReady({
+				message: CATALOG_UNAVAILABLE_READINESS_MESSAGE,
+				modelId,
+				reason: "resolution_failed",
+				reasoningEffort,
+			}),
+		};
+	}
 
 	if (!modelDefinition) {
 		return {
@@ -275,6 +300,7 @@ const evaluateThinkspaceModel = async ({
 
 	try {
 		const resolved = resolveLanguageModel({
+			modelDefinition,
 			policy,
 			userCredentials: userCredential
 				? { [modelDefinition.providerId]: userCredential }
@@ -330,6 +356,7 @@ const evaluateOwnedThinkspaceModel = async ({
 	getThinkspaceByOwner = getThinkspace,
 	getUserCredential = getDecryptedCredential,
 	getUserSettings = getUserProductModelSettings,
+	modelCatalog,
 	ownerUserId,
 	thinkspaceId,
 }: GetOwnedThinkspaceModelReadinessInput): Promise<ThinkspaceModelEvaluation | null> => {
@@ -343,6 +370,7 @@ const evaluateOwnedThinkspaceModel = async ({
 		db,
 		env,
 		getUserCredential: async (_db, input) => await getUserCredential(db, input),
+		modelCatalog,
 		settings: await getUserSettings(db, ownerUserId),
 		thinkspace,
 		userId: ownerUserId,

--- a/packages/api/src/models/resolver.test.ts
+++ b/packages/api/src/models/resolver.test.ts
@@ -16,9 +16,20 @@ test("parses native provider:model identifiers", () => {
 	assert.throws(() => parseModelId("google"));
 });
 
-test("rejects unknown models", () => {
+const requireDefinition = (modelId: string) => {
+	const definition = getModelDefinition(modelId);
+	assert.ok(definition, `expected a catalog definition for ${modelId}`);
+	return definition;
+};
+
+test("rejects definitions that do not match the policy model id", () => {
 	assert.throws(
-		() => resolveLanguageModel({ policy: { modelId: "openai:not-real" } }),
+		() =>
+			resolveLanguageModel({
+				modelDefinition: requireDefinition("openai:gpt-4.1"),
+				policy: { credentialPermission: "granted", modelId: "openai:not-real" },
+				userCredentials: { openai: "sk-test" },
+			}),
 		ModelResolutionError,
 	);
 });
@@ -27,6 +38,7 @@ test("requires explicit Thinkspace Permission before a saved credential can reso
 	assert.throws(
 		() =>
 			resolveLanguageModel({
+				modelDefinition: requireDefinition("openai:gpt-4.1"),
 				policy: { modelId: "openai:gpt-4.1" },
 				userCredentials: { openai: "sk-test" },
 			}),
@@ -36,6 +48,7 @@ test("requires explicit Thinkspace Permission before a saved credential can reso
 
 test("resolves Google credentials through the native Google provider seam", () => {
 	const resolved = resolveLanguageModel({
+		modelDefinition: requireDefinition("google:gemini-2.5-flash"),
 		policy: { credentialPermission: "granted", modelId: "google:gemini-2.5-flash" },
 		userCredentials: { google: "google-test-key" },
 	});

--- a/packages/api/src/models/resolver.ts
+++ b/packages/api/src/models/resolver.ts
@@ -4,7 +4,7 @@ import { createOpenAI } from "@ai-sdk/openai";
 import type { LanguageModelV3, SharedV3ProviderOptions } from "@ai-sdk/provider";
 import { defaultSettingsMiddleware, wrapLanguageModel } from "ai";
 
-import { getModelDefinition, parseModelId } from "./catalog";
+import { parseModelId } from "./catalog";
 import type { ModelCatalogEntry, ModelProviderId } from "./catalog";
 
 export type ReasoningEffort = "low" | "medium" | "high";
@@ -16,6 +16,12 @@ export interface ThinkspaceModelPolicy {
 }
 
 export interface ResolveLanguageModelInput {
+	/**
+	 * Catalog-resolved definition for `policy.modelId`. Callers resolve it
+	 * through a ModelCatalog (models.dev with its static snapshot fallback);
+	 * the resolver never performs a direct static-catalog lookup.
+	 */
+	modelDefinition: ModelCatalogEntry;
 	policy: ThinkspaceModelPolicy;
 	userCredentials?: Partial<Record<ModelProviderId, string | undefined>>;
 }
@@ -77,15 +83,15 @@ const withDefaultProviderOptions = (
 };
 
 export const resolveLanguageModel = ({
+	modelDefinition,
 	policy,
 	userCredentials,
 }: ResolveLanguageModelInput): ResolvedLanguageModel => {
-	const modelDefinition = getModelDefinition(policy.modelId);
-	if (!modelDefinition) {
+	if (modelDefinition.id !== policy.modelId) {
 		throw new ModelResolutionError(`Unknown model: ${policy.modelId}`);
 	}
 
-	const { providerId, providerModelId } = parseModelId(policy.modelId);
+	const { providerId, providerModelId } = parseModelId(modelDefinition.id);
 	if (policy.credentialPermission !== "granted") {
 		throw new ModelResolutionError(
 			"This Thinkspace has not been granted Permission to use the saved provider credential.",

--- a/packages/api/src/thinkspaces/router.test.ts
+++ b/packages/api/src/thinkspaces/router.test.ts
@@ -6,7 +6,11 @@ import { ORPCError, call } from "@orpc/server";
 import type { AnyProcedure } from "@orpc/server";
 
 import type { Context } from "../context";
+import { getModelCatalog } from "../models/catalog";
+import type { ModelCatalogEntry } from "../models/catalog";
 import { encryptCredential } from "../models/credentials";
+import { createMemoryModelCatalog } from "../models/model-catalog";
+import type { ModelCatalog } from "../models/model-catalog";
 import { thinkspacesRouter } from "./router";
 import type { ThinkspaceTurnInspection } from "./inspect";
 import type { ThinkspaceTurnAcceptance } from "./turns";
@@ -52,13 +56,35 @@ const authenticatedSession = {
 	user: { id: "owner_user" },
 };
 
+/**
+ * Memory ModelCatalog over the reviewed static entries plus a models.dev-only
+ * entry, so router tests never reach the live models.dev fetch path.
+ */
+const modelsDevOnlyEntry: ModelCatalogEntry = {
+	capabilities: ["text", "tools", "reasoning"],
+	contextWindow: 1_048_576,
+	description: "Gemini catalog-only test model from the models.dev catalog.",
+	id: "google:gemini-catalog-only",
+	maxOutputTokens: 65_536,
+	name: "Gemini Catalog Only",
+	providerId: "google",
+	providerName: "Google",
+	reasoning: "google_thinking_config",
+	reviewedAt: "2026-06-10",
+	source: "models.dev API catalog (https://models.dev/api.json).",
+};
+
+const memoryModelCatalog = createMemoryModelCatalog([...getModelCatalog(), modelsDevOnlyEntry]);
+
 const createCallContext = ({
 	db,
 	env = {},
+	modelCatalog = memoryModelCatalog,
 	session = authenticatedSession,
 }: {
 	db: ProductDb;
 	env?: Record<string, unknown>;
+	modelCatalog?: ModelCatalog;
 	session?: typeof authenticatedSession | null;
 }): Context =>
 	({
@@ -66,6 +92,7 @@ const createCallContext = ({
 		env,
 		executionCtx: undefined,
 		headers: new Headers(),
+		modelCatalog,
 		session,
 	}) as unknown as Context;
 
@@ -306,6 +333,53 @@ test("owners can still submit and inspect turns through the router with the Thin
 	assert.equal(submitted.submissionId, "submission_1");
 	assert.equal(inspected.status, "accepted");
 	assert.ok(runtimeNames.every((name) => name === OWNED_THINKSPACE_ID));
+});
+
+test("a turn submits end-to-end on a models.dev-only model from a credentialed, Permission-granted provider", async () => {
+	const acceptance: ThinkspaceTurnAcceptance = {
+		acceptedAt: 1_717_000_000_000,
+		deduplicated: false,
+		idempotencyKey: "retry-key-2",
+		status: "accepted",
+		submissionId: "submission_2",
+		thinkspaceId: OWNED_THINKSPACE_ID,
+	};
+	const env = {
+		BETTER_AUTH_SECRET: "test-secret",
+		THINKSPACE_AGENT: {
+			get: () => ({ acceptTurnSubmission: () => Promise.resolve(acceptance) }),
+			idFromName: (name: string) => ({ toString: () => `durable-object-id:${name}` }),
+		},
+	};
+	// The same structural row serves the Thinkspace, settings (default model
+	// pinned to a models.dev-only id), and saved-credential selects.
+	const readyRow = {
+		...ownedThinkspaceRow(),
+		defaultModel: "google:gemini-catalog-only",
+		encryptedCredential: await encryptCredential("google-test-key", "test-secret"),
+		reasoningEffort: "medium",
+		requestedPermissions: JSON.stringify([
+			{
+				granted: true,
+				providerId: "google",
+				type: "model_provider_credential_permission",
+			},
+		]),
+	};
+	const context = createCallContext({ db: createDbReturning([readyRow]), env });
+
+	const submitted = await call(
+		thinkspacesRouter.submitTurn,
+		{
+			idempotencyKey: "retry-key-2",
+			instruction: "Summarize the Thinkspace goal.",
+			thinkspaceId: OWNED_THINKSPACE_ID,
+		},
+		{ context },
+	);
+
+	assert.equal(submitted.status, "accepted");
+	assert.equal(submitted.submissionId, "submission_2");
 });
 
 test("Thinkspace control-plane reads still work for owners", async () => {

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -187,6 +187,7 @@ export const thinkspacesRouter = {
 			const readiness = await getOwnedThinkspaceModelReadiness({
 				db: context.db,
 				env: context.env,
+				modelCatalog: context.modelCatalog,
 				ownerUserId: context.session.user.id,
 				thinkspaceId: input.thinkspaceId,
 			});
@@ -241,6 +242,7 @@ export const thinkspacesRouter = {
 				env: context.env,
 				idempotencyKey: input.idempotencyKey,
 				instruction: input.instruction,
+				modelCatalog: context.modelCatalog,
 				ownerUserId: context.session.user.id,
 				thinkspaceId: input.thinkspaceId,
 			});

--- a/packages/api/src/thinkspaces/turns.ts
+++ b/packages/api/src/thinkspaces/turns.ts
@@ -11,6 +11,7 @@ import type {
 	CheckThinkspaceModelReadinessInput,
 	ThinkspaceModelReadiness,
 } from "../models/readiness";
+import type { ModelCatalog } from "../models/model-catalog";
 import { getThinkspace } from "./repository";
 import { resolveThinkspaceAgentRuntime, THINKSPACE_AGENT_BINDING_NAME } from "./runtime";
 
@@ -43,13 +44,17 @@ export interface SubmitOwnedThinkspaceTurnInput {
 	getUserSettings?: GetUserSettings;
 	idempotencyKey: string;
 	instruction: string;
+	modelCatalog?: ModelCatalog;
 	ownerUserId: string;
 	thinkspaceId: string;
 }
 
 type ThinkspaceTurnEnv = Pick<
 	CloudflareEnv,
-	"API_ENCRYPTION_KEY" | "BETTER_AUTH_SECRET" | typeof THINKSPACE_AGENT_BINDING_NAME
+	| "API_ENCRYPTION_KEY"
+	| "BETTER_AUTH_SECRET"
+	| "MODEL_CATALOG_KV"
+	| typeof THINKSPACE_AGENT_BINDING_NAME
 >;
 
 type GetThinkspaceByOwner = (
@@ -140,6 +145,7 @@ export const submitOwnedThinkspaceTurn = async ({
 	getUserSettings = getUserProductModelSettings,
 	idempotencyKey,
 	instruction,
+	modelCatalog,
 	ownerUserId,
 	thinkspaceId,
 }: SubmitOwnedThinkspaceTurnInput): Promise<ThinkspaceTurnAcceptance | null> => {
@@ -161,6 +167,7 @@ export const submitOwnedThinkspaceTurn = async ({
 	const readiness = await checkModelReadiness({
 		db,
 		env,
+		modelCatalog,
 		settings: await getUserSettings(db, ownerUserId),
 		thinkspace,
 		userId: ownerUserId,


### PR DESCRIPTION
## Problem / Intent

Model readiness and the turn-model resolver still looked up model definitions via the static catalog's direct lookup, so a Thinkspace Agent turn could only ever run on the small hand-reviewed list — even after the catalog read surface went live on models.dev. Closes #46.

## Approach

Change where model definitions come from, not where model selection lives. Readiness resolves the configured model id through an injected `ModelCatalog` (defaulting to the models.dev-backed product catalog with its static snapshot fallback), and `resolveLanguageModel` now takes the catalog-resolved definition as input instead of looking anything up itself. Unknown ids keep failing closed as `unknown_model`; total catalog unavailability (both models.dev and the snapshot failing) maps to a product-safe not-ready readiness rather than leaking raw errors. The thinkspaces router threads the request-context catalog into readiness and turn submission, so any cataloged model from a credentialed, Permission-granted provider reports ready and runs end-to-end. Tests inject a memory `ModelCatalog`; no live network.
