### PR TITLE
Add minimal Thinkspace Permission storage

### DIFF
--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -32,14 +32,24 @@ interface EnabledToolSelection {
 }
 
 interface PermissionPlaceholder {
-	actions: string[];
-	approvalRequired: boolean;
-	resource: {
+	actions?: string[];
+	approvalRequired?: boolean;
+	kind?: "model_provider_credential";
+	providerId?: string;
+	reason?: string;
+	resource?: {
 		serverId: string;
 		toolName: string;
 	};
-	risk: string;
-	type: string;
+	risk?: string;
+	type?: string;
+}
+
+interface GrantedPermissionView {
+	id: string;
+	kind: string;
+	providerId: string | null;
+	reason: string;
 }
 
 interface AgentProfileRevisionView {
@@ -363,6 +373,76 @@ const SubmitTurnSection = ({
 	);
 };
 
+const PermissionsSection = ({
+	grantedPermissions,
+	requestedPermissions,
+}: {
+	grantedPermissions: GrantedPermissionView[];
+	requestedPermissions: PermissionPlaceholder[];
+}) => (
+	<section aria-labelledby="permissions-heading" className="grid gap-4">
+		<div className="grid gap-1">
+			<h2 className="text-lg font-semibold tracking-tight" id="permissions-heading">
+				Permissions
+			</h2>
+			<p className="text-muted-foreground text-sm">
+				Scoped access for this Thinkspace. Permissions are separate from Approvals.
+			</p>
+		</div>
+		<div className="grid gap-3">
+			<div className="grid gap-2">
+				<p className="text-sm font-medium">Requested on draft</p>
+				{requestedPermissions.length === 0 ? (
+					<p className="border border-border p-4 text-muted-foreground text-sm">
+						No draft Permission requests.
+					</p>
+				) : (
+					<div className="border border-border">
+						{requestedPermissions.map((permission, index) => (
+							<div
+								key={`${permission.kind ?? permission.type}:${permission.providerId ?? permission.resource?.serverId ?? index}`}
+								className={`grid gap-0.5 p-4 ${index < requestedPermissions.length - 1 ? "border-b border-border" : ""}`}
+							>
+								<p className="text-sm font-medium">
+									{permission.kind === "model_provider_credential"
+										? `Model credential: ${permission.providerId}`
+										: `${permission.resource?.serverId ?? "Tool"}${permission.resource?.toolName ? `/${permission.resource.toolName}` : ""}`}
+								</p>
+								<p className="text-muted-foreground text-xs">
+									{permission.reason ??
+										`Risk: ${permission.risk ?? "unknown"} · Approval required: ${permission.approvalRequired ? "yes" : "no"}`}
+								</p>
+							</div>
+						))}
+					</div>
+				)}
+			</div>
+			<div className="grid gap-2">
+				<p className="text-sm font-medium">Granted to Thinkspace</p>
+				{grantedPermissions.length === 0 ? (
+					<p className="border border-border p-4 text-muted-foreground text-sm">
+						No granted Permissions.
+					</p>
+				) : (
+					<div className="border border-border">
+						{grantedPermissions.map((permission, index) => (
+							<div
+								key={permission.id}
+								className={`grid gap-0.5 p-4 ${index < grantedPermissions.length - 1 ? "border-b border-border" : ""}`}
+							>
+								<p className="text-sm font-medium">
+									{permission.kind}: {permission.providerId ?? "scoped resource"}
+								</p>
+								<p className="text-muted-foreground text-xs">{permission.reason}</p>
+							</div>
+						))}
+					</div>
+				)}
+			</div>
+		</div>
+	</section>
+);
+
 const RouteComponent = () => {
 	const { thinkspaceId } = routeApi.useParams();
 	const context = routeApi.useRouteContext();
@@ -432,6 +512,7 @@ const RouteComponent = () => {
 	const isDraft = thinkspace.status === "draft";
 	const enabledTools = profileRevision?.toolEnablements.map(toEnabledToolSelection) ?? [];
 	const requestedPermissions = profileRevision?.requestedPermissions ?? [];
+	const grantedPermissions = (thinkspace.grantedPermissions ?? []) as GrantedPermissionView[];
 
 	const toggleCatalogTool = (serverId: string, risk: "read_only" | "mutating" | "unknown") => {
 		const selected = enabledTools.some((tool) => tool.serverId === serverId);
@@ -626,36 +707,10 @@ const RouteComponent = () => {
 
 			<Separator />
 
-			<section aria-labelledby="permissions-heading" className="grid gap-4">
-				<div className="grid gap-1">
-					<h2 className="text-lg font-semibold tracking-tight" id="permissions-heading">
-						Permissions
-					</h2>
-					<p className="text-muted-foreground text-sm">
-						Scoped access for this Thinkspace. Permissions are separate from Approvals.
-					</p>
-				</div>
-				{requestedPermissions.length === 0 ? (
-					<p className="border border-border p-4 text-muted-foreground text-sm">
-						No Permissions configured.
-					</p>
-				) : (
-					<div className="border border-border">
-						{requestedPermissions.map((permission, index) => (
-							<div
-								key={`${permission.resource.serverId}:${permission.resource.toolName}`}
-								className={`grid gap-0.5 p-4 ${index < requestedPermissions.length - 1 ? "border-b border-border" : ""}`}
-							>
-								<p className="text-sm font-medium">{permission.resource.serverId}</p>
-								<p className="text-muted-foreground text-xs">
-									Risk: {permission.risk} · Approval required:{" "}
-									{permission.approvalRequired ? "yes" : "no"}
-								</p>
-							</div>
-						))}
-					</div>
-				)}
-			</section>
+			<PermissionsSection
+				grantedPermissions={grantedPermissions}
+				requestedPermissions={requestedPermissions}
+			/>
 
 			{isArchived || isDraft ? null : (
 				<>

--- a/packages/api/src/models/credentials.ts
+++ b/packages/api/src/models/credentials.ts
@@ -107,5 +107,7 @@ export const getDecryptedCredential = async (
 			),
 		)
 		.limit(1);
-	return row ? await decryptCredential(row.encryptedCredential, input.secret) : null;
+	return typeof row?.encryptedCredential === "string"
+		? await decryptCredential(row.encryptedCredential, input.secret)
+		: null;
 };

--- a/packages/api/src/models/readiness.test.ts
+++ b/packages/api/src/models/readiness.test.ts
@@ -49,9 +49,8 @@ const unavailableCatalog: ModelCatalog = {
 	sourceId: "models_dev",
 };
 
-const createThinkspace = (requestedPermissions = "[]") => ({
+const createThinkspace = () => ({
 	id: "thinkspace_model_readiness",
-	requestedPermissions,
 });
 
 const activeRevision = (modelId = "google:gemini-2.5-flash-lite") =>
@@ -62,14 +61,9 @@ const activeRevision = (modelId = "google:gemini-2.5-flash-lite") =>
 		version: 1,
 	}) as never;
 
-const grantedCredentialPermission = (providerId: string): string =>
-	JSON.stringify([
-		{
-			granted: true,
-			providerId,
-			type: "model_provider_credential_permission",
-		},
-	]);
+const grantedCredentialPermission =
+	(providerId: string) => (_db: ProductDb, input: { providerId: string; thinkspaceId: string }) =>
+		Promise.resolve(input.providerId === providerId);
 
 test("reports ready for the default model once the credential Permission is granted", async () => {
 	const readiness = await checkThinkspaceModelReadiness({
@@ -80,9 +74,10 @@ test("reports ready for the default model once the credential Permission is gran
 			assert.equal(input.userId, "user_123");
 			return Promise.resolve("google-test-key");
 		},
+		hasModelProviderCredentialPermission: grantedCredentialPermission("google"),
 		modelCatalog,
 		settings: null,
-		thinkspace: createThinkspace(grantedCredentialPermission("google")),
+		thinkspace: createThinkspace(),
 		userId: "user_123",
 	});
 
@@ -110,9 +105,10 @@ test("fails closed when the user has no saved provider credential", async () => 
 		db,
 		env: createEnv(),
 		getUserCredential: () => Promise.resolve(null),
+		hasModelProviderCredentialPermission: grantedCredentialPermission("google"),
 		modelCatalog,
 		settings: null,
-		thinkspace: createThinkspace(grantedCredentialPermission("google")),
+		thinkspace: createThinkspace(),
 		userId: "user_123",
 	});
 
@@ -130,6 +126,7 @@ test("requires Thinkspace Permission before resolving any saved credential", asy
 			credentialLoadCount += 1;
 			return Promise.resolve("sk-test");
 		},
+		hasModelProviderCredentialPermission: () => Promise.resolve(false),
 		modelCatalog,
 		settings: { defaultModel: "openai:gpt-4.1", reasoningEffort: "medium" },
 		thinkspace: createThinkspace(),
@@ -150,9 +147,10 @@ test("reports ready only after the Thinkspace credential Permission is granted",
 			assert.equal(input.userId, "user_123");
 			return Promise.resolve("sk-test");
 		},
+		hasModelProviderCredentialPermission: grantedCredentialPermission("openai"),
 		modelCatalog,
 		settings: { defaultModel: "openai:gpt-4.1", reasoningEffort: "medium" },
-		thinkspace: createThinkspace(grantedCredentialPermission("openai")),
+		thinkspace: createThinkspace(),
 		userId: "user_123",
 	});
 
@@ -168,9 +166,10 @@ test("owner-gated model readiness reports readiness for owned Thinkspaces", asyn
 		getThinkspaceByOwner: (_db, input) => {
 			assert.equal(input.ownerUserId, "owner_user");
 			assert.equal(input.thinkspaceId, "thinkspace_owned");
-			return Promise.resolve(createThinkspace(grantedCredentialPermission("google")));
+			return Promise.resolve(createThinkspace());
 		},
 		getUserCredential: () => Promise.resolve("google-test-key"),
+		hasModelProviderCredentialPermission: grantedCredentialPermission("google"),
 		modelCatalog,
 		ownerUserId: "owner_user",
 		thinkspaceId: "thinkspace_owned",
@@ -185,9 +184,9 @@ test("resolves a usable turn model for ready owned Thinkspaces", async () => {
 		db,
 		env: createEnv(),
 		getActiveRevision: () => Promise.resolve(activeRevision()),
-		getThinkspaceByOwner: () =>
-			Promise.resolve(createThinkspace(grantedCredentialPermission("google"))),
+		getThinkspaceByOwner: () => Promise.resolve(createThinkspace()),
 		getUserCredential: () => Promise.resolve("google-test-key"),
+		hasModelProviderCredentialPermission: grantedCredentialPermission("google"),
 		modelCatalog,
 		ownerUserId: "owner_user",
 		thinkspaceId: "thinkspace_owned",
@@ -204,9 +203,9 @@ test("turn model resolution fails closed with a product-safe error when not read
 			db,
 			env: createEnv(),
 			getActiveRevision: () => Promise.resolve(activeRevision()),
-			getThinkspaceByOwner: () =>
-				Promise.resolve(createThinkspace(grantedCredentialPermission("google"))),
+			getThinkspaceByOwner: () => Promise.resolve(createThinkspace()),
 			getUserCredential: () => Promise.resolve(null),
+			hasModelProviderCredentialPermission: grantedCredentialPermission("google"),
 			modelCatalog,
 			ownerUserId: "owner_user",
 			thinkspaceId: "thinkspace_owned",
@@ -225,8 +224,7 @@ test("owner-gated model readiness is not ready without an active Agent Profile r
 		db,
 		env: createEnv(),
 		getActiveRevision: () => Promise.resolve(null),
-		getThinkspaceByOwner: () =>
-			Promise.resolve(createThinkspace(grantedCredentialPermission("google"))),
+		getThinkspaceByOwner: () => Promise.resolve(createThinkspace()),
 		modelCatalog,
 		ownerUserId: "owner_user",
 		thinkspaceId: "thinkspace_owned",
@@ -272,9 +270,10 @@ test("reports ready for a models.dev-only model from a credentialed, Permission-
 		db,
 		env: createEnv(),
 		getUserCredential: () => Promise.resolve("google-test-key"),
+		hasModelProviderCredentialPermission: grantedCredentialPermission("google"),
 		modelCatalog,
 		settings: { defaultModel: "google:gemini-catalog-only", reasoningEffort: "medium" },
-		thinkspace: createThinkspace(grantedCredentialPermission("google")),
+		thinkspace: createThinkspace(),
 		userId: "user_123",
 	});
 
@@ -288,9 +287,9 @@ test("resolves a usable turn model for a models.dev-only model id", async () => 
 		db,
 		env: createEnv(),
 		getActiveRevision: () => Promise.resolve(activeRevision("google:gemini-catalog-only")),
-		getThinkspaceByOwner: () =>
-			Promise.resolve(createThinkspace(grantedCredentialPermission("google"))),
+		getThinkspaceByOwner: () => Promise.resolve(createThinkspace()),
 		getUserCredential: () => Promise.resolve("google-test-key"),
+		hasModelProviderCredentialPermission: grantedCredentialPermission("google"),
 		modelCatalog,
 		ownerUserId: "owner_user",
 		thinkspaceId: "thinkspace_owned",
@@ -308,7 +307,7 @@ test("catalog unavailability fails closed with a product-safe readiness", async 
 		getUserCredential: () => Promise.resolve("google-test-key"),
 		modelCatalog: unavailableCatalog,
 		settings: null,
-		thinkspace: createThinkspace(grantedCredentialPermission("google")),
+		thinkspace: createThinkspace(),
 		userId: "user_123",
 	});
 

--- a/packages/api/src/models/readiness.ts
+++ b/packages/api/src/models/readiness.ts
@@ -10,11 +10,12 @@ import type {
 	AgentProfileModelBehavior,
 } from "../thinkspaces/agent-profile";
 import { getActiveAgentProfileRevision } from "../thinkspaces/agent-profile-repository";
-import { DEFAULT_MODEL_ID, MODEL_PROVIDER_IDS } from "./catalog";
+import { DEFAULT_MODEL_ID } from "./catalog";
 import type { ModelCatalogEntry, ModelProviderId } from "./catalog";
 import { getDecryptedCredential } from "./credentials";
 import type { ModelCatalog } from "./model-catalog";
 import { createProductModelCatalog } from "./models-dev";
+import { hasThinkspaceModelProviderCredentialPermission } from "../thinkspaces/permissions";
 import { getThinkspace } from "../thinkspaces/repository";
 import { ModelResolutionError, resolveLanguageModel } from "./resolver";
 import type { ReasoningEffort, ThinkspaceModelPolicy } from "./resolver";
@@ -84,6 +85,7 @@ export interface GetOwnedThinkspaceModelReadinessInput {
 	getThinkspaceByOwner?: GetThinkspaceByOwner;
 	getActiveRevision?: GetActiveRevision;
 	getUserCredential?: GetUserCredential;
+	hasModelProviderCredentialPermission?: HasModelProviderCredentialPermission;
 	modelCatalog?: ModelCatalog;
 	ownerUserId: string;
 	thinkspaceId: string;
@@ -96,7 +98,8 @@ export interface CheckThinkspaceModelReadinessInput {
 	modelCatalog?: ModelCatalog;
 	modelBehavior?: AgentProfileModelBehavior;
 	settings: ModelReadinessUserSettings | null;
-	thinkspace: Pick<Thinkspace, "id" | "requestedPermissions">;
+	hasModelProviderCredentialPermission?: HasModelProviderCredentialPermission;
+	thinkspace: Pick<Thinkspace, "id">;
 	userId: string;
 }
 
@@ -111,7 +114,7 @@ const CATALOG_UNAVAILABLE_READINESS_MESSAGE =
 type GetThinkspaceByOwner = (
 	db: ProductDb,
 	input: { ownerUserId: string; thinkspaceId: string },
-) => Promise<Pick<Thinkspace, "id" | "requestedPermissions"> | null>;
+) => Promise<Pick<Thinkspace, "id"> | null>;
 
 type GetActiveRevision = (
 	db: ProductDb,
@@ -131,41 +134,10 @@ const isReasoningEffort = (value: string): value is ReasoningEffort =>
 const encryptionSecret = (env: ModelReadinessEnv): string =>
 	env.API_ENCRYPTION_KEY ?? env.BETTER_AUTH_SECRET;
 
-const parsePermissions = (requestedPermissions: string): unknown[] => {
-	try {
-		const parsed = JSON.parse(requestedPermissions) as unknown;
-		return Array.isArray(parsed) ? parsed : [];
-	} catch {
-		return [];
-	}
-};
-
-const isProviderId = (value: unknown): value is ModelProviderId =>
-	typeof value === "string" && MODEL_PROVIDER_IDS.includes(value as ModelProviderId);
-
-const hasGrantedModelCredentialPermission = (
-	thinkspace: Pick<Thinkspace, "requestedPermissions">,
-	providerId: ModelProviderId,
-): boolean =>
-	parsePermissions(thinkspace.requestedPermissions).some((permission) => {
-		if (!(permission && typeof permission === "object")) {
-			return false;
-		}
-
-		const candidate = permission as {
-			granted?: unknown;
-			providerId?: unknown;
-			status?: unknown;
-			type?: unknown;
-		};
-
-		return (
-			candidate.type === "model_provider_credential_permission" &&
-			isProviderId(candidate.providerId) &&
-			candidate.providerId === providerId &&
-			(candidate.granted === true || candidate.status === "granted")
-		);
-	});
+type HasModelProviderCredentialPermission = (
+	db: ProductDb,
+	input: { providerId: ModelProviderId; thinkspaceId: string },
+) => Promise<boolean>;
 
 const getReasoningEffort = (input: {
 	modelBehavior?: AgentProfileModelBehavior;
@@ -272,6 +244,7 @@ const evaluateThinkspaceModel = async ({
 	db,
 	env,
 	getUserCredential = getDecryptedCredential,
+	hasModelProviderCredentialPermission = hasThinkspaceModelProviderCredentialPermission,
 	modelBehavior,
 	modelCatalog,
 	settings,
@@ -307,10 +280,10 @@ const evaluateThinkspaceModel = async ({
 		};
 	}
 
-	const credentialPermission = hasGrantedModelCredentialPermission(
-		thinkspace,
-		modelDefinition.providerId,
-	)
+	const credentialPermission = (await hasModelProviderCredentialPermission(db, {
+		providerId: modelDefinition.providerId,
+		thinkspaceId: thinkspace.id,
+	}))
 		? "granted"
 		: "not_granted";
 	const policy: ThinkspaceModelPolicy = {
@@ -385,6 +358,7 @@ const evaluateOwnedThinkspaceModel = async ({
 	getActiveRevision = getActiveAgentProfileRevision,
 	getThinkspaceByOwner = getThinkspace,
 	getUserCredential = getDecryptedCredential,
+	hasModelProviderCredentialPermission = hasThinkspaceModelProviderCredentialPermission,
 	modelCatalog,
 	ownerUserId,
 	thinkspaceId,
@@ -412,6 +386,7 @@ const evaluateOwnedThinkspaceModel = async ({
 		db,
 		env,
 		getUserCredential: async (_db, input) => await getUserCredential(db, input),
+		hasModelProviderCredentialPermission,
 		modelBehavior: activeRevision.modelBehavior,
 		modelCatalog,
 		settings: null,

--- a/packages/api/src/thinkspaces/lifecycle.test.ts
+++ b/packages/api/src/thinkspaces/lifecycle.test.ts
@@ -25,11 +25,6 @@ test("creates a draft Thinkspace record around a trimmed Goal and reviewable con
 		"Review repository shape, sources, permissions, and expected artifact.",
 	);
 	assert.equal(record.status, "draft");
-	assert.equal(record.requestedPermissions, "[]");
-	assert.equal(
-		record.approvalDefaults,
-		JSON.stringify(THINKSPACE_CREATION_DEFAULTS.approvalDefaults),
-	);
 	assert.equal(
 		record.memoryGovernance,
 		JSON.stringify(THINKSPACE_CREATION_DEFAULTS.memoryGovernance),
@@ -44,7 +39,7 @@ test("builds a deterministic configuration summary when none is supplied", () =>
 	});
 
 	assert.match(record.configurationSummary ?? "", /Goal: Compare release notes/u);
-	assert.match(record.configurationSummary ?? "", /Skills, requested Permissions/u);
+	assert.match(record.configurationSummary ?? "", /Skills and Permission requests/u);
 	assert.match(
 		record.configurationSummary ?? "",
 		/Memory governance starts in user-reviewed mode/u,

--- a/packages/api/src/thinkspaces/lifecycle.ts
+++ b/packages/api/src/thinkspaces/lifecycle.ts
@@ -5,13 +5,9 @@ const MAX_GOAL_LENGTH = 280;
 const MAX_CONFIGURATION_SUMMARY_LENGTH = 1600;
 
 export const THINKSPACE_CREATION_DEFAULTS = {
-	approvalDefaults: {
-		externalMutations: "require_approval",
-	},
 	memoryGovernance: {
 		retention: "user_reviewed",
 	},
-	requestedPermissions: [] as string[],
 } as const;
 
 export interface CreateThinkspaceLifecycleInput {
@@ -41,7 +37,7 @@ const assertMaxLength = (label: string, value: string, maxLength: number) => {
 const buildDefaultConfigurationSummary = (goal: string): string =>
 	[
 		`Goal: ${goal}`,
-		"Initial configuration keeps Skills, requested Permissions, and Approval policy placeholders empty until the user deliberately scopes them.",
+		"Initial configuration keeps Skills and Permission requests empty until the user deliberately scopes them.",
 		"Memory governance starts in user-reviewed mode so retained understanding is accepted intentionally.",
 	].join("\n");
 
@@ -92,13 +88,11 @@ export const createThinkspaceCreationRecord = ({
 	assertMaxLength("Configuration summary", normalizedSummary, MAX_CONFIGURATION_SUMMARY_LENGTH);
 
 	return {
-		approvalDefaults: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.approvalDefaults),
 		configurationSummary: normalizedSummary || buildDefaultConfigurationSummary(normalizedGoal),
 		goal: normalizedGoal,
 		id,
 		memoryGovernance: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.memoryGovernance),
 		ownerUserId,
-		requestedPermissions: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.requestedPermissions),
 		status: THINKSPACE_STATUS.DRAFT,
 	};
 };

--- a/packages/api/src/thinkspaces/permissions.ts
+++ b/packages/api/src/thinkspaces/permissions.ts
@@ -1,0 +1,117 @@
+import type { ProductDb } from "@better-agent/db";
+import {
+	THINKSPACE_PERMISSION_KINDS,
+	thinkspacePermissions,
+} from "@better-agent/db/schema/permissions";
+import type {
+	NewThinkspacePermission,
+	ThinkspacePermission,
+} from "@better-agent/db/schema/permissions";
+import { and, eq } from "drizzle-orm";
+
+import { MODEL_PROVIDER_IDS } from "../models/catalog";
+import type { ModelProviderId } from "../models/catalog";
+import type { RequestedPermission } from "./agent-profile";
+
+export interface GrantThinkspacePermissionInput {
+	grantedByUserId: string;
+	permission: RequestedPermission;
+	thinkspaceId: string;
+}
+
+const isModelProviderId = (value: string): value is ModelProviderId =>
+	MODEL_PROVIDER_IDS.includes(value as ModelProviderId);
+
+const createPermissionId = (): string => `thinkspace_permission_${crypto.randomUUID()}`;
+
+export const toThinkspacePermissionGrant = ({
+	grantedByUserId,
+	permission,
+	thinkspaceId,
+}: GrantThinkspacePermissionInput): NewThinkspacePermission | null => {
+	if (!("kind" in permission) || permission.kind !== "model_provider_credential") {
+		return null;
+	}
+
+	if (!isModelProviderId(permission.providerId)) {
+		return null;
+	}
+
+	return {
+		grantedByUserId,
+		id: createPermissionId(),
+		kind: THINKSPACE_PERMISSION_KINDS.MODEL_PROVIDER_CREDENTIAL,
+		providerId: permission.providerId,
+		reason: permission.reason,
+		thinkspaceId,
+	};
+};
+
+export const grantThinkspacePermissions = async (
+	db: ProductDb,
+	inputs: GrantThinkspacePermissionInput[],
+): Promise<ThinkspacePermission[]> => {
+	const grants = inputs
+		.map(toThinkspacePermissionGrant)
+		.filter((grant): grant is NewThinkspacePermission => grant !== null);
+
+	if (grants.length === 0) {
+		return [];
+	}
+
+	const saved = await Promise.all(
+		grants.map(async (grant) => {
+			const [row] = await db
+				.insert(thinkspacePermissions)
+				.values(grant)
+				.onConflictDoUpdate({
+					set: {
+						grantedByUserId: grant.grantedByUserId,
+						reason: grant.reason,
+					},
+					target: [
+						thinkspacePermissions.thinkspaceId,
+						thinkspacePermissions.kind,
+						thinkspacePermissions.providerId,
+					],
+				})
+				.returning();
+
+			if (!row) {
+				throw new Error("Thinkspace Permission grant was not persisted.");
+			}
+
+			return row;
+		}),
+	);
+
+	return saved;
+};
+
+export const hasThinkspaceModelProviderCredentialPermission = async (
+	db: ProductDb,
+	input: { providerId: ModelProviderId; thinkspaceId: string },
+): Promise<boolean> => {
+	const [permission] = await db
+		.select({ id: thinkspacePermissions.id })
+		.from(thinkspacePermissions)
+		.where(
+			and(
+				eq(thinkspacePermissions.thinkspaceId, input.thinkspaceId),
+				eq(thinkspacePermissions.kind, THINKSPACE_PERMISSION_KINDS.MODEL_PROVIDER_CREDENTIAL),
+				eq(thinkspacePermissions.providerId, input.providerId),
+			),
+		)
+		.limit(1);
+
+	return Boolean(permission);
+};
+
+export const listThinkspacePermissions = async (
+	db: ProductDb,
+	input: { thinkspaceId: string },
+): Promise<ThinkspacePermission[]> =>
+	await db
+		.select()
+		.from(thinkspacePermissions)
+		.where(eq(thinkspacePermissions.thinkspaceId, input.thinkspaceId));

--- a/packages/api/src/thinkspaces/repository.ts
+++ b/packages/api/src/thinkspaces/repository.ts
@@ -21,13 +21,6 @@ export interface ArchiveThinkspaceInput extends GetThinkspaceInput {
 	patch: Pick<typeof thinkspaces.$inferInsert, "archivedAt" | "status" | "updatedAt">;
 }
 
-export interface UpdateThinkspaceConfigurationInput extends GetThinkspaceInput {
-	patch: Pick<
-		typeof thinkspaces.$inferInsert,
-		"approvalDefaults" | "requestedPermissions" | "updatedAt"
-	>;
-}
-
 export interface CreateThinkspaceInput {
 	record: typeof thinkspaces.$inferInsert;
 }
@@ -89,19 +82,6 @@ export const archiveThinkspace = async (
 		.returning();
 
 	return archived ?? null;
-};
-
-export const updateThinkspaceConfiguration = async (
-	db: ProductDb,
-	{ ownerUserId, patch, thinkspaceId }: UpdateThinkspaceConfigurationInput,
-): Promise<Thinkspace | null> => {
-	const [updated] = await db
-		.update(thinkspaces)
-		.set(patch)
-		.where(and(eq(thinkspaces.id, thinkspaceId), eq(thinkspaces.ownerUserId, ownerUserId)))
-		.returning();
-
-	return updated ?? null;
 };
 
 export const listThinkspaces = async (

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -31,6 +31,7 @@ import {
 	saveAgentProfileDraft,
 } from "./agent-profile-repository";
 import { inspectOwnedThinkspaceTurn, THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH } from "./inspect";
+import { grantThinkspacePermissions, listThinkspacePermissions } from "./permissions";
 import { createToolPermissionPlaceholder, serializeThinkspaceToolSelections } from "./policy";
 import {
 	createThinkspaceArchivePatch,
@@ -63,6 +64,10 @@ const createThinkspaceInput = z.object({
 
 const thinkspaceIdInput = z.object({
 	thinkspaceId: z.string().min(1),
+});
+
+const activateAgentProfileInput = thinkspaceIdInput.extend({
+	grantedPermissionIndexes: z.array(z.number().int().nonnegative()).optional(),
 });
 
 const toolSelectionSchema = z.object({
@@ -174,7 +179,7 @@ const throwProductSafeProfileError = (error: unknown): never => {
 
 export const thinkspacesRouter = {
 	activateAgentProfile: protectedProcedure
-		.input(thinkspaceIdInput)
+		.input(activateAgentProfileInput)
 		.handler(async ({ context, input }) => {
 			const thinkspace = await getThinkspace(context.db, {
 				ownerUserId: context.session.user.id,
@@ -209,11 +214,29 @@ export const thinkspacesRouter = {
 					draft,
 					thinkspace,
 				});
+				const grantIndexes =
+					input.grantedPermissionIndexes ?? draft.requestedPermissions.map((_, index) => index);
+				const requestedGrants: RequestedPermission[] = [];
+				for (const index of grantIndexes) {
+					const permission = draft.requestedPermissions[index];
+					if (permission) {
+						requestedGrants.push(permission);
+					}
+				}
 
 				await applyAgentProfileActivation(context.db, { activation });
+				const grantedPermissions = await grantThinkspacePermissions(
+					context.db,
+					requestedGrants.map((permission) => ({
+						grantedByUserId: context.session.user.id,
+						permission,
+						thinkspaceId: thinkspace.id,
+					})),
+				);
 
 				return {
 					activatedRevision: activation.activatedRevision,
+					grantedPermissions,
 					thinkspaceId: thinkspace.id,
 					thinkspaceStatus: activation.thinkspaceActivationPatch?.status ?? thinkspace.status,
 				};
@@ -300,6 +323,9 @@ export const thinkspacesRouter = {
 		return {
 			...thinkspace,
 			agentProfileRevision: await getCurrentAgentProfileRevision(context.db, {
+				thinkspaceId: thinkspace.id,
+			}),
+			grantedPermissions: await listThinkspacePermissions(context.db, {
 				thinkspaceId: thinkspace.id,
 			}),
 		};

--- a/packages/api/src/thinkspaces/turns.ts
+++ b/packages/api/src/thinkspaces/turns.ts
@@ -65,7 +65,7 @@ type ThinkspaceTurnEnv = Pick<
 type GetThinkspaceByOwner = (
 	db: ProductDb,
 	input: { ownerUserId: string; thinkspaceId: string },
-) => Promise<Pick<Thinkspace, "id" | "requestedPermissions" | "status"> | null>;
+) => Promise<Pick<Thinkspace, "id" | "status"> | null>;
 
 type GetActiveRevision = (
 	db: ProductDb,

--- a/packages/db/src/migrations/0006_gray_talisman.sql
+++ b/packages/db/src/migrations/0006_gray_talisman.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `thinkspace_permissions` (
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`granted_by_user_id` text NOT NULL,
+	`id` text PRIMARY KEY NOT NULL,
+	`kind` text NOT NULL,
+	`provider_id` text,
+	`reason` text DEFAULT '' NOT NULL,
+	`thinkspace_id` text NOT NULL,
+	FOREIGN KEY (`thinkspace_id`) REFERENCES `thinkspaces`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_thinkspace_permissions_thinkspace` ON `thinkspace_permissions` (`thinkspace_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `uidx_thinkspace_permissions_model_provider` ON `thinkspace_permissions` (`thinkspace_id`,`kind`,`provider_id`);--> statement-breakpoint
+ALTER TABLE `thinkspaces` DROP COLUMN `approval_defaults`;--> statement-breakpoint
+ALTER TABLE `thinkspaces` DROP COLUMN `requested_permissions`;

--- a/packages/db/src/migrations/meta/0006_snapshot.json
+++ b/packages/db/src/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1163 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "179a1ae2-fa82-4d8f-a94d-7d1ee18d683a",
+  "prevId": "cfcb4668-7dae-435e-95e3-20418e3b376b",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_account_provider_account": {
+          "name": "idx_account_provider_account",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_server_catalog": {
+      "name": "mcp_server_catalog",
+      "columns": {
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'streamable_http'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_agent_profiles": {
+      "name": "thinkspace_agent_profiles",
+      "columns": {
+        "activated_at": {
+          "name": "activated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_permissions": {
+          "name": "requested_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "routines": {
+          "name": "routines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "skill_references": {
+          "name": "skill_references",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_enablements": {
+          "name": "tool_enablements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_agent_profiles_thinkspace_version": {
+          "name": "uq_agent_profiles_thinkspace_version",
+          "columns": [
+            "thinkspace_id",
+            "version"
+          ],
+          "isUnique": true
+        },
+        "uq_agent_profiles_thinkspace_active": {
+          "name": "uq_agent_profiles_thinkspace_active",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'active'"
+        },
+        "uq_agent_profiles_thinkspace_draft": {
+          "name": "uq_agent_profiles_thinkspace_draft",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'draft'"
+        },
+        "idx_agent_profiles_thinkspace_status": {
+          "name": "idx_agent_profiles_thinkspace_status",
+          "columns": [
+            "thinkspace_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_agent_profiles_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_agent_profiles_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_agent_profiles",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_permissions": {
+      "name": "thinkspace_permissions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_thinkspace_permissions_thinkspace": {
+          "name": "idx_thinkspace_permissions_thinkspace",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": false
+        },
+        "uidx_thinkspace_permissions_model_provider": {
+          "name": "uidx_thinkspace_permissions_model_provider",
+          "columns": [
+            "thinkspace_id",
+            "kind",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_permissions_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_permissions_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_permissions",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspaces": {
+      "name": "thinkspaces",
+      "columns": {
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration_summary": {
+          "name": "configuration_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memory_governance": {
+          "name": "memory_governance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_thinkspaces_owner_status_updated": {
+          "name": "idx_thinkspaces_owner_status_updated",
+          "columns": [
+            "owner_user_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "idx_thinkspaces_owner_created": {
+          "name": "idx_thinkspaces_owner_created",
+          "columns": [
+            "owner_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_thinkspaces_owner_archived": {
+          "name": "idx_thinkspaces_owner_archived",
+          "columns": [
+            "owner_user_id",
+            "archived_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thinkspaces_owner_user_id_user_id_fk": {
+          "name": "thinkspaces_owner_user_id_user_id_fk",
+          "tableFrom": "thinkspaces",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_mcp_connections": {
+      "name": "user_mcp_connections",
+      "columns": {
+        "catalog_visible": {
+          "name": "catalog_visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_headers": {
+          "name": "encrypted_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'streamable_http'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_mcp_connections_user": {
+          "name": "idx_user_mcp_connections_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_mcp_connections_server": {
+          "name": "idx_user_mcp_connections_server",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_mcp_connections_server_id_mcp_server_catalog_id_fk": {
+          "name": "user_mcp_connections_server_id_mcp_server_catalog_id_fk",
+          "tableFrom": "user_mcp_connections",
+          "tableTo": "mcp_server_catalog",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_mcp_connections_user_id_user_id_fk": {
+          "name": "user_mcp_connections_user_id_user_id_fk",
+          "tableFrom": "user_mcp_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_product_settings": {
+      "name": "user_product_settings",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_product_settings_user_id_user_id_fk": {
+          "name": "user_product_settings_user_id_user_id_fk",
+          "tableFrom": "user_product_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_provider_credentials": {
+      "name": "user_provider_credentials",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_provider_credentials_user": {
+          "name": "idx_user_provider_credentials_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_provider_credentials_user_provider": {
+          "name": "idx_user_provider_credentials_user_provider",
+          "columns": [
+            "user_id",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_provider_credentials_user_id_user_id_fk": {
+          "name": "user_provider_credentials_user_id_user_id_fk",
+          "tableFrom": "user_provider_credentials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        },
+        "idx_verification_expires_at": {
+          "name": "idx_verification_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1781141072949,
       "tag": "0005_thick_baron_strucker",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1781142185393,
+      "tag": "0006_gray_talisman",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -17,6 +17,14 @@ export {
 } from "./agent-profiles";
 export { timestampMsNow } from "./common";
 export {
+	type NewThinkspacePermission,
+	THINKSPACE_PERMISSION_KINDS,
+	thinkspacePermissionRelations,
+	type ThinkspacePermission,
+	thinkspacePermissions,
+	type ThinkspacePermissionKind,
+} from "./permissions";
+export {
 	mcpServerCatalog,
 	mcpServerCatalogRelations,
 	type McpServerCatalogEntry,

--- a/packages/db/src/schema/permissions.ts
+++ b/packages/db/src/schema/permissions.ts
@@ -1,0 +1,45 @@
+import { relations } from "drizzle-orm";
+import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+
+import { timestampMsNow } from "./common";
+import { thinkspaces } from "./thinkspaces";
+
+export const THINKSPACE_PERMISSION_KINDS = {
+	MODEL_PROVIDER_CREDENTIAL: "model_provider_credential",
+} as const;
+
+export type ThinkspacePermissionKind =
+	(typeof THINKSPACE_PERMISSION_KINDS)[keyof typeof THINKSPACE_PERMISSION_KINDS];
+
+export const thinkspacePermissions = sqliteTable(
+	"thinkspace_permissions",
+	{
+		createdAt: integer("created_at", { mode: "timestamp_ms" }).default(timestampMsNow).notNull(),
+		grantedByUserId: text("granted_by_user_id").notNull(),
+		id: text("id").primaryKey(),
+		kind: text("kind").notNull(),
+		providerId: text("provider_id"),
+		reason: text("reason").default("").notNull(),
+		thinkspaceId: text("thinkspace_id")
+			.notNull()
+			.references(() => thinkspaces.id, { onDelete: "cascade" }),
+	},
+	(table) => [
+		index("idx_thinkspace_permissions_thinkspace").on(table.thinkspaceId),
+		uniqueIndex("uidx_thinkspace_permissions_model_provider").on(
+			table.thinkspaceId,
+			table.kind,
+			table.providerId,
+		),
+	],
+);
+
+export const thinkspacePermissionRelations = relations(thinkspacePermissions, ({ one }) => ({
+	thinkspace: one(thinkspaces, {
+		fields: [thinkspacePermissions.thinkspaceId],
+		references: [thinkspaces.id],
+	}),
+}));
+
+export type ThinkspacePermission = typeof thinkspacePermissions.$inferSelect;
+export type NewThinkspacePermission = typeof thinkspacePermissions.$inferInsert;

--- a/packages/db/src/schema/thinkspaces.ts
+++ b/packages/db/src/schema/thinkspaces.ts
@@ -22,12 +22,6 @@ export type ThinkspaceStatus = (typeof THINKSPACE_STATUS)[keyof typeof THINKSPAC
 export const thinkspaces = sqliteTable(
 	"thinkspaces",
 	{
-		/**
-		 * @deprecated Legacy curation config. Approval policy is Permission/
-		 * Approval-owned and never lives on the Agent Profile; this column is
-		 * superseded by Thinkspace-owned Permission storage (ADR-0003/0004/0007).
-		 */
-		approvalDefaults: text("approval_defaults").default("{}").notNull(),
 		archivedAt: integer("archived_at", { mode: "timestamp_ms" }),
 		configurationSummary: text("configuration_summary").default("").notNull(),
 		createdAt: integer("created_at", { mode: "timestamp_ms" }).default(timestampMsNow).notNull(),
@@ -37,13 +31,6 @@ export const thinkspaces = sqliteTable(
 		ownerUserId: text("owner_user_id")
 			.notNull()
 			.references(() => user.id, { onDelete: "cascade" }),
-		/**
-		 * @deprecated Legacy curation config, still read by model-credential
-		 * readiness checks. Permission requests are migrating to draft Agent
-		 * Profile revisions; granted Permissions belong to Thinkspace-owned
-		 * Permission storage (ADR-0007).
-		 */
-		requestedPermissions: text("requested_permissions").default("[]").notNull(),
 		status: text("status").default(THINKSPACE_STATUS.DRAFT).notNull(),
 		updatedAt: integer("updated_at", { mode: "timestamp_ms" })
 			.default(timestampMsNow)


### PR DESCRIPTION
Closes #54\n\n## Summary\n- add Thinkspace-owned Permission storage for granted model-provider credential Permissions\n- grant requested draft Permissions during Agent Profile activation and keep active revisions request-free\n- move model readiness to Permission storage and show requested vs granted Permissions in the detail UI\n- drop deprecated thinkspaces.requested_permissions and approval_defaults via generated migration\n\n## Validation\n- bun test packages\n- bun run check-types\n- bun x ultracite check 'apps/web/src/routes/thinkspaces.$thinkspaceId.tsx' packages/api/src/models/credentials.ts packages/api/src/models/readiness.ts packages/api/src/models/readiness.test.ts packages/api/src/thinkspaces/lifecycle.ts packages/api/src/thinkspaces/lifecycle.test.ts packages/api/src/thinkspaces/permissions.ts packages/api/src/thinkspaces/repository.ts packages/api/src/thinkspaces/router.ts packages/api/src/thinkspaces/turns.ts packages/db/src/schema/permissions.ts packages/db/src/schema/thinkspaces.ts packages/db/src/schema/index.ts\n- bun run build