### PR TITLE
Move tool enablement onto Agent Profile revisions

### DIFF
--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -51,17 +51,16 @@ interface AgentProfileRevisionView {
 		modelId: string;
 		reasoningLevel: string;
 	};
+	requestedPermissions?: PermissionPlaceholder[];
 	status: "active" | "draft" | "superseded";
+	toolEnablements: { source: string; toolId: string }[];
 	version: number;
 }
 
-const parseJsonArray = <T,>(value: string): T[] => {
-	try {
-		const parsed = JSON.parse(value) as unknown;
-		return Array.isArray(parsed) ? (parsed as T[]) : [];
-	} catch {
-		return [];
-	}
+const toEnabledToolSelection = (enablement: { toolId: string }): EnabledToolSelection => {
+	const [serverId, toolName] = enablement.toolId.split(":", 2);
+
+	return { risk: "unknown", serverId: serverId ?? enablement.toolId, toolName };
 };
 
 type TurnInspectionStatus = "accepted" | "completed" | "failed" | "running" | "unknown";
@@ -431,10 +430,8 @@ const RouteComponent = () => {
 	const profileRevision = thinkspace.agentProfileRevision;
 	const isArchived = thinkspace.status === "archived";
 	const isDraft = thinkspace.status === "draft";
-	const enabledTools = parseJsonArray<EnabledToolSelection>(thinkspace.enabledToolIds);
-	const requestedPermissions = parseJsonArray<PermissionPlaceholder>(
-		thinkspace.requestedPermissions,
-	);
+	const enabledTools = profileRevision?.toolEnablements.map(toEnabledToolSelection) ?? [];
+	const requestedPermissions = profileRevision?.requestedPermissions ?? [];
 
 	const toggleCatalogTool = (serverId: string, risk: "read_only" | "mutating" | "unknown") => {
 		const selected = enabledTools.some((tool) => tool.serverId === serverId);
@@ -575,11 +572,15 @@ const RouteComponent = () => {
 
 			<section aria-labelledby="tools-heading" className="grid gap-4">
 				<div className="grid gap-1">
-					<h2 className="text-lg font-semibold tracking-tight" id="tools-heading">
-						Tools
-					</h2>
+					<div className="flex items-center gap-2">
+						<h2 className="text-lg font-semibold tracking-tight" id="tools-heading">
+							Tools
+						</h2>
+						{profileRevision ? <Badge variant="outline">{profileRevision.status}</Badge> : null}
+					</div>
 					<p className="text-muted-foreground text-sm">
-						Select catalog tools for this Thinkspace. A Permission is required before execution.
+						Select catalog tools on the Agent Profile revision. Draft selections take effect after
+						activation; active selections are used for turns.
 					</p>
 				</div>
 				{mcpCatalogQuery.data.length === 0 ? (

--- a/packages/api/src/thinkspaces/agent-profile-lifecycle.test.ts
+++ b/packages/api/src/thinkspaces/agent-profile-lifecycle.test.ts
@@ -82,6 +82,23 @@ test("activating a newer draft supersedes the active revision", () => {
 	assert.equal(second.thinkspaceActivationPatch, null);
 });
 
+test("draft tool enablements become active only after activation", () => {
+	const draft = {
+		...createDraft(),
+		toolEnablements: [{ source: "mcp_server" as const, toolId: "github:create_issue" }],
+	};
+
+	const activation = createAgentProfileActivation({
+		currentActive: null,
+		draft,
+		thinkspace: { id: "thinkspace_1", status: THINKSPACE_STATUS.DRAFT },
+	});
+
+	assert.deepEqual(activation.activatedRevision.toolEnablements, [
+		{ source: "mcp_server", toolId: "github:create_issue" },
+	]);
+});
+
 test("archived Thinkspaces reject Agent Profile activation", () => {
 	assert.throws(
 		() =>

--- a/packages/api/src/thinkspaces/agent-profile.ts
+++ b/packages/api/src/thinkspaces/agent-profile.ts
@@ -112,7 +112,20 @@ export interface ModelProviderCredentialPermissionRequest {
 	reason: string;
 }
 
-export type RequestedPermission = ModelProviderCredentialPermissionRequest;
+export interface ToolPermissionPlaceholderRequest {
+	actions: string[];
+	approvalRequired: boolean;
+	resource: {
+		serverId: string;
+		toolName: string;
+	};
+	risk: "read_only" | "mutating" | "unknown";
+	type: "mcp_tool_permission_placeholder";
+}
+
+export type RequestedPermission =
+	| ModelProviderCredentialPermissionRequest
+	| ToolPermissionPlaceholderRequest;
 
 interface AgentProfileRevisionBase {
 	createdAt: Date;
@@ -308,11 +321,30 @@ const isRoutine = (value: unknown): value is Routine =>
 	isNonEmptyString(value.instruction) &&
 	isRoutineSchedule(value.schedule);
 
+const isToolPermissionPlaceholderRequest = (
+	value: unknown,
+): value is ToolPermissionPlaceholderRequest => {
+	if (!(isRecord(value) && isRecord(value.resource))) {
+		return false;
+	}
+
+	return (
+		value.type === "mcp_tool_permission_placeholder" &&
+		Array.isArray(value.actions) &&
+		value.actions.every((action) => typeof action === "string" && action.length > 0) &&
+		typeof value.approvalRequired === "boolean" &&
+		isNonEmptyString(value.resource.serverId) &&
+		isNonEmptyString(value.resource.toolName) &&
+		(value.risk === "read_only" || value.risk === "mutating" || value.risk === "unknown")
+	);
+};
+
 const isRequestedPermission = (value: unknown): value is RequestedPermission =>
-	isRecord(value) &&
-	value.kind === "model_provider_credential" &&
-	MODEL_PROVIDER_IDS.includes(value.providerId as ModelProviderId) &&
-	typeof value.reason === "string";
+	(isRecord(value) &&
+		value.kind === "model_provider_credential" &&
+		MODEL_PROVIDER_IDS.includes(value.providerId as ModelProviderId) &&
+		typeof value.reason === "string") ||
+	isToolPermissionPlaceholderRequest(value);
 
 const parseJsonArray = <T>(
 	label: string,

--- a/packages/api/src/thinkspaces/lifecycle.test.ts
+++ b/packages/api/src/thinkspaces/lifecycle.test.ts
@@ -25,7 +25,6 @@ test("creates a draft Thinkspace record around a trimmed Goal and reviewable con
 		"Review repository shape, sources, permissions, and expected artifact.",
 	);
 	assert.equal(record.status, "draft");
-	assert.equal(record.enabledToolIds, "[]");
 	assert.equal(record.requestedPermissions, "[]");
 	assert.equal(
 		record.approvalDefaults,
@@ -45,7 +44,7 @@ test("builds a deterministic configuration summary when none is supplied", () =>
 	});
 
 	assert.match(record.configurationSummary ?? "", /Goal: Compare release notes/u);
-	assert.match(record.configurationSummary ?? "", /Skills, tools, requested Permissions/u);
+	assert.match(record.configurationSummary ?? "", /Skills, requested Permissions/u);
 	assert.match(
 		record.configurationSummary ?? "",
 		/Memory governance starts in user-reviewed mode/u,

--- a/packages/api/src/thinkspaces/lifecycle.ts
+++ b/packages/api/src/thinkspaces/lifecycle.ts
@@ -8,7 +8,6 @@ export const THINKSPACE_CREATION_DEFAULTS = {
 	approvalDefaults: {
 		externalMutations: "require_approval",
 	},
-	enabledToolIds: [] as string[],
 	memoryGovernance: {
 		retention: "user_reviewed",
 	},
@@ -42,7 +41,7 @@ const assertMaxLength = (label: string, value: string, maxLength: number) => {
 const buildDefaultConfigurationSummary = (goal: string): string =>
 	[
 		`Goal: ${goal}`,
-		"Initial configuration keeps Skills, tools, requested Permissions, and Approval policy placeholders empty until the user deliberately scopes them.",
+		"Initial configuration keeps Skills, requested Permissions, and Approval policy placeholders empty until the user deliberately scopes them.",
 		"Memory governance starts in user-reviewed mode so retained understanding is accepted intentionally.",
 	].join("\n");
 
@@ -95,7 +94,6 @@ export const createThinkspaceCreationRecord = ({
 	return {
 		approvalDefaults: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.approvalDefaults),
 		configurationSummary: normalizedSummary || buildDefaultConfigurationSummary(normalizedGoal),
-		enabledToolIds: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.enabledToolIds),
 		goal: normalizedGoal,
 		id,
 		memoryGovernance: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.memoryGovernance),

--- a/packages/api/src/thinkspaces/repository.ts
+++ b/packages/api/src/thinkspaces/repository.ts
@@ -24,7 +24,7 @@ export interface ArchiveThinkspaceInput extends GetThinkspaceInput {
 export interface UpdateThinkspaceConfigurationInput extends GetThinkspaceInput {
 	patch: Pick<
 		typeof thinkspaces.$inferInsert,
-		"approvalDefaults" | "enabledToolIds" | "requestedPermissions" | "updatedAt"
+		"approvalDefaults" | "requestedPermissions" | "updatedAt"
 	>;
 }
 

--- a/packages/api/src/thinkspaces/router.test.ts
+++ b/packages/api/src/thinkspaces/router.test.ts
@@ -66,6 +66,29 @@ const createDbForThinkspaceCreation = (settingsRows: Record<string, unknown>[] =
 	return { db: db as unknown as ProductDb, inserted };
 };
 
+const createDbForAgentProfileDraftUpdate = (row: Record<string, unknown>) => {
+	const saved: Record<string, unknown>[] = [];
+	const db = {
+		insert: () => ({
+			values: (value: Record<string, unknown>) => ({
+				onConflictDoUpdate: () => ({
+					returning: () => {
+						saved.push(value);
+						return Promise.resolve([value]);
+					},
+				}),
+			}),
+		}),
+		select: () => ({
+			from: () => ({
+				where: () => ({ limit: () => Promise.resolve([row]) }),
+			}),
+		}),
+	};
+
+	return { db: db as unknown as ProductDb, saved };
+};
+
 const createDbForAgentProfileActivation = (row: Record<string, unknown>) => {
 	const patches: Record<string, unknown>[] = [];
 	const db = {
@@ -111,7 +134,6 @@ const ownedThinkspaceRow = (overrides: Record<string, unknown> = {}): Record<str
 	...ownedAgentProfileColumns(),
 	archivedAt: null,
 	configurationSummary: "Watch release notes and draft a handoff.",
-	enabledToolIds: "[]",
 	goal: "Monitor releases",
 	id: OWNED_THINKSPACE_ID,
 	memoryGovernance: "{}",
@@ -275,6 +297,31 @@ test("owners can activate the draft Agent Profile revision and draft Thinkspace 
 	assert.equal(activation.thinkspaceStatus, "active");
 	assert.ok(patches.some((patch) => patch.status === "active" && patch.version === 1));
 	assert.ok(patches.some((patch) => patch.status === "active" && !("version" in patch)));
+});
+
+test("updating tools writes enablements and permission requests to the draft Agent Profile", async () => {
+	const { db, saved } = createDbForAgentProfileDraftUpdate(
+		ownedThinkspaceRow({ ...ownedAgentProfileColumns("draft"), status: "draft" }),
+	);
+	const context = createCallContext({ db });
+
+	const updated = await call(
+		thinkspacesRouter.updateToolSelections,
+		{
+			selections: [{ risk: "mutating", serverId: "github", toolName: "create_issue" }],
+			thinkspaceId: OWNED_THINKSPACE_ID,
+		},
+		{ context },
+	);
+
+	assert.ok(updated);
+	assert.equal(updated.agentProfileRevision.status, "draft");
+	assert.equal(
+		saved[0]?.toolEnablements,
+		'[{"source":"mcp_server","toolId":"github:create_issue"}]',
+	);
+	assert.match(String(saved[0]?.requestedPermissions), /mcp_tool_permission_placeholder/u);
+	assert.equal("enabledToolIds" in (saved[0] ?? {}), false);
 });
 
 test("Agent Profile activation rejects archived Thinkspaces before writes", async () => {

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -16,9 +16,11 @@ import {
 	validateAgentProfileIdentity,
 	validateAgentProfileModelBehavior,
 } from "./agent-profile";
+import type { RequestedPermission, ToolEnablement } from "./agent-profile";
 import {
 	AgentProfileLifecycleError,
 	createAgentProfileActivation,
+	createAgentProfileDraftFromActive,
 	createInitialAgentProfileDraft,
 } from "./agent-profile-lifecycle";
 import {
@@ -26,13 +28,10 @@ import {
 	getActiveAgentProfileRevision,
 	getCurrentAgentProfileRevision,
 	getDraftAgentProfileRevision,
+	saveAgentProfileDraft,
 } from "./agent-profile-repository";
 import { inspectOwnedThinkspaceTurn, THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH } from "./inspect";
-import {
-	createToolPermissionPlaceholder,
-	DEFAULT_APPROVAL_POLICY,
-	serializeThinkspaceToolSelections,
-} from "./policy";
+import { createToolPermissionPlaceholder, serializeThinkspaceToolSelections } from "./policy";
 import {
 	createThinkspaceArchivePatch,
 	createThinkspaceCreationRecord,
@@ -43,7 +42,6 @@ import {
 	createThinkspaceWithAgentProfileDraft,
 	getThinkspace,
 	listThinkspaces,
-	updateThinkspaceConfiguration,
 } from "./repository";
 import {
 	getOwnedThinkspaceAgentRuntimeReadiness,
@@ -91,6 +89,22 @@ const submitTurnInput = z.object({
 
 const createThinkspaceId = (): string => `thinkspace_${crypto.randomUUID()}`;
 const createAgentProfileRevisionId = (): string => `agent_profile_revision_${crypto.randomUUID()}`;
+
+const toToolEnablements = (selections: z.infer<typeof toolSelectionSchema>[]): ToolEnablement[] => {
+	const normalized = JSON.parse(serializeThinkspaceToolSelections(selections)) as z.infer<
+		typeof toolSelectionSchema
+	>[];
+
+	return normalized.map((selection) => ({
+		source: "mcp_server",
+		toolId: selection.toolName ? `${selection.serverId}:${selection.toolName}` : selection.serverId,
+	}));
+};
+
+const toRequestedPermissions = (
+	selections: z.infer<typeof toolSelectionSchema>[],
+): RequestedPermission[] =>
+	selections.map((selection) => createToolPermissionPlaceholder(selection) as RequestedPermission);
 
 const deriveAgentProfileDisplayName = (goal: string): string => {
 	const normalized = goal.trim();
@@ -426,23 +440,43 @@ export const thinkspacesRouter = {
 				});
 			}
 
-			const updated = await updateThinkspaceConfiguration(context.db, {
-				ownerUserId: context.session.user.id,
-				patch: {
-					approvalDefaults: JSON.stringify(DEFAULT_APPROVAL_POLICY),
-					enabledToolIds: serializeThinkspaceToolSelections(input.selections),
-					requestedPermissions: JSON.stringify(
-						input.selections.map((selection) => createToolPermissionPlaceholder(selection)),
-					),
-					updatedAt: new Date(),
-				},
-				thinkspaceId: input.thinkspaceId,
-			});
+			try {
+				const currentDraft = await getDraftAgentProfileRevision(context.db, {
+					thinkspaceId: thinkspace.id,
+				});
+				const activeRevision = await getActiveAgentProfileRevision(context.db, {
+					thinkspaceId: thinkspace.id,
+				});
+				const draft =
+					currentDraft ??
+					(activeRevision
+						? createAgentProfileDraftFromActive({
+								active: activeRevision,
+								id: createAgentProfileRevisionId(),
+							})
+						: null);
 
-			if (!updated) {
-				throw toNotFound();
+				if (!draft) {
+					throw new AgentProfileLifecycleError(
+						"No Agent Profile revision is available for tool enablement.",
+					);
+				}
+
+				const updatedDraft = await saveAgentProfileDraft(context.db, {
+					draft: {
+						...draft,
+						requestedPermissions: toRequestedPermissions(input.selections),
+						toolEnablements: toToolEnablements(input.selections),
+						updatedAt: new Date(),
+					},
+				});
+
+				return {
+					agentProfileRevision: updatedDraft,
+					thinkspaceId: thinkspace.id,
+				};
+			} catch (error) {
+				throwProductSafeProfileError(error);
 			}
-
-			return updated;
 		}),
 };

--- a/packages/db/src/migrations/0005_thick_baron_strucker.sql
+++ b/packages/db/src/migrations/0005_thick_baron_strucker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `thinkspaces` DROP COLUMN `enabled_tool_ids`;

--- a/packages/db/src/migrations/meta/0005_snapshot.json
+++ b/packages/db/src/migrations/meta/0005_snapshot.json
@@ -1,0 +1,1087 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cfcb4668-7dae-435e-95e3-20418e3b376b",
+  "prevId": "dd37e392-9940-4e0e-bb1e-14fe6b2b7c76",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_account_provider_account": {
+          "name": "idx_account_provider_account",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_server_catalog": {
+      "name": "mcp_server_catalog",
+      "columns": {
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'streamable_http'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_agent_profiles": {
+      "name": "thinkspace_agent_profiles",
+      "columns": {
+        "activated_at": {
+          "name": "activated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_permissions": {
+          "name": "requested_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "routines": {
+          "name": "routines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "skill_references": {
+          "name": "skill_references",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_enablements": {
+          "name": "tool_enablements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_agent_profiles_thinkspace_version": {
+          "name": "uq_agent_profiles_thinkspace_version",
+          "columns": [
+            "thinkspace_id",
+            "version"
+          ],
+          "isUnique": true
+        },
+        "uq_agent_profiles_thinkspace_active": {
+          "name": "uq_agent_profiles_thinkspace_active",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'active'"
+        },
+        "uq_agent_profiles_thinkspace_draft": {
+          "name": "uq_agent_profiles_thinkspace_draft",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'draft'"
+        },
+        "idx_agent_profiles_thinkspace_status": {
+          "name": "idx_agent_profiles_thinkspace_status",
+          "columns": [
+            "thinkspace_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_agent_profiles_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_agent_profiles_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_agent_profiles",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspaces": {
+      "name": "thinkspaces",
+      "columns": {
+        "approval_defaults": {
+          "name": "approval_defaults",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration_summary": {
+          "name": "configuration_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memory_governance": {
+          "name": "memory_governance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_permissions": {
+          "name": "requested_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_thinkspaces_owner_status_updated": {
+          "name": "idx_thinkspaces_owner_status_updated",
+          "columns": [
+            "owner_user_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "idx_thinkspaces_owner_created": {
+          "name": "idx_thinkspaces_owner_created",
+          "columns": [
+            "owner_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_thinkspaces_owner_archived": {
+          "name": "idx_thinkspaces_owner_archived",
+          "columns": [
+            "owner_user_id",
+            "archived_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thinkspaces_owner_user_id_user_id_fk": {
+          "name": "thinkspaces_owner_user_id_user_id_fk",
+          "tableFrom": "thinkspaces",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_mcp_connections": {
+      "name": "user_mcp_connections",
+      "columns": {
+        "catalog_visible": {
+          "name": "catalog_visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_headers": {
+          "name": "encrypted_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'streamable_http'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_mcp_connections_user": {
+          "name": "idx_user_mcp_connections_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_mcp_connections_server": {
+          "name": "idx_user_mcp_connections_server",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_mcp_connections_server_id_mcp_server_catalog_id_fk": {
+          "name": "user_mcp_connections_server_id_mcp_server_catalog_id_fk",
+          "tableFrom": "user_mcp_connections",
+          "tableTo": "mcp_server_catalog",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_mcp_connections_user_id_user_id_fk": {
+          "name": "user_mcp_connections_user_id_user_id_fk",
+          "tableFrom": "user_mcp_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_product_settings": {
+      "name": "user_product_settings",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_product_settings_user_id_user_id_fk": {
+          "name": "user_product_settings_user_id_user_id_fk",
+          "tableFrom": "user_product_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_provider_credentials": {
+      "name": "user_provider_credentials",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_provider_credentials_user": {
+          "name": "idx_user_provider_credentials_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_provider_credentials_user_provider": {
+          "name": "idx_user_provider_credentials_user_provider",
+          "columns": [
+            "user_id",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_provider_credentials_user_id_user_id_fk": {
+          "name": "user_provider_credentials_user_id_user_id_fk",
+          "tableFrom": "user_provider_credentials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        },
+        "idx_verification_expires_at": {
+          "name": "idx_verification_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1781139208245,
       "tag": "0004_quick_thunderbird",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1781141072949,
+      "tag": "0005_thick_baron_strucker",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/thinkspaces.ts
+++ b/packages/db/src/schema/thinkspaces.ts
@@ -31,12 +31,6 @@ export const thinkspaces = sqliteTable(
 		archivedAt: integer("archived_at", { mode: "timestamp_ms" }),
 		configurationSummary: text("configuration_summary").default("").notNull(),
 		createdAt: integer("created_at", { mode: "timestamp_ms" }).default(timestampMsNow).notNull(),
-		/**
-		 * @deprecated Legacy curation config. Tool enablement is migrating to
-		 * versioned Agent Profile revisions in `thinkspace_agent_profiles`
-		 * (ADR-0007).
-		 */
-		enabledToolIds: text("enabled_tool_ids").default("[]").notNull(),
 		goal: text("goal").notNull(),
 		id: text("id").primaryKey(),
 		memoryGovernance: text("memory_governance").default("{}").notNull(),


### PR DESCRIPTION
## Summary
- Update tool selection writes to edit the draft Agent Profile revision, creating a new draft from the active revision when needed.
- Store tool enablements and derived Permission placeholders on draft revisions; activation preserves enablements for subsequent turns.
- Render Thinkspace detail tools/Permissions from the current Agent Profile revision and label draft vs active state.
- Remove the deprecated thinkspaces.enabled_tool_ids column with generated migration 0005.

Closes #53

## Validation
- bun test packages
- bun run check-types
- bun x ultracite check 'apps/web/src/routes/thinkspaces..tsx' packages/api/src/thinkspaces/agent-profile.ts packages/api/src/thinkspaces/agent-profile-lifecycle.test.ts packages/api/src/thinkspaces/lifecycle.ts packages/api/src/thinkspaces/lifecycle.test.ts packages/api/src/thinkspaces/repository.ts packages/api/src/thinkspaces/router.ts packages/api/src/thinkspaces/router.test.ts packages/db/src/schema/thinkspaces.ts
- bun run build