### PR TITLE
Add Agent Profile foundation activation

### DIFF
--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -42,6 +42,19 @@ interface PermissionPlaceholder {
 	type: string;
 }
 
+interface AgentProfileRevisionView {
+	identity: {
+		displayName: string;
+		instructions: string;
+	};
+	modelBehavior: {
+		modelId: string;
+		reasoningLevel: string;
+	};
+	status: "active" | "draft" | "superseded";
+	version: number;
+}
+
 const parseJsonArray = <T,>(value: string): T[] => {
 	try {
 		const parsed = JSON.parse(value) as unknown;
@@ -65,6 +78,30 @@ const TURN_STATUS_BADGE_VARIANTS: Record<
 };
 
 const TURN_STATUS_POLL_INTERVAL_MS = 2000;
+
+const getSubmitTurnBlockedMessage = ({
+	isArchived,
+	isDraft,
+	modelReady,
+}: {
+	isArchived: boolean;
+	isDraft: boolean;
+	modelReady: boolean;
+}): string | null => {
+	if (isArchived) {
+		return "Archived Thinkspaces cannot accept new Thinkspace Agent turns.";
+	}
+
+	if (isDraft) {
+		return "Activate this Thinkspace before submitting turns.";
+	}
+
+	if (!modelReady) {
+		return "Model configuration must be ready before submitting a turn.";
+	}
+
+	return null;
+};
 
 const TurnInspectionPanel = ({
 	initialSubmissionId,
@@ -152,12 +189,90 @@ const TurnInspectionPanel = ({
 	);
 };
 
+const AgentProfileSection = ({
+	activationError,
+	isActivating,
+	isDraft,
+	onActivate,
+	profileRevision,
+}: {
+	activationError?: Error | null;
+	isActivating: boolean;
+	isDraft: boolean;
+	onActivate: () => void;
+	profileRevision: AgentProfileRevisionView | null;
+}) => (
+	<section aria-labelledby="agent-profile-heading" className="grid gap-4">
+		<div className="grid gap-1">
+			<h2 className="text-lg font-semibold tracking-tight" id="agent-profile-heading">
+				Agent Profile
+			</h2>
+			<p className="text-muted-foreground text-sm">
+				Identity, instructions, and model behavior are versioned together. Drafts take effect only
+				when activated.
+			</p>
+		</div>
+		{profileRevision ? (
+			<div className="grid gap-4 border border-border p-4">
+				<div className="flex items-start justify-between gap-4">
+					<div className="grid gap-1">
+						<p className="text-sm font-medium">{profileRevision.identity.displayName}</p>
+						<p className="text-muted-foreground text-xs">
+							Revision {profileRevision.version} · {profileRevision.status}
+						</p>
+					</div>
+					<Badge variant={profileRevision.status === "active" ? "default" : "outline"}>
+						{profileRevision.status}
+					</Badge>
+				</div>
+				<div className="grid gap-1 border-border border-t pt-4">
+					<p className="text-muted-foreground text-xs font-medium">Instructions</p>
+					<p className="whitespace-pre-wrap text-sm leading-relaxed">
+						{profileRevision.identity.instructions || "No instructions yet."}
+					</p>
+				</div>
+				<div className="grid gap-1 border-border border-t pt-4">
+					<p className="text-muted-foreground text-xs font-medium">Model behavior</p>
+					<p className="break-all text-sm">{profileRevision.modelBehavior.modelId}</p>
+					<p className="text-muted-foreground text-xs">
+						Reasoning level: {profileRevision.modelBehavior.reasoningLevel}
+					</p>
+				</div>
+				{isDraft && profileRevision.status === "draft" ? (
+					<div className="grid gap-2 border-border border-t pt-4">
+						<p className="text-muted-foreground text-sm">
+							Activation makes this revision the Thinkspace Agent&apos;s active behavior and moves
+							the Thinkspace out of draft.
+						</p>
+						<div>
+							<Button disabled={isActivating} onClick={onActivate} type="button">
+								{isActivating ? "Activating…" : "Activate Thinkspace"}
+							</Button>
+						</div>
+						{activationError ? (
+							<p className="text-destructive text-sm" role="alert">
+								{activationError.message}
+							</p>
+						) : null}
+					</div>
+				) : null}
+			</div>
+		) : (
+			<p className="border border-border p-4 text-muted-foreground text-sm">
+				No Agent Profile revision has been created for this Thinkspace yet.
+			</p>
+		)}
+	</section>
+);
+
 const SubmitTurnSection = ({
 	isArchived,
+	isDraft,
 	modelReady,
 	thinkspaceId,
 }: {
 	isArchived: boolean;
+	isDraft: boolean;
 	modelReady: boolean;
 	thinkspaceId: string;
 }) => {
@@ -172,8 +287,10 @@ const SubmitTurnSection = ({
 			},
 		}),
 	);
+	const blockedMessage = getSubmitTurnBlockedMessage({ isArchived, isDraft, modelReady });
+	const turnInputDisabled = Boolean(blockedMessage);
 	const submitDisabled =
-		isArchived || !modelReady || !turnInstruction.trim() || submitTurnMutation.isPending;
+		turnInputDisabled || !turnInstruction.trim() || submitTurnMutation.isPending;
 
 	return (
 		<section aria-labelledby="submit-turn-heading" className="grid gap-4">
@@ -203,7 +320,7 @@ const SubmitTurnSection = ({
 				<div className="grid gap-2">
 					<Label htmlFor="turn-instruction">Instruction</Label>
 					<Textarea
-						disabled={isArchived || !modelReady}
+						disabled={turnInputDisabled}
 						id="turn-instruction"
 						maxLength={4000}
 						onChange={(event) => setTurnInstruction(event.target.value)}
@@ -212,16 +329,7 @@ const SubmitTurnSection = ({
 						value={turnInstruction}
 					/>
 				</div>
-				{isArchived ? (
-					<p className="text-muted-foreground text-xs">
-						Archived Thinkspaces cannot accept new Thinkspace Agent turns.
-					</p>
-				) : null}
-				{isArchived || modelReady ? null : (
-					<p className="text-muted-foreground text-xs">
-						Model configuration must be ready before submitting a turn.
-					</p>
-				)}
+				{blockedMessage ? <p className="text-muted-foreground text-xs">{blockedMessage}</p> : null}
 				{submitTurnMutation.isError ? (
 					<p className="text-destructive text-xs">{submitTurnMutation.error.message}</p>
 				) : null}
@@ -287,6 +395,25 @@ const RouteComponent = () => {
 			},
 		}),
 	);
+	const activateAgentProfileMutation = useMutation(
+		context.orpc.thinkspaces.activateAgentProfile.mutationOptions({
+			onSuccess: async () => {
+				await Promise.all([
+					queryClient.invalidateQueries({
+						queryKey: context.orpc.thinkspaces.get.queryKey({ input: { thinkspaceId } }),
+					}),
+					queryClient.invalidateQueries({
+						queryKey: context.orpc.thinkspaces.list.queryKey(),
+					}),
+					queryClient.invalidateQueries({
+						queryKey: context.orpc.thinkspaces.modelReadiness.queryKey({
+							input: { thinkspaceId },
+						}),
+					}),
+				]);
+			},
+		}),
+	);
 	const updateToolSelectionsMutation = useMutation(
 		context.orpc.thinkspaces.updateToolSelections.mutationOptions({
 			onSuccess: async () => {
@@ -301,7 +428,9 @@ const RouteComponent = () => {
 	const runtimeReadiness = runtimeReadinessQuery.data;
 	const modelReadiness = modelReadinessQuery.data;
 	const runtimePolicy = runtimePolicyQuery.data;
+	const profileRevision = thinkspace.agentProfileRevision;
 	const isArchived = thinkspace.status === "archived";
+	const isDraft = thinkspace.status === "draft";
 	const enabledTools = parseJsonArray<EnabledToolSelection>(thinkspace.enabledToolIds);
 	const requestedPermissions = parseJsonArray<PermissionPlaceholder>(
 		thinkspace.requestedPermissions,
@@ -314,6 +443,17 @@ const RouteComponent = () => {
 			: [...enabledTools, { risk, serverId }];
 
 		updateToolSelectionsMutation.mutate({ selections, thinkspaceId });
+	};
+
+	const handleActivateAgentProfile = () => {
+		if (
+			!(isDraft && profileRevision?.status === "draft") ||
+			activateAgentProfileMutation.isPending
+		) {
+			return;
+		}
+
+		activateAgentProfileMutation.mutate({ thinkspaceId });
 	};
 
 	const handleArchive = () => {
@@ -343,12 +483,6 @@ const RouteComponent = () => {
 				<p className="max-w-2xl text-muted-foreground text-sm leading-relaxed">
 					{thinkspace.configurationSummary}
 				</p>
-				{thinkspace.initialInstructions ? (
-					<div className="border border-border p-4">
-						<p className="mb-1 text-muted-foreground text-xs font-medium">Initial instructions</p>
-						<p className="text-sm leading-relaxed">{thinkspace.initialInstructions}</p>
-					</div>
-				) : null}
 				<div className="flex gap-4 text-muted-foreground text-xs">
 					<span>Updated {formatDateTime(thinkspace.updatedAt)}</span>
 					{thinkspace.archivedAt ? (
@@ -356,6 +490,16 @@ const RouteComponent = () => {
 					) : null}
 				</div>
 			</div>
+
+			<Separator />
+
+			<AgentProfileSection
+				activationError={activateAgentProfileMutation.error}
+				isActivating={activateAgentProfileMutation.isPending}
+				isDraft={isDraft}
+				onActivate={handleActivateAgentProfile}
+				profileRevision={profileRevision}
+			/>
 
 			<Separator />
 
@@ -422,6 +566,7 @@ const RouteComponent = () => {
 
 			<SubmitTurnSection
 				isArchived={isArchived}
+				isDraft={isDraft}
 				modelReady={modelReadiness.status === "ready"}
 				thinkspaceId={thinkspaceId}
 			/>
@@ -511,7 +656,7 @@ const RouteComponent = () => {
 				)}
 			</section>
 
-			{isArchived ? null : (
+			{isArchived || isDraft ? null : (
 				<>
 					<Separator />
 					<section className="grid gap-4">

--- a/packages/api/src/thinkspaces/agent-profile-repository.ts
+++ b/packages/api/src/thinkspaces/agent-profile-repository.ts
@@ -68,6 +68,19 @@ export const getDraftAgentProfileRevision = async (
 	return revision?.status === AGENT_PROFILE_REVISION_STATUS.DRAFT ? revision : null;
 };
 
+export const getCurrentAgentProfileRevision = async (
+	db: ProductDb,
+	{ thinkspaceId }: GetAgentProfileRevisionInput,
+): Promise<ActiveAgentProfileRevision | DraftAgentProfileRevision | null> => {
+	const active = await getActiveAgentProfileRevision(db, { thinkspaceId });
+
+	if (active) {
+		return active;
+	}
+
+	return await getDraftAgentProfileRevision(db, { thinkspaceId });
+};
+
 export const listAgentProfileRevisions = async (
 	db: ProductDb,
 	{ thinkspaceId }: GetAgentProfileRevisionInput,
@@ -120,33 +133,56 @@ export interface ApplyAgentProfileActivationInput {
 /**
  * Persists an activation computed by `createAgentProfileActivation`.
  *
- * Writes run sequentially; the partial unique indexes on the table keep the
- * "one active, one draft" invariant safe even if a step fails. Atomic batch
- * semantics and the runtime-side snapshot/schedule reconciliation RPC are
- * deliberately left to the activation behavior slice.
+ * Writes are batched so revision activation and first Thinkspace activation
+ * succeed or fail as one D1 unit. Superseding the previous active revision
+ * is ordered before activating the draft to satisfy the partial unique index.
  */
 export const applyAgentProfileActivation = async (
 	db: ProductDb,
 	{ activation }: ApplyAgentProfileActivationInput,
 ): Promise<void> => {
 	const { activatedRevision, supersededRevision, thinkspaceActivationPatch } = activation;
-
-	if (supersededRevision) {
-		await db
-			.update(thinkspaceAgentProfiles)
-			.set(serializeAgentProfileRevision(supersededRevision))
-			.where(eq(thinkspaceAgentProfiles.id, supersededRevision.id));
-	}
-
-	await db
+	const activationUpdate = db
 		.update(thinkspaceAgentProfiles)
 		.set(serializeAgentProfileRevision(activatedRevision))
 		.where(eq(thinkspaceAgentProfiles.id, activatedRevision.id));
 
-	if (thinkspaceActivationPatch) {
-		await db
-			.update(thinkspaces)
-			.set(thinkspaceActivationPatch)
-			.where(eq(thinkspaces.id, activatedRevision.thinkspaceId));
+	if (supersededRevision && thinkspaceActivationPatch) {
+		await db.batch([
+			db
+				.update(thinkspaceAgentProfiles)
+				.set(serializeAgentProfileRevision(supersededRevision))
+				.where(eq(thinkspaceAgentProfiles.id, supersededRevision.id)),
+			activationUpdate,
+			db
+				.update(thinkspaces)
+				.set(thinkspaceActivationPatch)
+				.where(eq(thinkspaces.id, activatedRevision.thinkspaceId)),
+		]);
+		return;
 	}
+
+	if (supersededRevision) {
+		await db.batch([
+			db
+				.update(thinkspaceAgentProfiles)
+				.set(serializeAgentProfileRevision(supersededRevision))
+				.where(eq(thinkspaceAgentProfiles.id, supersededRevision.id)),
+			activationUpdate,
+		]);
+		return;
+	}
+
+	if (thinkspaceActivationPatch) {
+		await db.batch([
+			activationUpdate,
+			db
+				.update(thinkspaces)
+				.set(thinkspaceActivationPatch)
+				.where(eq(thinkspaces.id, activatedRevision.thinkspaceId)),
+		]);
+		return;
+	}
+
+	await db.batch([activationUpdate]);
 };

--- a/packages/api/src/thinkspaces/lifecycle.test.ts
+++ b/packages/api/src/thinkspaces/lifecycle.test.ts
@@ -8,26 +8,23 @@ import {
 	ThinkspaceLifecycleValidationError,
 } from "./lifecycle";
 
-test("creates an active Thinkspace record around a trimmed Goal and reviewable configuration", () => {
+test("creates a draft Thinkspace record around a trimmed Goal and reviewable configuration", () => {
 	const record = createThinkspaceCreationRecord({
 		configurationSummary:
 			"  Review repository shape, sources, permissions, and expected artifact.  ",
 		goal: "  Prepare a dependency-aligned salvage plan  ",
 		id: "thinkspace_test",
-		initialInstructions: "  Start with the existing ADRs.  ",
 		ownerUserId: "user_123",
 	});
 
 	assert.equal(record.id, "thinkspace_test");
 	assert.equal(record.ownerUserId, "user_123");
 	assert.equal(record.goal, "Prepare a dependency-aligned salvage plan");
-	assert.equal(record.initialInstructions, "Start with the existing ADRs.");
 	assert.equal(
 		record.configurationSummary,
 		"Review repository shape, sources, permissions, and expected artifact.",
 	);
-	assert.equal(record.status, "active");
-	assert.equal(record.selectedSkillIds, "[]");
+	assert.equal(record.status, "draft");
 	assert.equal(record.enabledToolIds, "[]");
 	assert.equal(record.requestedPermissions, "[]");
 	assert.equal(

--- a/packages/api/src/thinkspaces/lifecycle.ts
+++ b/packages/api/src/thinkspaces/lifecycle.ts
@@ -2,7 +2,6 @@ import { THINKSPACE_STATUS } from "@better-agent/db/schema/thinkspaces";
 import type { NewThinkspace } from "@better-agent/db/schema/thinkspaces";
 
 const MAX_GOAL_LENGTH = 280;
-const MAX_INITIAL_INSTRUCTIONS_LENGTH = 4000;
 const MAX_CONFIGURATION_SUMMARY_LENGTH = 1600;
 
 export const THINKSPACE_CREATION_DEFAULTS = {
@@ -14,14 +13,12 @@ export const THINKSPACE_CREATION_DEFAULTS = {
 		retention: "user_reviewed",
 	},
 	requestedPermissions: [] as string[],
-	selectedSkillIds: [] as string[],
 } as const;
 
 export interface CreateThinkspaceLifecycleInput {
 	configurationSummary?: string | null;
 	goal: string;
 	id: string;
-	initialInstructions?: string | null;
 	ownerUserId: string;
 }
 
@@ -73,11 +70,9 @@ export const createThinkspaceCreationRecord = ({
 	configurationSummary,
 	goal,
 	id,
-	initialInstructions,
 	ownerUserId,
 }: CreateThinkspaceLifecycleInput): NewThinkspace => {
 	const normalizedGoal = normalizeText(goal);
-	const normalizedInstructions = normalizeText(initialInstructions);
 	const normalizedSummary = normalizeText(configurationSummary);
 
 	if (!ownerUserId) {
@@ -95,7 +90,6 @@ export const createThinkspaceCreationRecord = ({
 	}
 
 	assertMaxLength("Goal", normalizedGoal, MAX_GOAL_LENGTH);
-	assertMaxLength("Initial instructions", normalizedInstructions, MAX_INITIAL_INSTRUCTIONS_LENGTH);
 	assertMaxLength("Configuration summary", normalizedSummary, MAX_CONFIGURATION_SUMMARY_LENGTH);
 
 	return {
@@ -104,11 +98,9 @@ export const createThinkspaceCreationRecord = ({
 		enabledToolIds: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.enabledToolIds),
 		goal: normalizedGoal,
 		id,
-		initialInstructions: normalizedInstructions,
 		memoryGovernance: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.memoryGovernance),
 		ownerUserId,
 		requestedPermissions: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.requestedPermissions),
-		selectedSkillIds: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.selectedSkillIds),
-		status: THINKSPACE_STATUS.ACTIVE,
+		status: THINKSPACE_STATUS.DRAFT,
 	};
 };

--- a/packages/api/src/thinkspaces/repository.ts
+++ b/packages/api/src/thinkspaces/repository.ts
@@ -1,7 +1,11 @@
 import type { ProductDb } from "@better-agent/db";
+import { thinkspaceAgentProfiles } from "@better-agent/db/schema/agent-profiles";
 import { THINKSPACE_STATUS, thinkspaces } from "@better-agent/db/schema/thinkspaces";
 import type { Thinkspace, ThinkspaceStatus } from "@better-agent/db/schema/thinkspaces";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, ne } from "drizzle-orm";
+
+import { parseAgentProfileRevision, serializeAgentProfileRevision } from "./agent-profile";
+import type { DraftAgentProfileRevision } from "./agent-profile";
 
 export interface ListThinkspacesInput {
 	ownerUserId: string;
@@ -28,17 +32,37 @@ export interface CreateThinkspaceInput {
 	record: typeof thinkspaces.$inferInsert;
 }
 
-export const createThinkspace = async (
+export interface CreateThinkspaceWithAgentProfileDraftInput extends CreateThinkspaceInput {
+	draft: DraftAgentProfileRevision;
+}
+
+export const createThinkspaceWithAgentProfileDraft = async (
 	db: ProductDb,
-	{ record }: CreateThinkspaceInput,
-): Promise<Thinkspace> => {
-	const [created] = await db.insert(thinkspaces).values(record).returning();
+	{ draft, record }: CreateThinkspaceWithAgentProfileDraftInput,
+): Promise<{ draft: DraftAgentProfileRevision; thinkspace: Thinkspace }> => {
+	const draftRecord = serializeAgentProfileRevision(draft);
+	const [thinkspaceRows, draftRows] = await db.batch([
+		db.insert(thinkspaces).values(record).returning(),
+		db.insert(thinkspaceAgentProfiles).values(draftRecord).returning(),
+	]);
+	const [created] = thinkspaceRows;
+	const [savedDraft] = draftRows;
 
 	if (!created) {
 		throw new Error("Thinkspace was not persisted.");
 	}
 
-	return created;
+	if (!savedDraft) {
+		throw new Error("Agent Profile draft was not persisted.");
+	}
+
+	const savedRevision = parseAgentProfileRevision(savedDraft);
+
+	if (savedRevision.status !== "draft") {
+		throw new Error("Agent Profile draft persistence returned a non-draft revision.");
+	}
+
+	return { draft: savedRevision, thinkspace: created };
 };
 
 export const getThinkspace = async (
@@ -82,10 +106,17 @@ export const updateThinkspaceConfiguration = async (
 
 export const listThinkspaces = async (
 	db: ProductDb,
-	{ ownerUserId, status = THINKSPACE_STATUS.ACTIVE }: ListThinkspacesInput,
+	{ ownerUserId, status }: ListThinkspacesInput,
 ): Promise<Thinkspace[]> =>
 	await db
 		.select()
 		.from(thinkspaces)
-		.where(and(eq(thinkspaces.ownerUserId, ownerUserId), eq(thinkspaces.status, status)))
+		.where(
+			and(
+				eq(thinkspaces.ownerUserId, ownerUserId),
+				status
+					? eq(thinkspaces.status, status)
+					: ne(thinkspaces.status, THINKSPACE_STATUS.ARCHIVED),
+			),
+		)
 		.orderBy(desc(thinkspaces.updatedAt));

--- a/packages/api/src/thinkspaces/router.test.ts
+++ b/packages/api/src/thinkspaces/router.test.ts
@@ -16,6 +16,7 @@ import type { ThinkspaceTurnInspection } from "./inspect";
 import type { ThinkspaceTurnAcceptance } from "./turns";
 
 const OWNED_THINKSPACE_ID = "thinkspace_router";
+const NOW = new Date("2026-06-10T12:00:00.000Z");
 
 /**
  * A db that fails the test if any query is attempted. Used to prove that
@@ -44,11 +45,79 @@ const createDbReturning = (rows: Record<string, unknown>[]): ProductDb =>
 		}),
 	}) as unknown as ProductDb;
 
-const ownedThinkspaceRow = (): Record<string, unknown> => ({
-	enabledToolIds: "[]",
+const createDbForThinkspaceCreation = (settingsRows: Record<string, unknown>[] = []) => {
+	const inserted: Record<string, unknown>[] = [];
+	const db = {
+		batch: () =>
+			Promise.resolve([[{ ...inserted[0], createdAt: NOW, updatedAt: NOW }], [{ ...inserted[1] }]]),
+		insert: () => ({
+			values: (value: Record<string, unknown>) => {
+				inserted.push(value);
+				return { returning: () => ({ value }) };
+			},
+		}),
+		select: () => ({
+			from: () => ({
+				where: () => ({ limit: () => Promise.resolve(settingsRows) }),
+			}),
+		}),
+	};
+
+	return { db: db as unknown as ProductDb, inserted };
+};
+
+const createDbForAgentProfileActivation = (row: Record<string, unknown>) => {
+	const patches: Record<string, unknown>[] = [];
+	const db = {
+		batch: (statements: unknown[]) => Promise.resolve(statements.map(() => [])),
+		select: () => ({
+			from: () => ({
+				where: () => ({ limit: () => Promise.resolve([row]) }),
+			}),
+		}),
+		update: () => ({
+			set: (patch: Record<string, unknown>) => ({
+				where: () => {
+					patches.push(patch);
+					return { patch };
+				},
+			}),
+		}),
+	};
+
+	return { db: db as unknown as ProductDb, patches };
+};
+
+const ownedAgentProfileColumns = (status: "active" | "draft" = "active") => ({
+	activatedAt: status === "active" ? NOW : null,
+	createdAt: NOW,
+	displayName: "Release Monitor",
 	id: OWNED_THINKSPACE_ID,
+	instructions: "Watch SDK releases.",
+	modelId: "google:gemini-2.5-flash-lite",
+	reasoningLevel: "medium",
 	requestedPermissions: "[]",
-	status: "active",
+	routines: "[]",
+	skillReferences: "[]",
+	status,
+	supersededAt: null,
+	thinkspaceId: OWNED_THINKSPACE_ID,
+	toolEnablements: "[]",
+	updatedAt: NOW,
+	version: 1,
+});
+
+const ownedThinkspaceRow = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+	...ownedAgentProfileColumns(),
+	archivedAt: null,
+	configurationSummary: "Watch release notes and draft a handoff.",
+	enabledToolIds: "[]",
+	goal: "Monitor releases",
+	id: OWNED_THINKSPACE_ID,
+	memoryGovernance: "{}",
+	ownerUserId: "owner_user",
+	requestedPermissions: "[]",
+	...overrides,
 });
 
 const authenticatedSession = {
@@ -138,6 +207,105 @@ const expectCode =
 	(code: string) =>
 	(error: unknown): boolean =>
 		error instanceof ORPCError && error.code === code;
+
+test("creating a Thinkspace persists a draft Agent Profile revision seeded from settings", async () => {
+	const { db, inserted } = createDbForThinkspaceCreation([
+		{ defaultModel: "google:gemini-catalog-only", reasoningEffort: "high" },
+	]);
+	const context = createCallContext({ db });
+
+	const created = await call(
+		thinkspacesRouter.create,
+		{
+			configurationSummary: " Watch model catalog changes. ",
+			goal: " Monitor model catalog releases ",
+			initialInstructions: " Use release notes first. ",
+		},
+		{ context },
+	);
+
+	assert.ok(created);
+	assert.equal(created.status, "draft");
+	assert.equal(created.agentProfileRevision.status, "draft");
+	assert.equal(created.agentProfileRevision.identity.displayName, "Monitor model catalog releases");
+	assert.equal(created.agentProfileRevision.identity.instructions, "Use release notes first.");
+	assert.deepEqual(created.agentProfileRevision.modelBehavior, {
+		modelId: "google:gemini-catalog-only",
+		reasoningLevel: "high",
+	});
+	assert.equal(inserted[0]?.status, "draft");
+	assert.equal("initialInstructions" in (inserted[0] ?? {}), false);
+	assert.equal("selectedSkillIds" in (inserted[0] ?? {}), false);
+	assert.equal(inserted[1]?.status, "draft");
+});
+
+test("creating a Thinkspace rejects models outside the catalog before persistence", async () => {
+	const { db, inserted } = createDbForThinkspaceCreation([
+		{ defaultModel: "google:not-real", reasoningEffort: "medium" },
+	]);
+
+	await assert.rejects(
+		call(
+			thinkspacesRouter.create,
+			{
+				configurationSummary: "Track unsupported models.",
+				goal: "Track unsupported models",
+			},
+			{ context: createCallContext({ db }) },
+		),
+		expectCode("BAD_REQUEST"),
+	);
+	assert.equal(inserted.length, 0);
+});
+
+test("owners can activate the draft Agent Profile revision and draft Thinkspace together", async () => {
+	const { db, patches } = createDbForAgentProfileActivation(
+		ownedThinkspaceRow({ ...ownedAgentProfileColumns("draft"), status: "draft" }),
+	);
+	const context = createCallContext({ db });
+
+	const activation = await call(
+		thinkspacesRouter.activateAgentProfile,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context },
+	);
+
+	assert.ok(activation);
+	assert.equal(activation.activatedRevision.status, "active");
+	assert.equal(activation.thinkspaceStatus, "active");
+	assert.ok(patches.some((patch) => patch.status === "active" && patch.version === 1));
+	assert.ok(patches.some((patch) => patch.status === "active" && !("version" in patch)));
+});
+
+test("Agent Profile activation rejects archived Thinkspaces before writes", async () => {
+	const { db, patches } = createDbForAgentProfileActivation(
+		ownedThinkspaceRow({ status: "archived" }),
+	);
+
+	await assert.rejects(
+		call(
+			thinkspacesRouter.activateAgentProfile,
+			{ thinkspaceId: OWNED_THINKSPACE_ID },
+			{ context: createCallContext({ db }) },
+		),
+		expectCode("BAD_REQUEST"),
+	);
+	assert.deepEqual(patches, []);
+});
+
+test("Agent Profile activation rejects Thinkspaces without a draft revision", async () => {
+	const { db, patches } = createDbForAgentProfileActivation(ownedThinkspaceRow());
+
+	await assert.rejects(
+		call(
+			thinkspacesRouter.activateAgentProfile,
+			{ thinkspaceId: OWNED_THINKSPACE_ID },
+			{ context: createCallContext({ db }) },
+		),
+		expectCode("BAD_REQUEST"),
+	);
+	assert.deepEqual(patches, []);
+});
 
 test("unauthenticated requests cannot reach any Thinkspace runtime operation", async () => {
 	for (const operation of runtimeOperations) {
@@ -393,5 +561,6 @@ test("Thinkspace control-plane reads still work for owners", async () => {
 	const listed = await call(thinkspacesRouter.list, undefined, { context });
 
 	assert.equal(thinkspace.id, OWNED_THINKSPACE_ID);
+	assert.equal(thinkspace.agentProfileRevision?.identity.instructions, "Watch SDK releases.");
 	assert.equal(listed.length, 1);
 });

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -1,11 +1,32 @@
 import { ORPCError } from "@orpc/server";
 import { z } from "zod";
 
+import { DEFAULT_MODEL_ID } from "../models/catalog";
+import { ModelCatalogError, validateCatalogModelId } from "../models/model-catalog";
 import {
 	getOwnedThinkspaceModelReadiness,
+	getUserProductModelSettings,
 	ThinkspaceTurnModelUnavailableError,
 } from "../models/readiness";
 import { protectedProcedure } from "../procedures";
+import {
+	AgentProfileValidationError,
+	AGENT_PROFILE_DISPLAY_NAME_MAX_LENGTH,
+	isAgentProfileReasoningLevel,
+	validateAgentProfileIdentity,
+	validateAgentProfileModelBehavior,
+} from "./agent-profile";
+import {
+	AgentProfileLifecycleError,
+	createAgentProfileActivation,
+	createInitialAgentProfileDraft,
+} from "./agent-profile-lifecycle";
+import {
+	applyAgentProfileActivation,
+	getActiveAgentProfileRevision,
+	getCurrentAgentProfileRevision,
+	getDraftAgentProfileRevision,
+} from "./agent-profile-repository";
 import { inspectOwnedThinkspaceTurn, THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH } from "./inspect";
 import {
 	createToolPermissionPlaceholder,
@@ -19,7 +40,7 @@ import {
 } from "./lifecycle";
 import {
 	archiveThinkspace,
-	createThinkspace,
+	createThinkspaceWithAgentProfileDraft,
 	getThinkspace,
 	listThinkspaces,
 	updateThinkspaceConfiguration,
@@ -69,6 +90,30 @@ const submitTurnInput = z.object({
 });
 
 const createThinkspaceId = (): string => `thinkspace_${crypto.randomUUID()}`;
+const createAgentProfileRevisionId = (): string => `agent_profile_revision_${crypto.randomUUID()}`;
+
+const deriveAgentProfileDisplayName = (goal: string): string => {
+	const normalized = goal.trim();
+
+	if (normalized.length <= AGENT_PROFILE_DISPLAY_NAME_MAX_LENGTH) {
+		return normalized;
+	}
+
+	return `${normalized.slice(0, AGENT_PROFILE_DISPLAY_NAME_MAX_LENGTH - 1).trimEnd()}…`;
+};
+
+const getSeedReasoningLevel = (input: {
+	catalogEntryReasoning: string;
+	reasoningEffort: string | null | undefined;
+}) => {
+	if (input.catalogEntryReasoning === "none") {
+		return "none";
+	}
+
+	return isAgentProfileReasoningLevel(input.reasoningEffort) && input.reasoningEffort !== "none"
+		? input.reasoningEffort
+		: "medium";
+};
 
 /**
  * Runtime resolution failures (missing/misconfigured Durable Object binding)
@@ -78,9 +123,14 @@ const createThinkspaceId = (): string => `thinkspace_${crypto.randomUUID()}`;
 const RUNTIME_UNAVAILABLE_MESSAGE =
 	"The Thinkspace Agent runtime is not available right now. Try again shortly.";
 
-const toBadRequest = (
-	error: ThinkspaceLifecycleValidationError,
-): ORPCError<"BAD_REQUEST", undefined> => new ORPCError("BAD_REQUEST", { message: error.message });
+const toBadRequest = (error: Error): ORPCError<"BAD_REQUEST", undefined> =>
+	new ORPCError("BAD_REQUEST", { message: error.message });
+
+const toCatalogUnavailable = (): ORPCError<"INTERNAL_SERVER_ERROR", undefined> =>
+	new ORPCError("INTERNAL_SERVER_ERROR", {
+		message:
+			"The model catalog is temporarily unavailable, so the Agent Profile draft could not be validated. Try again shortly.",
+	});
 
 const toRuntimeUnavailable = (): ORPCError<"INTERNAL_SERVER_ERROR", undefined> =>
 	new ORPCError("INTERNAL_SERVER_ERROR", { message: RUNTIME_UNAVAILABLE_MESSAGE });
@@ -88,7 +138,75 @@ const toRuntimeUnavailable = (): ORPCError<"INTERNAL_SERVER_ERROR", undefined> =
 const toNotFound = (): ORPCError<"NOT_FOUND", undefined> =>
 	new ORPCError("NOT_FOUND", { message: "Thinkspace was not found." });
 
+const throwProductSafeProfileError = (error: unknown): never => {
+	if (
+		error instanceof ThinkspaceLifecycleValidationError ||
+		error instanceof AgentProfileLifecycleError ||
+		error instanceof AgentProfileValidationError
+	) {
+		throw toBadRequest(error);
+	}
+
+	if (error instanceof ModelCatalogError) {
+		if (error.kind === "catalog_unavailable") {
+			throw toCatalogUnavailable();
+		}
+
+		throw toBadRequest(error);
+	}
+
+	throw error;
+};
+
 export const thinkspacesRouter = {
+	activateAgentProfile: protectedProcedure
+		.input(thinkspaceIdInput)
+		.handler(async ({ context, input }) => {
+			const thinkspace = await getThinkspace(context.db, {
+				ownerUserId: context.session.user.id,
+				thinkspaceId: input.thinkspaceId,
+			});
+
+			if (!thinkspace) {
+				throw toNotFound();
+			}
+
+			if (thinkspace.status === "archived") {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Archived Thinkspaces cannot activate Agent Profile revisions.",
+				});
+			}
+
+			try {
+				const draft = await getDraftAgentProfileRevision(context.db, {
+					thinkspaceId: thinkspace.id,
+				});
+
+				if (!draft) {
+					throw new AgentProfileLifecycleError(
+						"No draft Agent Profile revision is ready to activate.",
+					);
+				}
+
+				const activation = createAgentProfileActivation({
+					currentActive: await getActiveAgentProfileRevision(context.db, {
+						thinkspaceId: thinkspace.id,
+					}),
+					draft,
+					thinkspace,
+				});
+
+				await applyAgentProfileActivation(context.db, { activation });
+
+				return {
+					activatedRevision: activation.activatedRevision,
+					thinkspaceId: thinkspace.id,
+					thinkspaceStatus: activation.thinkspaceActivationPatch?.status ?? thinkspace.status,
+				};
+			} catch (error) {
+				throwProductSafeProfileError(error);
+			}
+		}),
 	archive: protectedProcedure.input(thinkspaceIdInput).handler(async ({ context, input }) => {
 		const thinkspace = await getThinkspace(context.db, {
 			ownerUserId: context.session.user.id,
@@ -125,17 +243,34 @@ export const thinkspacesRouter = {
 				configurationSummary: input.configurationSummary,
 				goal: input.goal,
 				id: createThinkspaceId(),
-				initialInstructions: input.initialInstructions,
 				ownerUserId: context.session.user.id,
 			});
+			const identity = validateAgentProfileIdentity({
+				displayName: deriveAgentProfileDisplayName(record.goal),
+				instructions: input.initialInstructions ?? "",
+			});
+			const settings = await getUserProductModelSettings(context.db, context.session.user.id);
+			const requestedModelId = settings?.defaultModel?.trim() || DEFAULT_MODEL_ID;
+			const { entry } = await validateCatalogModelId(context.modelCatalog, requestedModelId);
+			const modelBehavior = validateAgentProfileModelBehavior({
+				catalogEntry: entry,
+				modelId: requestedModelId,
+				reasoningLevel: getSeedReasoningLevel({
+					catalogEntryReasoning: entry.reasoning,
+					reasoningEffort: settings?.reasoningEffort,
+				}),
+			});
+			const draft = createInitialAgentProfileDraft({
+				id: createAgentProfileRevisionId(),
+				identity,
+				modelBehavior,
+				thinkspaceId: record.id,
+			});
+			const created = await createThinkspaceWithAgentProfileDraft(context.db, { draft, record });
 
-			return await createThinkspace(context.db, { record });
+			return { ...created.thinkspace, agentProfileRevision: created.draft };
 		} catch (error) {
-			if (error instanceof ThinkspaceLifecycleValidationError) {
-				throw toBadRequest(error);
-			}
-
-			throw error;
+			throwProductSafeProfileError(error);
 		}
 	}),
 	get: protectedProcedure.input(thinkspaceIdInput).handler(async ({ context, input }) => {
@@ -148,7 +283,12 @@ export const thinkspacesRouter = {
 			throw toNotFound();
 		}
 
-		return thinkspace;
+		return {
+			...thinkspace,
+			agentProfileRevision: await getCurrentAgentProfileRevision(context.db, {
+				thinkspaceId: thinkspace.id,
+			}),
+		};
 	}),
 	inspectTurn: protectedProcedure.input(inspectTurnInput).handler(async ({ context, input }) => {
 		try {

--- a/packages/db/src/migrations/0004_quick_thunderbird.sql
+++ b/packages/db/src/migrations/0004_quick_thunderbird.sql
@@ -1,0 +1,24 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_thinkspaces` (
+	`approval_defaults` text DEFAULT '{}' NOT NULL,
+	`archived_at` integer,
+	`configuration_summary` text DEFAULT '' NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`enabled_tool_ids` text DEFAULT '[]' NOT NULL,
+	`goal` text NOT NULL,
+	`id` text PRIMARY KEY NOT NULL,
+	`memory_governance` text DEFAULT '{}' NOT NULL,
+	`owner_user_id` text NOT NULL,
+	`requested_permissions` text DEFAULT '[]' NOT NULL,
+	`status` text DEFAULT 'draft' NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`owner_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_thinkspaces`("approval_defaults", "archived_at", "configuration_summary", "created_at", "enabled_tool_ids", "goal", "id", "memory_governance", "owner_user_id", "requested_permissions", "status", "updated_at") SELECT "approval_defaults", "archived_at", "configuration_summary", "created_at", "enabled_tool_ids", "goal", "id", "memory_governance", "owner_user_id", "requested_permissions", "status", "updated_at" FROM `thinkspaces`;--> statement-breakpoint
+DROP TABLE `thinkspaces`;--> statement-breakpoint
+ALTER TABLE `__new_thinkspaces` RENAME TO `thinkspaces`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `idx_thinkspaces_owner_status_updated` ON `thinkspaces` (`owner_user_id`,`status`,`updated_at`);--> statement-breakpoint
+CREATE INDEX `idx_thinkspaces_owner_created` ON `thinkspaces` (`owner_user_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_thinkspaces_owner_archived` ON `thinkspaces` (`owner_user_id`,`archived_at`);

--- a/packages/db/src/migrations/meta/0004_snapshot.json
+++ b/packages/db/src/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1095 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "dd37e392-9940-4e0e-bb1e-14fe6b2b7c76",
+  "prevId": "2f862a2e-f11c-4f59-8690-e190f151529b",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_account_provider_account": {
+          "name": "idx_account_provider_account",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_server_catalog": {
+      "name": "mcp_server_catalog",
+      "columns": {
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'streamable_http'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_agent_profiles": {
+      "name": "thinkspace_agent_profiles",
+      "columns": {
+        "activated_at": {
+          "name": "activated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_permissions": {
+          "name": "requested_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "routines": {
+          "name": "routines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "skill_references": {
+          "name": "skill_references",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_enablements": {
+          "name": "tool_enablements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_agent_profiles_thinkspace_version": {
+          "name": "uq_agent_profiles_thinkspace_version",
+          "columns": [
+            "thinkspace_id",
+            "version"
+          ],
+          "isUnique": true
+        },
+        "uq_agent_profiles_thinkspace_active": {
+          "name": "uq_agent_profiles_thinkspace_active",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'active'"
+        },
+        "uq_agent_profiles_thinkspace_draft": {
+          "name": "uq_agent_profiles_thinkspace_draft",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'draft'"
+        },
+        "idx_agent_profiles_thinkspace_status": {
+          "name": "idx_agent_profiles_thinkspace_status",
+          "columns": [
+            "thinkspace_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_agent_profiles_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_agent_profiles_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_agent_profiles",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspaces": {
+      "name": "thinkspaces",
+      "columns": {
+        "approval_defaults": {
+          "name": "approval_defaults",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration_summary": {
+          "name": "configuration_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "enabled_tool_ids": {
+          "name": "enabled_tool_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memory_governance": {
+          "name": "memory_governance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_permissions": {
+          "name": "requested_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_thinkspaces_owner_status_updated": {
+          "name": "idx_thinkspaces_owner_status_updated",
+          "columns": [
+            "owner_user_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "idx_thinkspaces_owner_created": {
+          "name": "idx_thinkspaces_owner_created",
+          "columns": [
+            "owner_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_thinkspaces_owner_archived": {
+          "name": "idx_thinkspaces_owner_archived",
+          "columns": [
+            "owner_user_id",
+            "archived_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thinkspaces_owner_user_id_user_id_fk": {
+          "name": "thinkspaces_owner_user_id_user_id_fk",
+          "tableFrom": "thinkspaces",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_mcp_connections": {
+      "name": "user_mcp_connections",
+      "columns": {
+        "catalog_visible": {
+          "name": "catalog_visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_headers": {
+          "name": "encrypted_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'streamable_http'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_mcp_connections_user": {
+          "name": "idx_user_mcp_connections_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_mcp_connections_server": {
+          "name": "idx_user_mcp_connections_server",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_mcp_connections_server_id_mcp_server_catalog_id_fk": {
+          "name": "user_mcp_connections_server_id_mcp_server_catalog_id_fk",
+          "tableFrom": "user_mcp_connections",
+          "tableTo": "mcp_server_catalog",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_mcp_connections_user_id_user_id_fk": {
+          "name": "user_mcp_connections_user_id_user_id_fk",
+          "tableFrom": "user_mcp_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_product_settings": {
+      "name": "user_product_settings",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_product_settings_user_id_user_id_fk": {
+          "name": "user_product_settings_user_id_user_id_fk",
+          "tableFrom": "user_product_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_provider_credentials": {
+      "name": "user_provider_credentials",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_provider_credentials_user": {
+          "name": "idx_user_provider_credentials_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_provider_credentials_user_provider": {
+          "name": "idx_user_provider_credentials_user_provider",
+          "columns": [
+            "user_id",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_provider_credentials_user_id_user_id_fk": {
+          "name": "user_provider_credentials_user_id_user_id_fk",
+          "tableFrom": "user_provider_credentials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        },
+        "idx_verification_expires_at": {
+          "name": "idx_verification_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1781129074166,
       "tag": "0003_hard_archangel",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1781139208245,
+      "tag": "0004_quick_thunderbird",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/thinkspaces.ts
+++ b/packages/db/src/schema/thinkspaces.ts
@@ -39,11 +39,6 @@ export const thinkspaces = sqliteTable(
 		enabledToolIds: text("enabled_tool_ids").default("[]").notNull(),
 		goal: text("goal").notNull(),
 		id: text("id").primaryKey(),
-		/**
-		 * @deprecated Legacy curation config. Agent instructions are owned by
-		 * the Agent Profile revision in `thinkspace_agent_profiles` (ADR-0007).
-		 */
-		initialInstructions: text("initial_instructions").default("").notNull(),
 		memoryGovernance: text("memory_governance").default("{}").notNull(),
 		ownerUserId: text("owner_user_id")
 			.notNull()
@@ -55,13 +50,7 @@ export const thinkspaces = sqliteTable(
 		 * Permission storage (ADR-0007).
 		 */
 		requestedPermissions: text("requested_permissions").default("[]").notNull(),
-		/**
-		 * @deprecated Legacy curation config. Skill references are migrating to
-		 * versioned Agent Profile revisions in `thinkspace_agent_profiles`
-		 * (ADR-0007).
-		 */
-		selectedSkillIds: text("selected_skill_ids").default("[]").notNull(),
-		status: text("status").default(THINKSPACE_STATUS.ACTIVE).notNull(),
+		status: text("status").default(THINKSPACE_STATUS.DRAFT).notNull(),
 		updatedAt: integer("updated_at", { mode: "timestamp_ms" })
 			.default(timestampMsNow)
 			.$onUpdate(() => new Date())


### PR DESCRIPTION
## Problem / Intent

Implements #50. Thinkspace creation needs to enter the Agent Profile lifecycle instead of storing Profile-owned instructions and skill placeholders on the Thinkspace row.

## Approach

Create a draft Thinkspace together with Agent Profile revision v1 using settings-seeded, catalog-validated model behavior; add owner-scoped activation that batches revision activation with first Thinkspace activation; and have the detail surface render and activate the current revision while the migration retires the legacy columns.
