### PR TITLE
Implement store-backed tool permission policy

### DIFF
--- a/apps/server/src/agents/thinkspace-agent.ts
+++ b/apps/server/src/agents/thinkspace-agent.ts
@@ -12,6 +12,8 @@ import type {
 	ThinkspaceTurnInspection,
 	ThinkspaceTurnInspectionRequest,
 } from "@better-agent/api/thinkspaces/inspect";
+import { createPermissionStorePolicy } from "@better-agent/api/thinkspaces/permission-policy";
+import type { ToolPotencyVerdict } from "@better-agent/api/thinkspaces/permission-policy";
 import { assembleThinkspaceTurn } from "@better-agent/api/thinkspaces/turn-assembly";
 import {
 	createThinkspaceRuntimeToolSet,
@@ -33,6 +35,7 @@ import type {
 	ThinkspaceTurnSubmissionRequest,
 } from "@better-agent/api/thinkspaces/turns";
 import { createDb } from "@better-agent/db";
+import type { ProductDb } from "@better-agent/db";
 import type { CloudflareEnv } from "@better-agent/env/types";
 import { Think } from "@cloudflare/think";
 import type { LanguageModel, ToolSet, UIMessage } from "ai";
@@ -50,6 +53,8 @@ const MISSING_TURN_CONTEXT_MESSAGE =
 	"This Thinkspace Agent turn is missing its Thinkspace context.";
 const MISSING_THINKSPACE_MESSAGE =
 	"This Thinkspace Agent turn could not verify its Thinkspace configuration.";
+const PERMISSION_EVALUATION_FAILED_MESSAGE =
+	"This Thinkspace Agent turn could not evaluate its Thinkspace tool Permissions.";
 
 export class ThinkspaceAgent extends Think<CloudflareEnv> {
 	private readonly runtimeToolSet: ToolSet = createThinkspaceRuntimeToolSet();
@@ -164,11 +169,17 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 			throw new Error(markThinkspaceTurnProductSafeError(MISSING_TURN_CONTEXT_MESSAGE));
 		}
 
-		const resolved = await this.resolveTurnModel(turnContext);
+		const db = createDb(this.env.DB);
+		const resolved = await this.resolveTurnModel(db, turnContext);
+		const toolPotencies = await ThinkspaceAgent.evaluateToolPotencies(
+			db,
+			turnContext,
+			resolved.activeRevision,
+		);
 		const assembly = assembleThinkspaceTurn({
 			maxSteps: this.maxSteps,
 			revision: resolved.activeRevision,
-			toolPotencies: [],
+			toolPotencies,
 		});
 
 		return {
@@ -179,14 +190,39 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 		};
 	}
 
