### PR TITLE
Make MCP tool access a grantable Thinkspace Permission

### DIFF
--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -31,10 +31,12 @@ interface EnabledToolSelection {
 	toolName?: string;
 }
 
-interface PermissionPlaceholder {
+type McpToolAccessScopeView = { type: "server" } | { toolName: string; type: "tool" };
+
+interface PermissionRequestView {
 	actions?: string[];
 	approvalRequired?: boolean;
-	kind?: "model_provider_credential";
+	kind?: "mcp_tool_access" | "model_provider_credential";
 	providerId?: string;
 	reason?: string;
 	resource?: {
@@ -42,6 +44,8 @@ interface PermissionPlaceholder {
 		toolName: string;
 	};
 	risk?: string;
+	scope?: McpToolAccessScopeView;
+	serverId?: string;
 	type?: string;
 }
 
@@ -50,6 +54,7 @@ interface GrantedPermissionView {
 	kind: string;
 	providerId: string | null;
 	reason: string;
+	resourceScope: string;
 }
 
 interface AgentProfileRevisionView {
@@ -61,7 +66,7 @@ interface AgentProfileRevisionView {
 		modelId: string;
 		reasoningLevel: string;
 	};
-	requestedPermissions?: PermissionPlaceholder[];
+	requestedPermissions?: PermissionRequestView[];
 	status: "active" | "draft" | "superseded";
 	toolEnablements: { source: string; toolId: string }[];
 	version: number;
@@ -71,6 +76,80 @@ const toEnabledToolSelection = (enablement: { toolId: string }): EnabledToolSele
 	const [serverId, toolName] = enablement.toolId.split(":", 2);
 
 	return { risk: "unknown", serverId: serverId ?? enablement.toolId, toolName };
+};
+
+const formatMcpScope = (scope: McpToolAccessScopeView | undefined): string => {
+	if (!scope) {
+		return "server scope";
+	}
+
+	return scope.type === "server" ? "server scope" : `tool: ${scope.toolName}`;
+};
+
+const parseStoredMcpScope = (value: string): McpToolAccessScopeView | undefined => {
+	try {
+		const parsed = JSON.parse(value) as unknown;
+
+		if (typeof parsed === "object" && parsed !== null && "type" in parsed) {
+			const { type } = parsed as { type?: unknown };
+			if (type === "server") {
+				return { type: "server" };
+			}
+			if (type === "tool" && typeof (parsed as { toolName?: unknown }).toolName === "string") {
+				return { toolName: (parsed as { toolName: string }).toolName, type: "tool" };
+			}
+		}
+	} catch {
+		return undefined;
+	}
+
+	return undefined;
+};
+
+const getPermissionRequestTitle = (permission: PermissionRequestView, index: number): string => {
+	if (permission.kind === "model_provider_credential") {
+		return `Model credential: ${permission.providerId}`;
+	}
+
+	if (permission.kind === "mcp_tool_access") {
+		return `MCP tool access: ${permission.serverId}`;
+	}
+
+	return `${permission.resource?.serverId ?? `Permission request ${index + 1}`}${
+		permission.resource?.toolName ? `/${permission.resource.toolName}` : ""
+	}`;
+};
+
+const getPermissionRequestDescription = (permission: PermissionRequestView): string => {
+	if (permission.kind === "mcp_tool_access") {
+		return `${formatMcpScope(permission.scope)} · Risk: ${permission.risk ?? "unknown"} · ${permission.reason ?? "No reason provided."}`;
+	}
+
+	return (
+		permission.reason ??
+		`Risk: ${permission.risk ?? "unknown"} · Approval required: ${permission.approvalRequired ? "yes" : "no"}`
+	);
+};
+
+const getGrantedPermissionTitle = (permission: GrantedPermissionView): string => {
+	if (permission.kind === "mcp_tool_access") {
+		return `MCP tool access: ${permission.providerId ?? "scoped server"}`;
+	}
+
+	if (permission.kind === "model_provider_credential") {
+		return `Model credential: ${permission.providerId ?? "provider"}`;
+	}
+
+	return `${permission.kind}: ${permission.providerId ?? "scoped resource"}`;
+};
+
+const getGrantedPermissionDescription = (permission: GrantedPermissionView): string => {
+	const scope =
+		permission.kind === "mcp_tool_access"
+			? `${formatMcpScope(parseStoredMcpScope(permission.resourceScope))} · `
+			: "";
+
+	return `${scope}${permission.reason || "No reason provided."}`;
 };
 
 type TurnInspectionStatus = "accepted" | "completed" | "failed" | "running" | "unknown";
@@ -378,7 +457,7 @@ const PermissionsSection = ({
 	requestedPermissions,
 }: {
 	grantedPermissions: GrantedPermissionView[];
-	requestedPermissions: PermissionPlaceholder[];
+	requestedPermissions: PermissionRequestView[];
 }) => (
 	<section aria-labelledby="permissions-heading" className="grid gap-4">
 		<div className="grid gap-1">
@@ -400,17 +479,14 @@ const PermissionsSection = ({
 					<div className="border border-border">
 						{requestedPermissions.map((permission, index) => (
 							<div
-								key={`${permission.kind ?? permission.type}:${permission.providerId ?? permission.resource?.serverId ?? index}`}
+								key={`${permission.kind ?? permission.type}:${permission.providerId ?? permission.serverId ?? permission.resource?.serverId ?? index}`}
 								className={`grid gap-0.5 p-4 ${index < requestedPermissions.length - 1 ? "border-b border-border" : ""}`}
 							>
 								<p className="text-sm font-medium">
-									{permission.kind === "model_provider_credential"
-										? `Model credential: ${permission.providerId}`
-										: `${permission.resource?.serverId ?? "Tool"}${permission.resource?.toolName ? `/${permission.resource.toolName}` : ""}`}
+									{getPermissionRequestTitle(permission, index)}
 								</p>
 								<p className="text-muted-foreground text-xs">
-									{permission.reason ??
-										`Risk: ${permission.risk ?? "unknown"} · Approval required: ${permission.approvalRequired ? "yes" : "no"}`}
+									{getPermissionRequestDescription(permission)}
 								</p>
 							</div>
 						))}
@@ -430,10 +506,10 @@ const PermissionsSection = ({
 								key={permission.id}
 								className={`grid gap-0.5 p-4 ${index < grantedPermissions.length - 1 ? "border-b border-border" : ""}`}
 							>
-								<p className="text-sm font-medium">
-									{permission.kind}: {permission.providerId ?? "scoped resource"}
+								<p className="text-sm font-medium">{getGrantedPermissionTitle(permission)}</p>
+								<p className="text-muted-foreground text-xs">
+									{getGrantedPermissionDescription(permission)}
 								</p>
-								<p className="text-muted-foreground text-xs">{permission.reason}</p>
 							</div>
 						))}
 					</div>

--- a/packages/api/src/testing/product-db.ts
+++ b/packages/api/src/testing/product-db.ts
@@ -35,5 +35,10 @@ export const createTestProductDb = (): ProductDb => {
 		}
 	}
 
-	return drizzle(sqlite, { schema }) as unknown as ProductDb;
+	const db = drizzle(sqlite, { schema });
+	const dbWithBatch: unknown = Object.assign(db, {
+		batch: async (queries: readonly PromiseLike<unknown>[]) => await Promise.all(queries),
+	});
+
+	return dbWithBatch as ProductDb;
 };

--- a/packages/api/src/thinkspaces/agent-profile-lifecycle.test.ts
+++ b/packages/api/src/thinkspaces/agent-profile-lifecycle.test.ts
@@ -151,6 +151,14 @@ test("requested Permissions never carry past activation", () => {
 				providerId: "anthropic" as const,
 				reason: "Use the saved Anthropic credential for this Thinkspace.",
 			},
+			{
+				kind: "mcp_tool_access" as const,
+				reason:
+					"Allow this Thinkspace Agent to read all explicitly enabled tools from the cloudflare-docs MCP server.",
+				risk: "read_only" as const,
+				scope: { type: "server" as const },
+				serverId: "cloudflare-docs",
+			},
 		],
 	};
 

--- a/packages/api/src/thinkspaces/agent-profile.test.ts
+++ b/packages/api/src/thinkspaces/agent-profile.test.ts
@@ -131,6 +131,16 @@ test("routine validation requires identity, instruction, and a usable schedule",
 
 test("rows round-trip through parse and serialize", () => {
 	const row = createRow({
+		requestedPermissions: JSON.stringify([
+			{
+				kind: "mcp_tool_access",
+				reason:
+					"Allow this Thinkspace Agent to read all explicitly enabled tools from the cloudflare-docs MCP server.",
+				risk: "read_only",
+				scope: { type: "server" },
+				serverId: "cloudflare-docs",
+			},
+		]),
 		routines:
 			'[{"instruction":"Check releases.","name":"Weekly","routineId":"routine_1","schedule":{"expression":"0 9 * * 1","kind":"cron"}}]',
 		toolEnablements: '[{"source":"built_in","toolId":"web_search"}]',

--- a/packages/api/src/thinkspaces/agent-profile.ts
+++ b/packages/api/src/thinkspaces/agent-profile.ts
@@ -112,20 +112,22 @@ export interface ModelProviderCredentialPermissionRequest {
 	reason: string;
 }
 
-export interface ToolPermissionPlaceholderRequest {
-	actions: string[];
-	approvalRequired: boolean;
-	resource: {
-		serverId: string;
-		toolName: string;
-	};
-	risk: "read_only" | "mutating" | "unknown";
-	type: "mcp_tool_permission_placeholder";
+export const MCP_TOOL_ACCESS_REQUEST_RISKS = ["read_only", "mutating", "unknown"] as const;
+export type McpToolAccessRequestRisk = (typeof MCP_TOOL_ACCESS_REQUEST_RISKS)[number];
+
+export type McpToolAccessScope = { type: "server" } | { toolName: string; type: "tool" };
+
+export interface McpToolAccessPermissionRequest {
+	kind: "mcp_tool_access";
+	reason: string;
+	risk: McpToolAccessRequestRisk;
+	scope: McpToolAccessScope;
+	serverId: string;
 }
 
 export type RequestedPermission =
 	| ModelProviderCredentialPermissionRequest
-	| ToolPermissionPlaceholderRequest;
+	| McpToolAccessPermissionRequest;
 
 interface AgentProfileRevisionBase {
 	createdAt: Date;
@@ -321,30 +323,34 @@ const isRoutine = (value: unknown): value is Routine =>
 	isNonEmptyString(value.instruction) &&
 	isRoutineSchedule(value.schedule);
 
-const isToolPermissionPlaceholderRequest = (
-	value: unknown,
-): value is ToolPermissionPlaceholderRequest => {
-	if (!(isRecord(value) && isRecord(value.resource))) {
+const isMcpToolAccessScope = (value: unknown): value is McpToolAccessScope => {
+	if (!isRecord(value)) {
 		return false;
 	}
 
-	return (
-		value.type === "mcp_tool_permission_placeholder" &&
-		Array.isArray(value.actions) &&
-		value.actions.every((action) => typeof action === "string" && action.length > 0) &&
-		typeof value.approvalRequired === "boolean" &&
-		isNonEmptyString(value.resource.serverId) &&
-		isNonEmptyString(value.resource.toolName) &&
-		(value.risk === "read_only" || value.risk === "mutating" || value.risk === "unknown")
-	);
+	if (value.type === "server") {
+		return true;
+	}
+
+	return value.type === "tool" && isNonEmptyString(value.toolName);
 };
+
+const isMcpToolAccessPermissionRequest = (
+	value: unknown,
+): value is McpToolAccessPermissionRequest =>
+	isRecord(value) &&
+	value.kind === "mcp_tool_access" &&
+	isNonEmptyString(value.serverId) &&
+	MCP_TOOL_ACCESS_REQUEST_RISKS.includes(value.risk as McpToolAccessRequestRisk) &&
+	isMcpToolAccessScope(value.scope) &&
+	typeof value.reason === "string";
 
 const isRequestedPermission = (value: unknown): value is RequestedPermission =>
 	(isRecord(value) &&
 		value.kind === "model_provider_credential" &&
 		MODEL_PROVIDER_IDS.includes(value.providerId as ModelProviderId) &&
 		typeof value.reason === "string") ||
-	isToolPermissionPlaceholderRequest(value);
+	isMcpToolAccessPermissionRequest(value);
 
 const parseJsonArray = <T>(
 	label: string,

--- a/packages/api/src/thinkspaces/permissions.test.ts
+++ b/packages/api/src/thinkspaces/permissions.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { user } from "@better-agent/db/schema/auth";
+import { THINKSPACE_PERMISSION_KINDS } from "@better-agent/db/schema/permissions";
+import { thinkspaces } from "@better-agent/db/schema/thinkspaces";
+
+import type { BuiltInMcpServer } from "../mcp/catalog";
+import { createTestProductDb } from "../testing/product-db";
+import type { McpToolAccessPermissionRequest } from "./agent-profile";
+import {
+	prepareThinkspacePermissionGrants,
+	saveThinkspacePermissionGrants,
+	ThinkspacePermissionGrantError,
+	toThinkspacePermissionGrant,
+} from "./permissions";
+
+const OWNER_USER_ID = "user_permission_grants";
+const THINKSPACE_ID = "thinkspace_permission_grants";
+
+const readOnlyAuthFreeServer: BuiltInMcpServer = {
+	authType: "none",
+	description: "Docs.",
+	enabledByDefaultForThinkspaces: false,
+	id: "docs",
+	name: "Docs",
+	riskLevel: "read_only",
+	transport: "streamable_http",
+	url: "https://example.com/mcp",
+};
+
+const mcpRequest = (
+	overrides: Partial<McpToolAccessPermissionRequest> = {},
+): McpToolAccessPermissionRequest => ({
+	kind: "mcp_tool_access",
+	reason: "Allow this Thinkspace Agent to read docs.",
+	risk: "read_only",
+	scope: { type: "server" },
+	serverId: "docs",
+	...overrides,
+});
+
+const grantInput = (permission = mcpRequest()) => ({
+	grantedByUserId: OWNER_USER_ID,
+	permission,
+	thinkspaceId: THINKSPACE_ID,
+});
+
+const createSeededDb = async () => {
+	const db = createTestProductDb();
+	await db
+		.insert(user)
+		.values({ email: "grant-owner@example.com", id: OWNER_USER_ID, name: "Owner" });
+	await db
+		.insert(thinkspaces)
+		.values({ goal: "Read docs", id: THINKSPACE_ID, ownerUserId: OWNER_USER_ID });
+
+	return db;
+};
+
+test("model-provider credential requests still convert into credential grants", () => {
+	const grant = toThinkspacePermissionGrant({
+		grantedByUserId: OWNER_USER_ID,
+		permission: {
+			kind: "model_provider_credential",
+			providerId: "google",
+			reason: "Use the saved Google credential.",
+		},
+		thinkspaceId: THINKSPACE_ID,
+	});
+
+	assert.equal(grant?.kind, THINKSPACE_PERMISSION_KINDS.MODEL_PROVIDER_CREDENTIAL);
+	assert.equal(grant?.providerId, "google");
+	assert.equal(grant?.resourceScope, JSON.stringify({ type: "model_provider" }));
+});
+
+test("grantable MCP requests convert into MCP tool access grants with explicit scope", () => {
+	const grant = toThinkspacePermissionGrant(grantInput(), {
+		builtInMcpServers: [readOnlyAuthFreeServer],
+	});
+
+	assert.equal(grant?.kind, THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS);
+	assert.equal(grant?.providerId, "docs");
+	assert.equal(grant?.resourceScope, JSON.stringify({ type: "server" }));
+});
+
+test("MCP grants reject servers outside the built-in catalog", () => {
+	assert.throws(
+		() => toThinkspacePermissionGrant(grantInput(), { builtInMcpServers: [] }),
+		ThinkspacePermissionGrantError,
+	);
+});
+
+test("MCP grants reject servers requiring auth, non-read-only requests, and unsafe URLs", () => {
+	assert.throws(
+		() =>
+			toThinkspacePermissionGrant(grantInput(), {
+				builtInMcpServers: [{ ...readOnlyAuthFreeServer, authType: "api_key_header" }],
+			}),
+		ThinkspacePermissionGrantError,
+	);
+	assert.throws(
+		() =>
+			toThinkspacePermissionGrant(grantInput(mcpRequest({ risk: "mutating" })), {
+				builtInMcpServers: [readOnlyAuthFreeServer],
+			}),
+		ThinkspacePermissionGrantError,
+	);
+	assert.throws(
+		() =>
+			toThinkspacePermissionGrant(grantInput(), {
+				builtInMcpServers: [{ ...readOnlyAuthFreeServer, riskLevel: "mutating" }],
+			}),
+		ThinkspacePermissionGrantError,
+	);
+	assert.throws(
+		() =>
+			toThinkspacePermissionGrant(grantInput(), {
+				builtInMcpServers: [{ ...readOnlyAuthFreeServer, url: "http://127.0.0.1/mcp" }],
+			}),
+		ThinkspacePermissionGrantError,
+	);
+});
+
+test("MCP grants keep per-Thinkspace uniqueness by kind and server id", async () => {
+	const db = await createSeededDb();
+	const firstGrant = prepareThinkspacePermissionGrants([grantInput()], {
+		builtInMcpServers: [readOnlyAuthFreeServer],
+	});
+	await saveThinkspacePermissionGrants(db, firstGrant);
+
+	const replacementGrant = prepareThinkspacePermissionGrants(
+		[
+			grantInput(
+				mcpRequest({
+					reason: "Allow one docs tool.",
+					scope: { toolName: "search_docs", type: "tool" },
+				}),
+			),
+		],
+		{ builtInMcpServers: [readOnlyAuthFreeServer] },
+	);
+	const saved = await saveThinkspacePermissionGrants(db, replacementGrant);
+
+	assert.equal(saved.length, 1);
+	assert.equal(saved[0]?.providerId, "docs");
+	assert.equal(saved[0]?.reason, "Allow one docs tool.");
+	assert.equal(saved[0]?.resourceScope, JSON.stringify({ toolName: "search_docs", type: "tool" }));
+});

--- a/packages/api/src/thinkspaces/permissions.ts
+++ b/packages/api/src/thinkspaces/permissions.ts
@@ -11,7 +11,10 @@ import { and, eq } from "drizzle-orm";
 
 import { MODEL_PROVIDER_IDS } from "../models/catalog";
 import type { ModelProviderId } from "../models/catalog";
-import type { RequestedPermission } from "./agent-profile";
+import { listBuiltInMcpServers } from "../mcp/catalog";
+import type { BuiltInMcpServer } from "../mcp/catalog";
+import { assertSafeMcpServerUrl } from "../mcp/url-policy";
+import type { McpToolAccessPermissionRequest, RequestedPermission } from "./agent-profile";
 
 export interface GrantThinkspacePermissionInput {
 	grantedByUserId: string;
@@ -19,42 +22,115 @@ export interface GrantThinkspacePermissionInput {
 	thinkspaceId: string;
 }
 
+export interface ThinkspacePermissionGrantOptions {
+	allowInsecureDevUrls?: boolean;
+	builtInMcpServers?: BuiltInMcpServer[];
+}
+
+export class ThinkspacePermissionGrantError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ThinkspacePermissionGrantError";
+	}
+}
+
+const MODEL_PROVIDER_SCOPE = JSON.stringify({ type: "model_provider" });
+
 const isModelProviderId = (value: string): value is ModelProviderId =>
 	MODEL_PROVIDER_IDS.includes(value as ModelProviderId);
 
 const createPermissionId = (): string => `thinkspace_permission_${crypto.randomUUID()}`;
 
-export const toThinkspacePermissionGrant = ({
-	grantedByUserId,
-	permission,
-	thinkspaceId,
-}: GrantThinkspacePermissionInput): NewThinkspacePermission | null => {
-	if (!("kind" in permission) || permission.kind !== "model_provider_credential") {
-		return null;
+const findBuiltInMcpServer = (
+	serverId: string,
+	options: ThinkspacePermissionGrantOptions,
+): BuiltInMcpServer | null => {
+	const catalog = options.builtInMcpServers ?? listBuiltInMcpServers();
+
+	return catalog.find((server) => server.id === serverId) ?? null;
+};
+
+const assertGrantableMcpToolAccess = (
+	permission: McpToolAccessPermissionRequest,
+	options: ThinkspacePermissionGrantOptions,
+): BuiltInMcpServer => {
+	const server = findBuiltInMcpServer(permission.serverId, options);
+
+	if (!server) {
+		throw new ThinkspacePermissionGrantError(
+			"Only built-in MCP servers can be granted to a Thinkspace in this slice.",
+		);
 	}
 
-	if (!isModelProviderId(permission.providerId)) {
-		return null;
+	if (server.authType !== "none") {
+		throw new ThinkspacePermissionGrantError(
+			"MCP servers that require authentication are not grantable in this slice.",
+		);
 	}
+
+	if (server.riskLevel !== "read_only" || permission.risk !== "read_only") {
+		throw new ThinkspacePermissionGrantError(
+			"Only read-only MCP tool access is grantable in this slice.",
+		);
+	}
+
+	try {
+		assertSafeMcpServerUrl(server.url, options.allowInsecureDevUrls ?? false);
+	} catch {
+		throw new ThinkspacePermissionGrantError("MCP server URL policy rejected this grant.");
+	}
+
+	return server;
+};
+
+const serializeMcpToolAccessScope = (permission: McpToolAccessPermissionRequest): string =>
+	JSON.stringify(permission.scope);
+
+export const toThinkspacePermissionGrant = (
+	{ grantedByUserId, permission, thinkspaceId }: GrantThinkspacePermissionInput,
+	options: ThinkspacePermissionGrantOptions = {},
+): NewThinkspacePermission | null => {
+	if (permission.kind === "model_provider_credential") {
+		if (!isModelProviderId(permission.providerId)) {
+			return null;
+		}
+
+		return {
+			grantedByUserId,
+			id: createPermissionId(),
+			kind: THINKSPACE_PERMISSION_KINDS.MODEL_PROVIDER_CREDENTIAL,
+			providerId: permission.providerId,
+			reason: permission.reason,
+			resourceScope: MODEL_PROVIDER_SCOPE,
+			thinkspaceId,
+		};
+	}
+
+	assertGrantableMcpToolAccess(permission, options);
 
 	return {
 		grantedByUserId,
 		id: createPermissionId(),
-		kind: THINKSPACE_PERMISSION_KINDS.MODEL_PROVIDER_CREDENTIAL,
-		providerId: permission.providerId,
+		kind: THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS,
+		providerId: permission.serverId,
 		reason: permission.reason,
+		resourceScope: serializeMcpToolAccessScope(permission),
 		thinkspaceId,
 	};
 };
 
-export const grantThinkspacePermissions = async (
-	db: ProductDb,
+export const prepareThinkspacePermissionGrants = (
 	inputs: GrantThinkspacePermissionInput[],
-): Promise<ThinkspacePermission[]> => {
-	const grants = inputs
-		.map(toThinkspacePermissionGrant)
+	options: ThinkspacePermissionGrantOptions = {},
+): NewThinkspacePermission[] =>
+	inputs
+		.map((input) => toThinkspacePermissionGrant(input, options))
 		.filter((grant): grant is NewThinkspacePermission => grant !== null);
 
+export const saveThinkspacePermissionGrants = async (
+	db: ProductDb,
+	grants: NewThinkspacePermission[],
+): Promise<ThinkspacePermission[]> => {
 	if (grants.length === 0) {
 		return [];
 	}
@@ -68,6 +144,7 @@ export const grantThinkspacePermissions = async (
 					set: {
 						grantedByUserId: grant.grantedByUserId,
 						reason: grant.reason,
+						resourceScope: grant.resourceScope,
 					},
 					target: [
 						thinkspacePermissions.thinkspaceId,
@@ -87,6 +164,13 @@ export const grantThinkspacePermissions = async (
 
 	return saved;
 };
+
+export const grantThinkspacePermissions = async (
+	db: ProductDb,
+	inputs: GrantThinkspacePermissionInput[],
+	options: ThinkspacePermissionGrantOptions = {},
+): Promise<ThinkspacePermission[]> =>
+	await saveThinkspacePermissionGrants(db, prepareThinkspacePermissionGrants(inputs, options));
 
 export const hasThinkspaceModelProviderCredentialPermission = async (
 	db: ProductDb,

--- a/packages/api/src/thinkspaces/policy.test.ts
+++ b/packages/api/src/thinkspaces/policy.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import {
 	assessPermissionPolicy,
-	createToolPermissionPlaceholder,
+	createMcpToolAccessPermissionRequest,
 	DEFAULT_APPROVAL_POLICY,
 	PermissionPolicyError,
 	serializeThinkspaceToolSelections,
@@ -44,12 +44,28 @@ test("serializes explicit Thinkspace tool selections and rejects duplicates", ()
 	);
 });
 
-test("permission placeholders keep possible access separate from Approval", () => {
-	assert.deepEqual(createToolPermissionPlaceholder({ risk: "unknown", serverId: "custom" }), {
-		actions: ["propose_action"],
-		approvalRequired: true,
-		resource: { serverId: "custom", toolName: "any_explicitly_enabled_tool" },
+test("MCP tool access requests keep possible access separate from Approval", () => {
+	assert.deepEqual(createMcpToolAccessPermissionRequest({ risk: "unknown", serverId: "custom" }), {
+		kind: "mcp_tool_access",
+		reason:
+			"Allow this Thinkspace Agent to read all explicitly enabled tools from the custom MCP server.",
 		risk: "unknown",
-		type: "mcp_tool_permission_placeholder",
+		scope: { type: "server" },
+		serverId: "custom",
 	});
+	assert.deepEqual(
+		createMcpToolAccessPermissionRequest({
+			risk: "read_only",
+			serverId: "cloudflare-docs",
+			toolName: "search_docs",
+		}),
+		{
+			kind: "mcp_tool_access",
+			reason:
+				"Allow this Thinkspace Agent to read search_docs from the cloudflare-docs MCP server.",
+			risk: "read_only",
+			scope: { toolName: "search_docs", type: "tool" },
+			serverId: "cloudflare-docs",
+		},
+	);
 });

--- a/packages/api/src/thinkspaces/policy.ts
+++ b/packages/api/src/thinkspaces/policy.ts
@@ -45,16 +45,20 @@ export const assessPermissionPolicy = ({
 	return "approved_action_required";
 };
 
-export const createToolPermissionPlaceholder = (selection: ThinkspaceToolSelection) => ({
-	actions: selection.risk === "read_only" ? ["read"] : ["propose_action"],
-	approvalRequired: selection.risk !== "read_only",
-	resource: {
-		serverId: selection.serverId,
-		toolName: selection.toolName ?? "any_explicitly_enabled_tool",
-	},
-	risk: selection.risk,
-	type: "mcp_tool_permission_placeholder",
-});
+export const createMcpToolAccessPermissionRequest = (selection: ThinkspaceToolSelection) => {
+	const serverId = selection.serverId.trim();
+	const toolName = selection.toolName?.trim() || undefined;
+	const scope = toolName ? ({ toolName, type: "tool" } as const) : ({ type: "server" } as const);
+	const scopeLabel = scope.type === "server" ? "all explicitly enabled tools" : scope.toolName;
+
+	return {
+		kind: "mcp_tool_access" as const,
+		reason: `Allow this Thinkspace Agent to read ${scopeLabel} from the ${serverId} MCP server.`,
+		risk: selection.risk,
+		scope,
+		serverId,
+	};
+};
 
 export const serializeThinkspaceToolSelections = (
 	selections: ThinkspaceToolSelection[],

--- a/packages/api/src/thinkspaces/router.test.ts
+++ b/packages/api/src/thinkspaces/router.test.ts
@@ -2,8 +2,16 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import type { ProductDb } from "@better-agent/db";
+import { thinkspaceAgentProfiles } from "@better-agent/db/schema/agent-profiles";
+import { user } from "@better-agent/db/schema/auth";
+import {
+	THINKSPACE_PERMISSION_KINDS,
+	thinkspacePermissions,
+} from "@better-agent/db/schema/permissions";
+import { thinkspaces } from "@better-agent/db/schema/thinkspaces";
 import { ORPCError, call } from "@orpc/server";
 import type { AnyProcedure } from "@orpc/server";
+import { eq } from "drizzle-orm";
 
 import type { Context } from "../context";
 import { getModelCatalog } from "../models/catalog";
@@ -11,6 +19,7 @@ import type { ModelCatalogEntry } from "../models/catalog";
 import { encryptCredential } from "../models/credentials";
 import { createMemoryModelCatalog } from "../models/model-catalog";
 import type { ModelCatalog } from "../models/model-catalog";
+import { createTestProductDb } from "../testing/product-db";
 import { thinkspacesRouter } from "./router";
 import type { ThinkspaceTurnInspection } from "./inspect";
 import type { ThinkspaceTurnAcceptance } from "./turns";
@@ -187,6 +196,47 @@ const createCallContext = ({
 		session,
 	}) as unknown as Context;
 
+const firstClassMcpPermissionRequest = (serverId = "cloudflare-docs") => ({
+	kind: "mcp_tool_access" as const,
+	reason: `Allow this Thinkspace Agent to read all explicitly enabled tools from the ${serverId} MCP server.`,
+	risk: "read_only" as const,
+	scope: { type: "server" as const },
+	serverId,
+});
+
+const seedRealThinkspaceWithProfile = async ({
+	db,
+	profileStatus = "draft",
+	requestedPermissions = [],
+	thinkspaceStatus = "draft",
+}: {
+	db: ProductDb;
+	profileStatus?: "active" | "draft";
+	requestedPermissions?: unknown[];
+	thinkspaceStatus?: "active" | "draft";
+}) => {
+	await db.insert(user).values({
+		email: "owner@example.com",
+		id: authenticatedSession.user.id,
+		name: "Owner",
+	});
+	await db.insert(thinkspaces).values({
+		configurationSummary: "Watch release notes and draft a handoff.",
+		goal: "Monitor releases",
+		id: OWNED_THINKSPACE_ID,
+		ownerUserId: authenticatedSession.user.id,
+		status: thinkspaceStatus,
+	});
+	await db.insert(thinkspaceAgentProfiles).values({
+		...ownedAgentProfileColumns(profileStatus),
+		id: `profile_${profileStatus}_${crypto.randomUUID()}`,
+		requestedPermissions: JSON.stringify(requestedPermissions),
+		status: profileStatus,
+		thinkspaceId: OWNED_THINKSPACE_ID,
+		toolEnablements: JSON.stringify([{ source: "mcp_server", toolId: "cloudflare-docs" }]),
+	});
+};
+
 interface RuntimeOperationAttempt {
 	input: Record<string, string>;
 	name: string;
@@ -299,6 +349,71 @@ test("owners can activate the draft Agent Profile revision and draft Thinkspace 
 	assert.ok(patches.some((patch) => patch.status === "active" && !("version" in patch)));
 });
 
+test("activating a granted MCP request creates a Thinkspace Permission grant and clears active requests", async () => {
+	const db = createTestProductDb();
+	await seedRealThinkspaceWithProfile({
+		db,
+		requestedPermissions: [firstClassMcpPermissionRequest()],
+	});
+
+	const activation = await call(
+		thinkspacesRouter.activateAgentProfile,
+		{ grantedPermissionIndexes: [0], thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+
+	assert.ok(activation);
+	assert.equal(activation.activatedRevision.status, "active");
+	assert.equal("requestedPermissions" in activation.activatedRevision, false);
+	assert.equal(activation.grantedPermissions.length, 1);
+	assert.equal(activation.grantedPermissions[0]?.kind, THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS);
+	assert.equal(activation.grantedPermissions[0]?.providerId, "cloudflare-docs");
+	assert.equal(activation.grantedPermissions[0]?.resourceScope, JSON.stringify({ type: "server" }));
+});
+
+test("declining an MCP request creates no grant while activation still succeeds", async () => {
+	const db = createTestProductDb();
+	await seedRealThinkspaceWithProfile({
+		db,
+		requestedPermissions: [firstClassMcpPermissionRequest()],
+	});
+
+	const activation = await call(
+		thinkspacesRouter.activateAgentProfile,
+		{ grantedPermissionIndexes: [], thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+	const grants = await db.select().from(thinkspacePermissions);
+
+	assert.ok(activation);
+	assert.equal(activation.activatedRevision.status, "active");
+	assert.deepEqual(activation.grantedPermissions, []);
+	assert.deepEqual(grants, []);
+});
+
+test("invalid MCP grants reject before the draft activates", async () => {
+	const db = createTestProductDb();
+	await seedRealThinkspaceWithProfile({
+		db,
+		requestedPermissions: [firstClassMcpPermissionRequest("context7")],
+	});
+
+	await assert.rejects(
+		call(
+			thinkspacesRouter.activateAgentProfile,
+			{ thinkspaceId: OWNED_THINKSPACE_ID },
+			{ context: createCallContext({ db }) },
+		),
+		expectCode("BAD_REQUEST"),
+	);
+
+	const [revision] = await db
+		.select({ status: thinkspaceAgentProfiles.status })
+		.from(thinkspaceAgentProfiles)
+		.where(eq(thinkspaceAgentProfiles.thinkspaceId, OWNED_THINKSPACE_ID));
+	assert.equal(revision?.status, "draft");
+});
+
 test("updating tools writes enablements and permission requests to the draft Agent Profile", async () => {
 	const { db, saved } = createDbForAgentProfileDraftUpdate(
 		ownedThinkspaceRow({ ...ownedAgentProfileColumns("draft"), status: "draft" }),
@@ -320,7 +435,8 @@ test("updating tools writes enablements and permission requests to the draft Age
 		saved[0]?.toolEnablements,
 		'[{"source":"mcp_server","toolId":"github:create_issue"}]',
 	);
-	assert.match(String(saved[0]?.requestedPermissions), /mcp_tool_permission_placeholder/u);
+	assert.match(String(saved[0]?.requestedPermissions), /mcp_tool_access/u);
+	assert.doesNotMatch(String(saved[0]?.requestedPermissions), /mcp_tool_permission_placeholder/u);
 	assert.equal("enabledToolIds" in (saved[0] ?? {}), false);
 });
 
@@ -616,4 +732,43 @@ test("Thinkspace control-plane reads still work for owners", async () => {
 	assert.equal(thinkspace.id, OWNED_THINKSPACE_ID);
 	assert.equal(thinkspace.agentProfileRevision?.identity.instructions, "Watch SDK releases.");
 	assert.equal(listed.length, 1);
+});
+
+test("Thinkspace detail includes MCP grants and remains owner-gated", async () => {
+	const db = createTestProductDb();
+	await seedRealThinkspaceWithProfile({ db, profileStatus: "active", thinkspaceStatus: "active" });
+	await db.insert(thinkspacePermissions).values({
+		grantedByUserId: authenticatedSession.user.id,
+		id: "thinkspace_permission_cloudflare_docs",
+		kind: THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS,
+		providerId: "cloudflare-docs",
+		reason: "Allow this Thinkspace Agent to read Cloudflare docs.",
+		resourceScope: JSON.stringify({ type: "server" }),
+		thinkspaceId: OWNED_THINKSPACE_ID,
+	});
+
+	const thinkspace = await call(
+		thinkspacesRouter.get,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+
+	assert.equal(thinkspace.grantedPermissions.length, 1);
+	assert.equal(thinkspace.grantedPermissions[0]?.kind, THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS);
+	assert.equal(thinkspace.grantedPermissions[0]?.providerId, "cloudflare-docs");
+	assert.equal(thinkspace.grantedPermissions[0]?.resourceScope, JSON.stringify({ type: "server" }));
+
+	await assert.rejects(
+		call(
+			thinkspacesRouter.get,
+			{ thinkspaceId: OWNED_THINKSPACE_ID },
+			{
+				context: createCallContext({
+					db,
+					session: { session: { id: "session_other" }, user: { id: "other_user" } },
+				}),
+			},
+		),
+		expectCode("NOT_FOUND"),
+	);
 });

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -31,8 +31,13 @@ import {
 	saveAgentProfileDraft,
 } from "./agent-profile-repository";
 import { inspectOwnedThinkspaceTurn, THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH } from "./inspect";
-import { grantThinkspacePermissions, listThinkspacePermissions } from "./permissions";
-import { createToolPermissionPlaceholder, serializeThinkspaceToolSelections } from "./policy";
+import {
+	listThinkspacePermissions,
+	prepareThinkspacePermissionGrants,
+	saveThinkspacePermissionGrants,
+	ThinkspacePermissionGrantError,
+} from "./permissions";
+import { createMcpToolAccessPermissionRequest, serializeThinkspaceToolSelections } from "./policy";
 import {
 	createThinkspaceArchivePatch,
 	createThinkspaceCreationRecord,
@@ -109,7 +114,7 @@ const toToolEnablements = (selections: z.infer<typeof toolSelectionSchema>[]): T
 const toRequestedPermissions = (
 	selections: z.infer<typeof toolSelectionSchema>[],
 ): RequestedPermission[] =>
-	selections.map((selection) => createToolPermissionPlaceholder(selection) as RequestedPermission);
+	selections.map((selection) => createMcpToolAccessPermissionRequest(selection));
 
 const deriveAgentProfileDisplayName = (goal: string): string => {
 	const normalized = goal.trim();
@@ -161,7 +166,8 @@ const throwProductSafeProfileError = (error: unknown): never => {
 	if (
 		error instanceof ThinkspaceLifecycleValidationError ||
 		error instanceof AgentProfileLifecycleError ||
-		error instanceof AgentProfileValidationError
+		error instanceof AgentProfileValidationError ||
+		error instanceof ThinkspacePermissionGrantError
 	) {
 		throw toBadRequest(error);
 	}
@@ -224,14 +230,17 @@ export const thinkspacesRouter = {
 					}
 				}
 
+				const grantInputs = requestedGrants.map((permission) => ({
+					grantedByUserId: context.session.user.id,
+					permission,
+					thinkspaceId: thinkspace.id,
+				}));
+				const permissionGrants = prepareThinkspacePermissionGrants(grantInputs);
+
 				await applyAgentProfileActivation(context.db, { activation });
-				const grantedPermissions = await grantThinkspacePermissions(
+				const grantedPermissions = await saveThinkspacePermissionGrants(
 					context.db,
-					requestedGrants.map((permission) => ({
-						grantedByUserId: context.session.user.id,
-						permission,
-						thinkspaceId: thinkspace.id,
-					})),
+					permissionGrants,
 				);
 
 				return {

--- a/packages/db/src/migrations/0007_zippy_living_lightning.sql
+++ b/packages/db/src/migrations/0007_zippy_living_lightning.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `thinkspace_permissions` ADD `resource_scope` text DEFAULT '{}' NOT NULL;

--- a/packages/db/src/migrations/meta/0007_snapshot.json
+++ b/packages/db/src/migrations/meta/0007_snapshot.json
@@ -1,0 +1,1085 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "d4e00b60-83f3-4e98-b9f1-edd33d18b1d8",
+	"prevId": "179a1ae2-fa82-4d8f-a94d-7d1ee18d683a",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": ["user_id"],
+					"isUnique": false
+				},
+				"idx_account_provider_account": {
+					"name": "idx_account_provider_account",
+					"columns": ["provider_id", "account_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"mcp_server_catalog": {
+			"name": "mcp_server_catalog",
+			"columns": {
+				"auth_type": {
+					"name": "auth_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'none'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"risk_level": {
+					"name": "risk_level",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'unknown'"
+				},
+				"transport": {
+					"name": "transport",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'streamable_http'"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": ["token"],
+					"isUnique": true
+				},
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": ["user_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"thinkspace_agent_profiles": {
+			"name": "thinkspace_agent_profiles",
+			"columns": {
+				"activated_at": {
+					"name": "activated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"instructions": {
+					"name": "instructions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"model_id": {
+					"name": "model_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reasoning_level": {
+					"name": "reasoning_level",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"requested_permissions": {
+					"name": "requested_permissions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"routines": {
+					"name": "routines",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"skill_references": {
+					"name": "skill_references",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'draft'"
+				},
+				"superseded_at": {
+					"name": "superseded_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"thinkspace_id": {
+					"name": "thinkspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tool_enablements": {
+					"name": "tool_enablements",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"version": {
+					"name": "version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"uq_agent_profiles_thinkspace_version": {
+					"name": "uq_agent_profiles_thinkspace_version",
+					"columns": ["thinkspace_id", "version"],
+					"isUnique": true
+				},
+				"uq_agent_profiles_thinkspace_active": {
+					"name": "uq_agent_profiles_thinkspace_active",
+					"columns": ["thinkspace_id"],
+					"isUnique": true,
+					"where": "status = 'active'"
+				},
+				"uq_agent_profiles_thinkspace_draft": {
+					"name": "uq_agent_profiles_thinkspace_draft",
+					"columns": ["thinkspace_id"],
+					"isUnique": true,
+					"where": "status = 'draft'"
+				},
+				"idx_agent_profiles_thinkspace_status": {
+					"name": "idx_agent_profiles_thinkspace_status",
+					"columns": ["thinkspace_id", "status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"thinkspace_agent_profiles_thinkspace_id_thinkspaces_id_fk": {
+					"name": "thinkspace_agent_profiles_thinkspace_id_thinkspaces_id_fk",
+					"tableFrom": "thinkspace_agent_profiles",
+					"tableTo": "thinkspaces",
+					"columnsFrom": ["thinkspace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"thinkspace_permissions": {
+			"name": "thinkspace_permissions",
+			"columns": {
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"granted_by_user_id": {
+					"name": "granted_by_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"resource_scope": {
+					"name": "resource_scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"thinkspace_id": {
+					"name": "thinkspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_thinkspace_permissions_thinkspace": {
+					"name": "idx_thinkspace_permissions_thinkspace",
+					"columns": ["thinkspace_id"],
+					"isUnique": false
+				},
+				"uidx_thinkspace_permissions_model_provider": {
+					"name": "uidx_thinkspace_permissions_model_provider",
+					"columns": ["thinkspace_id", "kind", "provider_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"thinkspace_permissions_thinkspace_id_thinkspaces_id_fk": {
+					"name": "thinkspace_permissions_thinkspace_id_thinkspaces_id_fk",
+					"tableFrom": "thinkspace_permissions",
+					"tableTo": "thinkspaces",
+					"columnsFrom": ["thinkspace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"thinkspaces": {
+			"name": "thinkspaces",
+			"columns": {
+				"archived_at": {
+					"name": "archived_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"configuration_summary": {
+					"name": "configuration_summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"goal": {
+					"name": "goal",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"memory_governance": {
+					"name": "memory_governance",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"owner_user_id": {
+					"name": "owner_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'draft'"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				}
+			},
+			"indexes": {
+				"idx_thinkspaces_owner_status_updated": {
+					"name": "idx_thinkspaces_owner_status_updated",
+					"columns": ["owner_user_id", "status", "updated_at"],
+					"isUnique": false
+				},
+				"idx_thinkspaces_owner_created": {
+					"name": "idx_thinkspaces_owner_created",
+					"columns": ["owner_user_id", "created_at"],
+					"isUnique": false
+				},
+				"idx_thinkspaces_owner_archived": {
+					"name": "idx_thinkspaces_owner_archived",
+					"columns": ["owner_user_id", "archived_at"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"thinkspaces_owner_user_id_user_id_fk": {
+					"name": "thinkspaces_owner_user_id_user_id_fk",
+					"tableFrom": "thinkspaces",
+					"tableTo": "user",
+					"columnsFrom": ["owner_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user": {
+			"name": "user",
+			"columns": {
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				}
+			},
+			"indexes": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_mcp_connections": {
+			"name": "user_mcp_connections",
+			"columns": {
+				"catalog_visible": {
+					"name": "catalog_visible",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"encrypted_headers": {
+					"name": "encrypted_headers",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"server_id": {
+					"name": "server_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transport": {
+					"name": "transport",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'streamable_http'"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_user_mcp_connections_user": {
+					"name": "idx_user_mcp_connections_user",
+					"columns": ["user_id"],
+					"isUnique": false
+				},
+				"idx_user_mcp_connections_server": {
+					"name": "idx_user_mcp_connections_server",
+					"columns": ["server_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"user_mcp_connections_server_id_mcp_server_catalog_id_fk": {
+					"name": "user_mcp_connections_server_id_mcp_server_catalog_id_fk",
+					"tableFrom": "user_mcp_connections",
+					"tableTo": "mcp_server_catalog",
+					"columnsFrom": ["server_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"user_mcp_connections_user_id_user_id_fk": {
+					"name": "user_mcp_connections_user_id_user_id_fk",
+					"tableFrom": "user_mcp_connections",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_product_settings": {
+			"name": "user_product_settings",
+			"columns": {
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"default_model": {
+					"name": "default_model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reasoning_effort": {
+					"name": "reasoning_effort",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'medium'"
+				},
+				"theme": {
+					"name": "theme",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'system'"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_product_settings_user_id_user_id_fk": {
+					"name": "user_product_settings_user_id_user_id_fk",
+					"tableFrom": "user_product_settings",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_provider_credentials": {
+			"name": "user_provider_credentials",
+			"columns": {
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"encrypted_credential": {
+					"name": "encrypted_credential",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_user_provider_credentials_user": {
+					"name": "idx_user_provider_credentials_user",
+					"columns": ["user_id"],
+					"isUnique": false
+				},
+				"idx_user_provider_credentials_user_provider": {
+					"name": "idx_user_provider_credentials_user_provider",
+					"columns": ["user_id", "provider_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"user_provider_credentials_user_id_user_id_fk": {
+					"name": "user_provider_credentials_user_id_user_id_fk",
+					"tableFrom": "user_provider_credentials",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": ["identifier"],
+					"isUnique": false
+				},
+				"idx_verification_expires_at": {
+					"name": "idx_verification_expires_at",
+					"columns": ["expires_at"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1,55 +1,62 @@
 {
-  "version": "7",
-  "dialect": "sqlite",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "6",
-      "when": 1780029615327,
-      "tag": "0000_fuzzy_dexter_bennett",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "6",
-      "when": 1780032873037,
-      "tag": "0001_left_thunderbird",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "6",
-      "when": 1781125034998,
-      "tag": "0002_adorable_star_brand",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "6",
-      "when": 1781129074166,
-      "tag": "0003_hard_archangel",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "6",
-      "when": 1781139208245,
-      "tag": "0004_quick_thunderbird",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "6",
-      "when": 1781141072949,
-      "tag": "0005_thick_baron_strucker",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "6",
-      "when": 1781142185393,
-      "tag": "0006_gray_talisman",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "sqlite",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "6",
+			"when": 1780029615327,
+			"tag": "0000_fuzzy_dexter_bennett",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "6",
+			"when": 1780032873037,
+			"tag": "0001_left_thunderbird",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "6",
+			"when": 1781125034998,
+			"tag": "0002_adorable_star_brand",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "6",
+			"when": 1781129074166,
+			"tag": "0003_hard_archangel",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "6",
+			"when": 1781139208245,
+			"tag": "0004_quick_thunderbird",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "6",
+			"when": 1781141072949,
+			"tag": "0005_thick_baron_strucker",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "6",
+			"when": 1781142185393,
+			"tag": "0006_gray_talisman",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "6",
+			"when": 1781217593374,
+			"tag": "0007_zippy_living_lightning",
+			"breakpoints": true
+		}
+	]
 }

--- a/packages/db/src/schema/permissions.ts
+++ b/packages/db/src/schema/permissions.ts
@@ -27,6 +27,12 @@ export const thinkspacePermissions = sqliteTable(
 		 */
 		providerId: text("provider_id"),
 		reason: text("reason").default("").notNull(),
+		/**
+		 * JSON-encoded scope details for resource-targeted grants. MCP tool access
+		 * uses this to record whether the grant covers the whole built-in server
+		 * or a narrower tool selection, while still living on this table.
+		 */
+		resourceScope: text("resource_scope").default("{}").notNull(),
 		thinkspaceId: text("thinkspace_id")
 			.notNull()
 			.references(() => thinkspaces.id, { onDelete: "cascade" }),


### PR DESCRIPTION
## Summary
- replace draft MCP placeholder requests with first-class `mcp_tool_access` Permission requests
- add existing-table MCP grant persistence with explicit `resource_scope` and grant-time built-in/read-only/auth-free/URL validation
- convert granted draft requests at activation, support declined requests, and keep active revisions request-free
- surface MCP grants and draft requests on the Thinkspace detail payload/UI

## Validation
- bun test
- bun run check-types
- bun x ultracite check <touched files>

Note: repo-wide `bun x ultracite check` still reports unrelated pre-existing/generated formatting/lint issues in docs/walkthrough, routeTree/snapshots/fixture JSON, `packages/api/src/mcp/url-policy.ts`, and `packages/db/src/utils.ts`.

Closes #62