### PR TITLE
Add account settings for Agent Profile model defaults

### DIFF
--- a/apps/web/src/routes/settings.product.tsx
+++ b/apps/web/src/routes/settings.product.tsx
@@ -16,14 +16,32 @@ const PROVIDER_LABELS = {
 	openai: "OpenAI",
 } as const;
 
+const REASONING_EFFORTS = ["low", "medium", "high"] as const;
+
 const RouteComponent = () => {
 	const context = routeApi.useRouteContext();
 	const queryClient = useQueryClient();
 	const catalogQuery = useSuspenseQuery(context.orpc.models.listAvailable.queryOptions());
 	const credentialsQuery = useSuspenseQuery(context.orpc.models.listCredentials.queryOptions());
+	const defaultsQuery = useSuspenseQuery(context.orpc.models.getDefaults.queryOptions());
+	const [defaultModel, setDefaultModel] = useState(defaultsQuery.data.defaultModel);
+	const [defaultReasoningEffort, setDefaultReasoningEffort] = useState(
+		defaultsQuery.data.reasoningEffort,
+	);
 	const [providerId, setProviderId] = useState<keyof typeof PROVIDER_LABELS>("openai");
 	const [credential, setCredential] = useState("");
 	const [label, setLabel] = useState("");
+	const saveDefaults = useMutation(
+		context.orpc.models.updateDefaults.mutationOptions({
+			onSuccess: async (settings) => {
+				setDefaultModel(settings.defaultModel);
+				setDefaultReasoningEffort(settings.reasoningEffort);
+				await queryClient.invalidateQueries({
+					queryKey: context.orpc.models.getDefaults.queryKey(),
+				});
+			},
+		}),
+	);
 	const saveCredential = useMutation(
 		context.orpc.models.saveCredential.mutationOptions({
 			onSuccess: async () => {
@@ -38,6 +56,18 @@ const RouteComponent = () => {
 			},
 		}),
 	);
+
+	const defaultsChanged =
+		defaultModel !== defaultsQuery.data.defaultModel ||
+		defaultReasoningEffort !== defaultsQuery.data.reasoningEffort;
+
+	const handleDefaultsSubmit = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (!(defaultModel && defaultsChanged) || saveDefaults.isPending) {
+			return;
+		}
+		saveDefaults.mutate({ defaultModel, reasoningEffort: defaultReasoningEffort });
+	};
 
 	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
@@ -56,6 +86,69 @@ const RouteComponent = () => {
 					before using any resource configured here.
 				</p>
 			</div>
+
+			<section aria-labelledby="model-defaults-heading" className="grid gap-4">
+				<div className="grid gap-1">
+					<h3 className="text-sm font-medium" id="model-defaults-heading">
+						Default Agent Profile model behavior
+					</h3>
+					<p className="text-muted-foreground text-sm">
+						These defaults seed newly created Agent Profile drafts. Existing Thinkspaces keep
+						running under their active revision.
+					</p>
+				</div>
+				<form
+					className="grid max-w-xl gap-4 border border-border p-4"
+					onSubmit={handleDefaultsSubmit}
+				>
+					<div className="grid gap-1.5">
+						<Label htmlFor="default-model">Default model</Label>
+						<select
+							className="h-8 w-full border border-input bg-transparent px-2.5 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 dark:bg-input/30"
+							id="default-model"
+							onChange={(event) => setDefaultModel(event.target.value)}
+							value={defaultModel}
+						>
+							{catalogQuery.data.map((model) => (
+								<option key={model.id} value={model.id}>
+									{model.name} · {model.providerName} · {model.id}
+								</option>
+							))}
+						</select>
+					</div>
+					<div className="grid gap-1.5">
+						<Label htmlFor="default-reasoning-effort">Reasoning effort</Label>
+						<select
+							className="h-8 w-full border border-input bg-transparent px-2.5 text-sm capitalize outline-none transition-colors focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 dark:bg-input/30"
+							id="default-reasoning-effort"
+							onChange={(event) =>
+								setDefaultReasoningEffort(event.target.value as (typeof REASONING_EFFORTS)[number])
+							}
+							value={defaultReasoningEffort}
+						>
+							{REASONING_EFFORTS.map((effort) => (
+								<option key={effort} value={effort}>
+									{effort}
+								</option>
+							))}
+						</select>
+					</div>
+					{saveDefaults.error ? (
+						<p className="text-destructive text-sm" role="alert">
+							{saveDefaults.error.message}
+						</p>
+					) : null}
+					<Button
+						className="w-fit"
+						disabled={!defaultsChanged || saveDefaults.isPending}
+						type="submit"
+					>
+						{saveDefaults.isPending ? "Saving…" : "Save defaults"}
+					</Button>
+				</form>
+			</section>
+
+			<Separator />
 
 			<section aria-labelledby="model-catalog-heading" className="grid gap-4">
 				<div className="grid gap-1">

--- a/packages/api/src/models/router.test.ts
+++ b/packages/api/src/models/router.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+import { ORPCError, call } from "@orpc/server";
+
+import type { Context } from "../context";
+import { getModelCatalog } from "./catalog";
+import { createMemoryModelCatalog, ModelCatalogError } from "./model-catalog";
+import type { ModelCatalog } from "./model-catalog";
+import { modelsRouter } from "./router";
+
+const authenticatedSession = {
+	session: { id: "session_1" },
+	user: { id: "owner_user" },
+};
+
+const modelCatalog = createMemoryModelCatalog(getModelCatalog());
+
+const unavailableCatalog: ModelCatalog = {
+	getModel: () =>
+		Promise.reject(new ModelCatalogError("catalog_unavailable", "both sources unavailable")),
+	listModels: () =>
+		Promise.reject(new ModelCatalogError("catalog_unavailable", "both sources unavailable")),
+	sourceId: "models_dev",
+};
+
+const createCallContext = ({
+	db,
+	catalog = modelCatalog,
+}: {
+	catalog?: ModelCatalog;
+	db: ProductDb;
+}): Context =>
+	({
+		db,
+		env: {},
+		executionCtx: undefined,
+		headers: new Headers(),
+		modelCatalog: catalog,
+		session: authenticatedSession,
+	}) as unknown as Context;
+
+const createDbForDefaults = (rows: Record<string, unknown>[] = []) => {
+	const inserted: Record<string, unknown>[] = [];
+	const updated: Record<string, unknown>[] = [];
+	const db = {
+		insert: () => ({
+			values: (value: Record<string, unknown>) => {
+				inserted.push(value);
+				return {
+					onConflictDoUpdate: ({ set }: { set: Record<string, unknown> }) => {
+						updated.push(set);
+						return Promise.resolve();
+					},
+				};
+			},
+		}),
+		select: () => ({
+			from: () => ({
+				where: () => ({ limit: () => Promise.resolve(rows) }),
+			}),
+		}),
+	};
+
+	return { db: db as unknown as ProductDb, inserted, updated };
+};
+
+const expectCode =
+	(code: string) =>
+	(error: unknown): boolean =>
+		error instanceof ORPCError && error.code === code;
+
+test("reads saved model defaults with fallback values", async () => {
+	const { db } = createDbForDefaults([{ defaultModel: "openai:gpt-4.1", reasoningEffort: "high" }]);
+	const settings = await call(modelsRouter.getDefaults, undefined, {
+		context: createCallContext({ db }),
+	});
+
+	assert.equal(settings.defaultModel, "openai:gpt-4.1");
+	assert.equal(settings.reasoningEffort, "high");
+});
+
+test("updates model defaults only for catalog models", async () => {
+	const { db, inserted, updated } = createDbForDefaults();
+	const settings = await call(
+		modelsRouter.updateDefaults,
+		{ defaultModel: "google:gemini-2.5-flash-lite", reasoningEffort: "low" },
+		{ context: createCallContext({ db }) },
+	);
+
+	assert.equal(settings.defaultModel, "google:gemini-2.5-flash-lite");
+	assert.equal(settings.reasoningEffort, "low");
+	assert.equal(inserted[0]?.userId, "owner_user");
+	assert.equal(inserted[0]?.defaultModel, "google:gemini-2.5-flash-lite");
+	assert.equal(inserted[0]?.reasoningEffort, "low");
+	assert.equal(updated[0]?.defaultModel, "google:gemini-2.5-flash-lite");
+});
+
+test("rejects unknown default model ids", async () => {
+	const { db, inserted } = createDbForDefaults();
+	await assert.rejects(
+		call(
+			modelsRouter.updateDefaults,
+			{ defaultModel: "google:not-real", reasoningEffort: "medium" },
+			{ context: createCallContext({ db }) },
+		),
+		expectCode("BAD_REQUEST"),
+	);
+	assert.equal(inserted.length, 0);
+});
+
+test("default update fails safely when the model catalog is unavailable", async () => {
+	const { db, inserted } = createDbForDefaults();
+	await assert.rejects(
+		call(
+			modelsRouter.updateDefaults,
+			{ defaultModel: "google:gemini-2.5-flash-lite", reasoningEffort: "medium" },
+			{ context: createCallContext({ catalog: unavailableCatalog, db }) },
+		),
+		expectCode("SERVICE_UNAVAILABLE"),
+	);
+	assert.equal(inserted.length, 0);
+});

--- a/packages/api/src/models/router.ts
+++ b/packages/api/src/models/router.ts
@@ -1,8 +1,12 @@
+import type { ProductDb } from "@better-agent/db";
+import { userProductSettings } from "@better-agent/db/schema/settings";
 import { ORPCError } from "@orpc/server";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { protectedProcedure, publicProcedure } from "../procedures";
-import { MODEL_PROVIDER_IDS } from "./catalog";
+import { DEFAULT_MODEL_ID, MODEL_PROVIDER_IDS } from "./catalog";
+import { ModelCatalogError } from "./model-catalog";
 import {
 	encryptCredential,
 	getCredentialMap,
@@ -11,6 +15,8 @@ import {
 	upsertProviderCredential,
 } from "./credentials";
 
+const REASONING_EFFORTS = ["low", "medium", "high"] as const;
+
 const providerIdSchema = z.enum(MODEL_PROVIDER_IDS);
 const saveCredentialInput = z.object({
 	credential: z.string().trim().min(8),
@@ -18,10 +24,47 @@ const saveCredentialInput = z.object({
 	providerId: providerIdSchema,
 });
 
+const updateDefaultsInput = z.object({
+	defaultModel: z.string().trim().min(1),
+	reasoningEffort: z.enum(REASONING_EFFORTS),
+});
+
 const encryptionSecret = (env: { API_ENCRYPTION_KEY?: string; BETTER_AUTH_SECRET: string }) =>
 	env.API_ENCRYPTION_KEY ?? env.BETTER_AUTH_SECRET;
 
+const catalogUnavailableError = () =>
+	new ORPCError("SERVICE_UNAVAILABLE", {
+		message: "The model catalog is temporarily unavailable. Try again shortly.",
+	});
+
+const isReasoningEffort = (
+	value: string | null | undefined,
+): value is (typeof REASONING_EFFORTS)[number] =>
+	typeof value === "string" &&
+	REASONING_EFFORTS.includes(value as (typeof REASONING_EFFORTS)[number]);
+
+const getUserModelDefaults = async (db: ProductDb, userId: string) => {
+	const [settings] = await db
+		.select({
+			defaultModel: userProductSettings.defaultModel,
+			reasoningEffort: userProductSettings.reasoningEffort,
+		})
+		.from(userProductSettings)
+		.where(eq(userProductSettings.userId, userId))
+		.limit(1);
+
+	return {
+		defaultModel: settings?.defaultModel ?? DEFAULT_MODEL_ID,
+		reasoningEffort: isReasoningEffort(settings?.reasoningEffort)
+			? settings.reasoningEffort
+			: "medium",
+	};
+};
+
 export const modelsRouter = {
+	getDefaults: protectedProcedure.handler(
+		async ({ context }) => await getUserModelDefaults(context.db, context.session.user.id),
+	),
 	list: publicProcedure.handler(async ({ context }) => await context.modelCatalog.listModels()),
 	listAvailable: protectedProcedure.handler(async ({ context }) => {
 		const [models, credentials] = await Promise.all([
@@ -71,5 +114,47 @@ export const modelsRouter = {
 					message: error instanceof Error ? error.message : "Credential could not be saved.",
 				});
 			}
+		}),
+	updateDefaults: protectedProcedure
+		.input(updateDefaultsInput)
+		.handler(async ({ context, input }) => {
+			let model = null;
+			try {
+				model = await context.modelCatalog.getModel(input.defaultModel);
+			} catch (error) {
+				if (error instanceof ModelCatalogError) {
+					throw catalogUnavailableError();
+				}
+				throw error;
+			}
+
+			if (!model) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Choose a model from the supported model catalog.",
+				});
+			}
+
+			const updatedAt = new Date();
+			await context.db
+				.insert(userProductSettings)
+				.values({
+					defaultModel: model.id,
+					reasoningEffort: input.reasoningEffort,
+					updatedAt,
+					userId: context.session.user.id,
+				})
+				.onConflictDoUpdate({
+					set: {
+						defaultModel: model.id,
+						reasoningEffort: input.reasoningEffort,
+						updatedAt,
+					},
+					target: userProductSettings.userId,
+				});
+
+			return {
+				defaultModel: model.id,
+				reasoningEffort: input.reasoningEffort,
+			};
 		}),
 };


### PR DESCRIPTION
## Summary
- Add protected model-defaults endpoints for reading/updating user_product_settings.defaultModel and reasoningEffort.
- Validate default model updates against the injected Model Catalog with product-safe errors for unknown models/catalog unavailability.
- Add a Product settings form to choose the default catalog model and reasoning effort used by new Agent Profile drafts.

Closes #52

## Validation
- bun test packages
- bun run check-types
- bun x ultracite check 'packages/api/src/models/router.ts' 'packages/api/src/models/router.test.ts' 'apps/web/src/routes/settings.product.tsx'
- bun run build