+	/**
+	 * Tool potency comes from the real store-backed Permission policy: the
+	 * Thinkspace's granted Permissions decide which enabled tools become
+	 * active, never the Profile alone. Evaluation failures stay product-safe.
+	 */
+	private static async evaluateToolPotencies(
+		db: ProductDb,
+		turnContext: ThinkspaceTurnRuntimeContext,
+		activeRevision: NonNullable<
+			Awaited<ReturnType<typeof resolveOwnedThinkspaceTurnModel>>
+		>["activeRevision"],
+	): Promise<ToolPotencyVerdict[]> {
+		try {
+			return await createPermissionStorePolicy({ db }).evaluateToolPotency({
+				enablements: activeRevision.toolEnablements,
+				thinkspaceId: turnContext.thinkspaceId,
+			});
+		} catch (error) {
+			throw new Error(markThinkspaceTurnProductSafeError(PERMISSION_EVALUATION_FAILED_MESSAGE), {
+				cause: error,
+			});
+		}
+	}
+
 	private async resolveTurnModel(
+		db: ProductDb,
 		turnContext: ThinkspaceTurnRuntimeContext,
 	): Promise<NonNullable<Awaited<ReturnType<typeof resolveOwnedThinkspaceTurnModel>>>> {
 		let resolved: Awaited<ReturnType<typeof resolveOwnedThinkspaceTurnModel>>;
 
 		try {
 			resolved = await resolveOwnedThinkspaceTurnModel({
-				db: createDb(this.env.DB),
+				db,
 				env: this.env,
 				ownerUserId: turnContext.ownerUserId,
 				thinkspaceId: turnContext.thinkspaceId,

--- a/apps/server/src/worker-routes.test.ts
+++ b/apps/server/src/worker-routes.test.ts
@@ -12,9 +12,12 @@ import test from "node:test";
  * entry points are the owner-gated oRPC procedures that talk to the Durable
  * Object by Thinkspace id.
  */
-const workerSource = readFileSync(new URL("index.ts", import.meta.url).pathname, "utf-8");
+const sourceRoot = import.meta.url.includes("/dist/src/")
+	? new URL("../../src/", import.meta.url)
+	: new URL("./", import.meta.url);
+const workerSource = readFileSync(new URL("index.ts", sourceRoot).pathname, "utf-8");
 const agentSource = readFileSync(
-	new URL("agents/thinkspace-agent.ts", import.meta.url).pathname,
+	new URL("agents/thinkspace-agent.ts", sourceRoot).pathname,
 	"utf-8",
 );
 
@@ -27,8 +30,12 @@ test("the worker never mounts raw Project Think agent routes", () => {
 
 test("the worker only exposes known app-owned route prefixes", () => {
 	const mountedRoutes = [
-		...workerSource.matchAll(/app\.(?:use|on|get|post)\(\s*(?:\[[^\]]*\],\s*)?"([^"]+)"/gu),
-	].map((match) => match[1]);
+		...workerSource.matchAll(/app\.(?:use|on|get|post)\(\s*(?:\[[^\]]*\],\s*)?"(?<route>[^"]+)"/gu),
+	].map((match) => {
+		const route = match.groups?.route;
+		assert.ok(route);
+		return route;
+	});
 
 	assert.deepEqual(mountedRoutes, [
 		"/*",
@@ -43,4 +50,10 @@ test("the worker only exposes known app-owned route prefixes", () => {
 test("the Thinkspace Agent runtime keeps direct HTTP access fail-closed", () => {
 	assert.match(agentSource, /override fetch\(/u);
 	assert.match(agentSource, /status: 404/u);
+});
+
+test("the Thinkspace Agent runtime gets tool verdicts from the store-backed Permission policy", () => {
+	assert.match(agentSource, /createPermissionStorePolicy\(\{ db \}\)\.evaluateToolPotency/u);
+	assert.match(agentSource, /enablements: activeRevision\.toolEnablements/u);
+	assert.doesNotMatch(agentSource, /toolPotencies:\s*\[\]/u);
 });

--- a/packages/api/src/testing/bun-sqlite.d.ts
+++ b/packages/api/src/testing/bun-sqlite.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Minimal ambient declaration for `bun:sqlite`, which the test runtime (bun)
+ * provides but the compilation's type roots (node, workers-types) do not.
+ * Only the surface the test-support database helper touches is declared.
+ */
+declare module "bun:sqlite" {
+	export class Database {
+		constructor(filename?: string);
+		close(): void;
+		exec(sql: string): void;
+	}
+}

--- a/packages/api/src/testing/product-db.ts
+++ b/packages/api/src/testing/product-db.ts
@@ -1,0 +1,39 @@
+/**
+ * Real test database support: an in-memory SQLite database with the actual
+ * product migrations applied, wrapped in the same drizzle schema the worker
+ * uses. Tests that exercise storage-backed seams (Permission policy, model
+ * readiness) run against this instead of hand-faked query stubs, so schema
+ * drift fails loudly.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+
+import type { ProductDb } from "@better-agent/db";
+import * as schema from "@better-agent/db/schema/index";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+const MIGRATIONS_DIR = decodeURIComponent(
+	new URL("../../../db/src/migrations/", import.meta.url).pathname,
+);
+const STATEMENT_BREAKPOINT = "--> statement-breakpoint";
+
+export const createTestProductDb = (): ProductDb => {
+	const sqlite = new Database(":memory:");
+	const migrationFiles = readdirSync(MIGRATIONS_DIR)
+		.filter((file) => file.endsWith(".sql"))
+		.toSorted((left, right) => left.localeCompare(right));
+
+	for (const file of migrationFiles) {
+		const migration = readFileSync(`${MIGRATIONS_DIR}/${file}`, "utf-8");
+
+		for (const statement of migration.split(STATEMENT_BREAKPOINT)) {
+			const sql = statement.trim();
+
+			if (sql) {
+				sqlite.exec(sql);
+			}
+		}
+	}
+
+	return drizzle(sqlite, { schema }) as unknown as ProductDb;
+};

--- a/packages/api/src/thinkspaces/permission-policy.test.ts
+++ b/packages/api/src/thinkspaces/permission-policy.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+import { user } from "@better-agent/db/schema/auth";
+import {
+	THINKSPACE_PERMISSION_KINDS,
+	thinkspacePermissions,
+} from "@better-agent/db/schema/permissions";
+import { thinkspaces } from "@better-agent/db/schema/thinkspaces";
+import { eq } from "drizzle-orm";
+
+import { createTestProductDb } from "../testing/product-db";
+import type { ActiveAgentProfileRevision, ToolEnablement } from "./agent-profile";
+import { createPermissionStorePolicy, mcpServerIdFromToolId } from "./permission-policy";
+import { assembleThinkspaceTurn } from "./turn-assembly";
+
+const OWNER_USER_ID = "user_permission_policy";
+const THINKSPACE_ID = "thinkspace_permission_policy";
+const OTHER_THINKSPACE_ID = "thinkspace_permission_policy_other";
+
+const seedThinkspace = async (db: ProductDb, thinkspaceId: string) => {
+	await db.insert(thinkspaces).values({
+		goal: "Track upstream SDK releases.",
+		id: thinkspaceId,
+		ownerUserId: OWNER_USER_ID,
+	});
+};
+
+const createSeededDb = async (): Promise<ProductDb> => {
+	const db = createTestProductDb();
+
+	await db.insert(user).values({
+		email: "owner@example.com",
+		id: OWNER_USER_ID,
+		name: "Owner",
+	});
+	await seedThinkspace(db, THINKSPACE_ID);
+
+	return db;
+};
+
+const grantMcpToolAccess = async (
+	db: ProductDb,
+	serverId: string,
+	thinkspaceId = THINKSPACE_ID,
+) => {
+	await db.insert(thinkspacePermissions).values({
+		grantedByUserId: OWNER_USER_ID,
+		id: `thinkspace_permission_${serverId}_${thinkspaceId}`,
+		kind: THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS,
+		providerId: serverId,
+		thinkspaceId,
+	});
+};
+
+const evaluate = (db: ProductDb, enablements: ToolEnablement[], thinkspaceId = THINKSPACE_ID) =>
+	createPermissionStorePolicy({ db }).evaluateToolPotency({ enablements, thinkspaceId });
+
+test("MCP toolIds resolve to their server id at both server and tool scope", () => {
+	assert.equal(mcpServerIdFromToolId("cloudflare-docs"), "cloudflare-docs");
+	assert.equal(mcpServerIdFromToolId("cloudflare-docs:search_docs"), "cloudflare-docs");
+});
+
+test("built-in enablements are potent with no stored grant", async () => {
+	const db = await createSeededDb();
+
+	const verdicts = await evaluate(db, [{ source: "built_in", toolId: "web_search" }]);
+
+	assert.deepEqual(verdicts, [{ potency: "potent", toolId: "web_search" }]);
+});
+
+test("MCP enablements are inert when no matching grant exists", async () => {
+	const db = await createSeededDb();
+
+	const verdicts = await evaluate(db, [
+		{ source: "mcp_server", toolId: "cloudflare-docs" },
+		{ source: "mcp_server", toolId: "aws-knowledge:search_documentation" },
+	]);
+
+	assert.deepEqual(verdicts, [
+		{ potency: "inert", toolId: "cloudflare-docs" },
+		{ potency: "inert", toolId: "aws-knowledge:search_documentation" },
+	]);
+});
+
+test("a granted MCP tool access Permission makes that server's enablements potent", async () => {
+	const db = await createSeededDb();
+	await grantMcpToolAccess(db, "cloudflare-docs");
+
+	const verdicts = await evaluate(db, [
+		{ source: "mcp_server", toolId: "cloudflare-docs" },
+		{ source: "mcp_server", toolId: "cloudflare-docs:search_docs" },
+		{ source: "mcp_server", toolId: "aws-knowledge" },
+	]);
+
+	assert.deepEqual(verdicts, [
+		{ potency: "potent", toolId: "cloudflare-docs" },
+		{ potency: "potent", toolId: "cloudflare-docs:search_docs" },
+		{ potency: "inert", toolId: "aws-knowledge" },
+	]);
+});
+
+test("grants match on kind: a model-provider credential grant never grants MCP access", async () => {
+	const db = await createSeededDb();
+	await db.insert(thinkspacePermissions).values({
+		grantedByUserId: OWNER_USER_ID,
+		id: "thinkspace_permission_credential",
+		kind: THINKSPACE_PERMISSION_KINDS.MODEL_PROVIDER_CREDENTIAL,
+		providerId: "cloudflare-docs",
+		thinkspaceId: THINKSPACE_ID,
+	});
+
+	const verdicts = await evaluate(db, [{ source: "mcp_server", toolId: "cloudflare-docs" }]);
+
+	assert.deepEqual(verdicts, [{ potency: "inert", toolId: "cloudflare-docs" }]);
+});
+
+test("grants are Thinkspace-scoped: another Thinkspace's grant never leaks", async () => {
+	const db = await createSeededDb();
+	await seedThinkspace(db, OTHER_THINKSPACE_ID);
+	await grantMcpToolAccess(db, "cloudflare-docs", OTHER_THINKSPACE_ID);
+
+	const verdicts = await evaluate(db, [{ source: "mcp_server", toolId: "cloudflare-docs" }]);
+
+	assert.deepEqual(verdicts, [{ potency: "inert", toolId: "cloudflare-docs" }]);
+});
+
+test("Connected Account and Local Node enablements stay inert even with grants present", async () => {
+	const db = await createSeededDb();
+	await grantMcpToolAccess(db, "github");
+
+	const verdicts = await evaluate(db, [
+		{ source: "connected_account", toolId: "github" },
+		{ source: "local_node", toolId: "github" },
+	]);
+
+	assert.deepEqual(verdicts, [
+		{ potency: "inert", toolId: "github" },
+		{ potency: "inert", toolId: "github" },
+	]);
+});
+
+test("a revoked grant makes the tool inert on the next evaluation", async () => {
+	const db = await createSeededDb();
+	await grantMcpToolAccess(db, "cloudflare-docs");
+
+	const enablements: ToolEnablement[] = [{ source: "mcp_server", toolId: "cloudflare-docs" }];
+	const granted = await evaluate(db, enablements);
+	assert.deepEqual(granted, [{ potency: "potent", toolId: "cloudflare-docs" }]);
+
+	await db
+		.delete(thinkspacePermissions)
+		.where(eq(thinkspacePermissions.providerId, "cloudflare-docs"));
+
+	const revoked = await evaluate(db, enablements);
+	assert.deepEqual(revoked, [{ potency: "inert", toolId: "cloudflare-docs" }]);
+});
+
+test("store-backed verdicts feeding turn assembly never activate tools the revision did not enable", async () => {
+	const db = await createSeededDb();
+	await grantMcpToolAccess(db, "cloudflare-docs");
+	await grantMcpToolAccess(db, "aws-knowledge");
+
+	const revision = {
+		id: "profile_revision_active",
+		identity: { displayName: "Release Monitor", instructions: "Watch releases." },
+		modelBehavior: { modelId: "google:gemini-2.5-flash-lite", reasoningLevel: "medium" },
+		status: "active",
+		toolEnablements: [
+			{ source: "built_in", toolId: "web_search" },
+			{ source: "mcp_server", toolId: "cloudflare-docs" },
+			{ source: "mcp_server", toolId: "microsoft-learn" },
+		],
+		version: 3,
+	} as unknown as ActiveAgentProfileRevision;
+
+	// The policy is asked about a superset, mimicking drift between caller
+	// input and the revision; assembly must ignore the extra verdict.
+	const toolPotencies = await evaluate(db, [
+		...revision.toolEnablements,
+		{ source: "mcp_server", toolId: "aws-knowledge" },
+	]);
+
+	const assembly = assembleThinkspaceTurn({ revision, toolPotencies });
+
+	assert.deepEqual(assembly.activeTools, ["web_search", "cloudflare-docs"]);
+});

--- a/packages/api/src/thinkspaces/permission-policy.ts
+++ b/packages/api/src/thinkspaces/permission-policy.ts
@@ -8,9 +8,19 @@
  * layer. Revoking a Permission never edits the Profile — the tool simply
  * goes inert.
  *
- * Permission storage does not exist yet; the adapters here encode only the
- * documented conservative rule and the test seam.
+ * Decision rule (fails closed): built-in-source enablements are potent on
+ * enablement alone; MCP-source enablements are potent only with a matching
+ * granted MCP tool access Permission in Thinkspace Permission storage;
+ * Connected Account and Local Node sources are unconditionally inert in this
+ * slice.
  */
+import type { ProductDb } from "@better-agent/db";
+import {
+	THINKSPACE_PERMISSION_KINDS,
+	thinkspacePermissions,
+} from "@better-agent/db/schema/permissions";
+import { and, eq } from "drizzle-orm";
+
 import type { ToolEnablement } from "./agent-profile";
 
 export type ToolPotency = "potent" | "inert";
@@ -29,27 +39,54 @@ export interface ThinkspacePermissionPolicy {
 	evaluateToolPotency: (input: EvaluateToolPotencyInput) => Promise<ToolPotencyVerdict[]>;
 }
 
-export class PermissionPolicyNotImplementedError extends Error {
-	constructor(message: string) {
-		super(message);
-		this.name = "PermissionPolicyNotImplementedError";
+/**
+ * An MCP enablement's toolId is `${serverId}:${toolName}` (one tool) or
+ * `${serverId}` (the whole server) — see the Thinkspace router's tool
+ * selection mapping. The grant is recorded at server scope, so matching
+ * happens on the server id.
+ */
+export const mcpServerIdFromToolId = (toolId: string): string => {
+	const [serverId] = toolId.split(":");
+
+	return serverId ?? toolId;
+};
+
+const isPotent = (
+	enablement: ToolEnablement,
+	grantedMcpServerIds: ReadonlySet<string>,
+): boolean => {
+	if (enablement.source === "built_in") {
+		return true;
 	}
-}
+
+	if (enablement.source === "mcp_server") {
+		return grantedMcpServerIds.has(mcpServerIdFromToolId(enablement.toolId));
+	}
+
+	// Connected Account and Local Node tools stay inert: no grant kind for
+	// them exists yet, so the system fails closed.
+	return false;
+};
+
+const evaluateAgainstGrants = (
+	enablements: ToolEnablement[],
+	grantedMcpServerIds: ReadonlySet<string>,
+): ToolPotencyVerdict[] =>
+	enablements.map((enablement) => ({
+		potency: isPotent(enablement, grantedMcpServerIds) ? "potent" : "inert",
+		toolId: enablement.toolId,
+	}));
+
+const NO_GRANTS: ReadonlySet<string> = new Set();
 
 /**
- * The documented default until Permission storage exists: safe built-in
- * tools need only enablement; tools reaching protected resources
- * (Connected Accounts, MCP servers, Local Nodes) are inert without a
- * Thinkspace-owned Permission — and no Permission can be granted yet.
+ * Source-default rule with no grant lookup: useful where Permission storage
+ * is out of reach (pure assembly tests) — equivalent to the store-backed
+ * policy when no MCP grant exists.
  */
 export const createEnablementOnlyPermissionPolicy = (): ThinkspacePermissionPolicy => ({
 	evaluateToolPotency: ({ enablements }) =>
-		Promise.resolve(
-			enablements.map((enablement) => ({
-				potency: enablement.source === "built_in" ? "potent" : "inert",
-				toolId: enablement.toolId,
-			})),
-		),
+		Promise.resolve(evaluateAgainstGrants(enablements, NO_GRANTS)),
 });
 
 /** Test adapter with caller-chosen verdicts per tool id. */
@@ -65,15 +102,47 @@ export const createMemoryPermissionPolicy = (
 		),
 });
 
-/**
- * Architecture slot for the real Permission-storage-backed policy. Fails
- * with a typed error until the Permission behavior slice implements it.
- */
-export const createPermissionStorePolicy = (): ThinkspacePermissionPolicy => ({
-	evaluateToolPotency: () =>
-		Promise.reject(
-			new PermissionPolicyNotImplementedError(
-				"Thinkspace Permission storage is not implemented yet.",
+const listGrantedMcpServerIds = async (
+	db: ProductDb,
+	thinkspaceId: string,
+): Promise<ReadonlySet<string>> => {
+	const rows = await db
+		.select({ serverId: thinkspacePermissions.providerId })
+		.from(thinkspacePermissions)
+		.where(
+			and(
+				eq(thinkspacePermissions.thinkspaceId, thinkspaceId),
+				eq(thinkspacePermissions.kind, THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS),
 			),
-		),
+		);
+
+	const grantedServerIds: string[] = [];
+
+	for (const row of rows) {
+		if (row.serverId) {
+			grantedServerIds.push(row.serverId);
+		}
+	}
+
+	return new Set(grantedServerIds);
+};
+
+/**
+ * The real Permission-storage-backed policy: reads granted MCP tool access
+ * Permissions from Thinkspace Permission storage and applies the
+ * source-default rule to everything else.
+ */
+export const createPermissionStorePolicy = ({
+	db,
+}: {
+	db: ProductDb;
+}): ThinkspacePermissionPolicy => ({
+	evaluateToolPotency: async ({ enablements, thinkspaceId }) => {
+		const needsGrantLookup = enablements.some((enablement) => enablement.source === "mcp_server");
+		const grantedMcpServerIds = needsGrantLookup
+			? await listGrantedMcpServerIds(db, thinkspaceId)
+			: NO_GRANTS;
+
+		return evaluateAgainstGrants(enablements, grantedMcpServerIds);
+	},
 });

--- a/packages/db/src/schema/permissions.ts
+++ b/packages/db/src/schema/permissions.ts
@@ -5,6 +5,7 @@ import { timestampMsNow } from "./common";
 import { thinkspaces } from "./thinkspaces";
 
 export const THINKSPACE_PERMISSION_KINDS = {
+	MCP_TOOL_ACCESS: "mcp_tool_access",
 	MODEL_PROVIDER_CREDENTIAL: "model_provider_credential",
 } as const;
 
@@ -18,6 +19,12 @@ export const thinkspacePermissions = sqliteTable(
 		grantedByUserId: text("granted_by_user_id").notNull(),
 		id: text("id").primaryKey(),
 		kind: text("kind").notNull(),
+		/**
+		 * The granted resource identity for kinds that target one: the model
+		 * provider id for `model_provider_credential` grants, the built-in MCP
+		 * server id for `mcp_tool_access` grants. The unique index below gives
+		 * every kind per-Thinkspace, per-resource uniqueness.
+		 */
 		providerId: text("provider_id"),
 		reason: text("reason").default("").notNull(),
 		thinkspaceId: text("thinkspace_id")


### PR DESCRIPTION
## Summary
- implement the store-backed Thinkspace Permission policy for tool potency
- wire Thinkspace Agent beforeTurn to evaluate real policy verdicts instead of an empty verdict list
- add migration-backed in-memory DB tests for granted, missing, revoked, and source-default scenarios

## Validation
- bun run check-types
- bun test
- bun x ultracite check apps/server/src/agents/thinkspace-agent.ts apps/server/src/worker-routes.test.ts packages/api/src/thinkspaces/permission-policy.ts packages/api/src/thinkspaces/permission-policy.test.ts packages/api/src/testing/product-db.ts packages/api/src/testing/bun-sqlite.d.ts packages/db/src/schema/permissions.ts

Closes #61