### PR TITLE
Connect granted MCP tools in Thinkspace turns

### DIFF
--- a/apps/server/src/agents/thinkspace-agent.ts
+++ b/apps/server/src/agents/thinkspace-agent.ts
@@ -12,8 +12,20 @@ import type {
 	ThinkspaceTurnInspection,
 	ThinkspaceTurnInspectionRequest,
 } from "@better-agent/api/thinkspaces/inspect";
+import type { BuiltInMcpServer } from "@better-agent/api/mcp/catalog";
+import { listBuiltInMcpServers } from "@better-agent/api/mcp/catalog";
+import {
+	createThinkspaceMcpDegradationNotice,
+	evaluateMcpRuntimeToolCallPermission,
+	planThinkspaceMcpRuntimeTools,
+	prepareThinkspaceMcpRuntimeTools,
+	THINKSPACE_MCP_TOOL_BLOCKED_REASON,
+} from "@better-agent/api/thinkspaces/mcp-runtime-tools";
 import { createPermissionStorePolicy } from "@better-agent/api/thinkspaces/permission-policy";
-import type { ToolPotencyVerdict } from "@better-agent/api/thinkspaces/permission-policy";
+import type {
+	ThinkspacePermissionPolicy,
+	ToolPotencyVerdict,
+} from "@better-agent/api/thinkspaces/permission-policy";
 import { assembleThinkspaceTurn } from "@better-agent/api/thinkspaces/turn-assembly";
 import {
 	createThinkspaceRuntimeToolSet,
@@ -38,6 +50,12 @@ import { createDb } from "@better-agent/db";
 import type { ProductDb } from "@better-agent/db";
 import type { CloudflareEnv } from "@better-agent/env/types";
 import { Think } from "@cloudflare/think";
+import type {
+	ChatErrorContext,
+	ChatResponseResult,
+	ToolCallContext,
+	ToolCallDecision,
+} from "@cloudflare/think";
 import type { LanguageModel, ToolSet, UIMessage } from "ai";
 
 const TURN_CONTEXT_STORAGE_KEY = "better-agent:turn-context";
@@ -56,11 +74,15 @@ const MISSING_THINKSPACE_MESSAGE =
 const PERMISSION_EVALUATION_FAILED_MESSAGE =
 	"This Thinkspace Agent turn could not evaluate its Thinkspace tool Permissions.";
 
+const toRuntimeMcpTransport = (transport: BuiltInMcpServer["transport"]) =>
+	transport === "streamable_http" ? "streamable-http" : "sse";
+
 export class ThinkspaceAgent extends Think<CloudflareEnv> {
 	private readonly runtimeToolSet: ToolSet = createThinkspaceRuntimeToolSet();
+	private readonly turnMcpServerIds = new Set<string>();
 	private readonly turnModelPlaceholder: LanguageModel = UNRESOLVED_TURN_MODEL;
 	private readonly turnSystemPrompt =
-		"You are a Thinkspace Agent for Better Agent. Complete the user's bounded instruction directly and concisely. You have no tools available in this slice; respond with model output only.";
+		"You are a Thinkspace Agent for Better Agent. Complete the user's bounded instruction directly and concisely. Tool availability is resolved per turn from the Thinkspace configuration.";
 
 	override maxSteps = THINKSPACE_RUNTIME_POLICY.maxSteps;
 	override workspaceBash = THINKSPACE_RUNTIME_POLICY.workspaceBash;
@@ -76,6 +98,10 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 		return Promise.resolve(
 			new Response("This Thinkspace Agent runtime is not directly accessible.", { status: 404 }),
 		);
+	}
+
+	override async onStart(): Promise<void> {
+		await this.removeKnownBuiltInMcpServers();
 	}
 
 	async acceptTurnSubmission(
@@ -170,9 +196,10 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 		}
 
 		const db = createDb(this.env.DB);
+		const permissionPolicy = createPermissionStorePolicy({ db });
 		const resolved = await this.resolveTurnModel(db, turnContext);
 		const toolPotencies = await ThinkspaceAgent.evaluateToolPotencies(
-			db,
+			permissionPolicy,
 			turnContext,
 			resolved.activeRevision,
 		);
@@ -181,12 +208,30 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 			revision: resolved.activeRevision,
 			toolPotencies,
 		});
+		const mcpPlan = planThinkspaceMcpRuntimeTools({
+			activeProductToolIds: assembly.activeTools,
+			revision: resolved.activeRevision,
+		});
+
+		await this.removeKnownBuiltInMcpServers();
+
+		const mcpPreparation = await prepareThinkspaceMcpRuntimeTools({
+			activeProductToolIds: mcpPlan.activeProductToolIds,
+			connectServer: ({ server }) => this.connectBuiltInMcpServerForTurn(server),
+			servers: mcpPlan.servers,
+		});
+		const turnConfig = createThinkspaceRuntimeTurnConfig({
+			activeTools: mcpPreparation.activeToolNames,
+		});
+		const degradationNotice = createThinkspaceMcpDegradationNotice(mcpPreparation.degradedServers);
 
 		return {
-			...createThinkspaceRuntimeTurnConfig(),
-			maxSteps: assembly.maxSteps,
+			...turnConfig,
 			model: resolved.model,
-			system: assembly.systemPrompt,
+			system: degradationNotice
+				? `${assembly.systemPrompt}\n\n${degradationNotice}`
+				: assembly.systemPrompt,
+			tools: mcpPreparation.tools,
 		};
 	}
 
@@ -196,14 +241,14 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 	 * active, never the Profile alone. Evaluation failures stay product-safe.
 	 */
 	private static async evaluateToolPotencies(
-		db: ProductDb,
+		permissionPolicy: ThinkspacePermissionPolicy,
 		turnContext: ThinkspaceTurnRuntimeContext,
 		activeRevision: NonNullable<
 			Awaited<ReturnType<typeof resolveOwnedThinkspaceTurnModel>>
 		>["activeRevision"],
 	): Promise<ToolPotencyVerdict[]> {
 		try {
-			return await createPermissionStorePolicy({ db }).evaluateToolPotency({
+			return await permissionPolicy.evaluateToolPotency({
 				enablements: activeRevision.toolEnablements,
 				thinkspaceId: turnContext.thinkspaceId,
 			});
@@ -212,6 +257,87 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 				cause: error,
 			});
 		}
+	}
+
+	override async beforeToolCall(ctx: ToolCallContext): Promise<ToolCallDecision | undefined> {
+		const turnContext =
+			await this.ctx.storage.get<ThinkspaceTurnRuntimeContext>(TURN_CONTEXT_STORAGE_KEY);
+
+		if (!turnContext) {
+			return { action: "block", reason: THINKSPACE_MCP_TOOL_BLOCKED_REASON };
+		}
+
+		try {
+			const db = createDb(this.env.DB);
+			const resolved = await this.resolveTurnModel(db, turnContext);
+			const decision = await evaluateMcpRuntimeToolCallPermission({
+				permissionPolicy: createPermissionStorePolicy({ db }),
+				revision: resolved.activeRevision,
+				runtimeToolName: ctx.toolName,
+				thinkspaceId: turnContext.thinkspaceId,
+			});
+
+			if (!(decision.applies && !decision.allowed)) {
+				return;
+			}
+
+			return { action: "block", reason: decision.reason ?? THINKSPACE_MCP_TOOL_BLOCKED_REASON };
+		} catch {
+			return { action: "block", reason: THINKSPACE_MCP_TOOL_BLOCKED_REASON };
+		}
+	}
+
+	override async onChatResponse(result: ChatResponseResult): Promise<void> {
+		try {
+			await this.cleanupTurnMcpServers();
+		} finally {
+			await super.onChatResponse(result);
+		}
+	}
+
+	override onChatError(error: unknown, ctx?: ChatErrorContext): unknown {
+		void this.cleanupTurnMcpServers();
+
+		return super.onChatError(error, ctx);
+	}
+
+	private async connectBuiltInMcpServerForTurn(server: BuiltInMcpServer): Promise<ToolSet> {
+		const result = await this.addMcpServer(server.name, server.url, {
+			id: server.id,
+			transport: { type: toRuntimeMcpTransport(server.transport) },
+		});
+
+		if (result.state !== "ready") {
+			throw new Error("Granted external information source is not ready for this turn.");
+		}
+
+		this.turnMcpServerIds.add(result.id);
+
+		return this.mcp.getAITools({ serverId: result.id, state: "ready" });
+	}
+
+	private async cleanupTurnMcpServers(): Promise<void> {
+		const serverIds = [...this.turnMcpServerIds];
+		this.turnMcpServerIds.clear();
+
+		await Promise.all(
+			serverIds.map((serverId) => this.removeMcpServer(serverId).catch(() => null)),
+		);
+	}
+
+	private async removeKnownBuiltInMcpServers(): Promise<void> {
+		const builtInServerIds = new Set(listBuiltInMcpServers().map((server) => server.id));
+		const serverIds = Object.keys(this.getMcpServers().servers).filter((serverId) =>
+			builtInServerIds.has(serverId),
+		);
+
+		for (const serverId of serverIds) {
+			this.turnMcpServerIds.delete(serverId);
+		}
+
+		await Promise.all(
+			serverIds.map((serverId) => this.removeMcpServer(serverId).catch(() => null)),
+		);
 	}
 
 	private async resolveTurnModel(

--- a/apps/server/src/worker-routes.test.ts
+++ b/apps/server/src/worker-routes.test.ts
@@ -53,7 +53,22 @@ test("the Thinkspace Agent runtime keeps direct HTTP access fail-closed", () => 
 });
 
 test("the Thinkspace Agent runtime gets tool verdicts from the store-backed Permission policy", () => {
-	assert.match(agentSource, /createPermissionStorePolicy\(\{ db \}\)\.evaluateToolPotency/u);
+	assert.match(agentSource, /const permissionPolicy = createPermissionStorePolicy\(\{ db \}\)/u);
+	assert.match(agentSource, /permissionPolicy\.evaluateToolPotency/u);
 	assert.match(agentSource, /enablements: activeRevision\.toolEnablements/u);
 	assert.doesNotMatch(agentSource, /toolPotencies:\s*\[\]/u);
+});
+
+test("the Thinkspace Agent runtime registers MCP tools only through grant-gated turn preparation", () => {
+	assert.match(agentSource, /planThinkspaceMcpRuntimeTools/u);
+	assert.match(agentSource, /prepareThinkspaceMcpRuntimeTools/u);
+	assert.match(agentSource, /addMcpServer/u);
+	assert.match(agentSource, /createThinkspaceRuntimeTurnConfig\(\{\s*activeTools:/u);
+});
+
+test("the Thinkspace Agent runtime rechecks Permission policy before MCP tool execution", () => {
+	assert.match(agentSource, /override async beforeToolCall/u);
+	assert.match(agentSource, /evaluateMcpRuntimeToolCallPermission/u);
+	assert.match(agentSource, /permissionPolicy: createPermissionStorePolicy\(\{ db \}\)/u);
+	assert.match(agentSource, /action: "block"/u);
 });

--- a/packages/api/src/mcp/tool-identity.ts
+++ b/packages/api/src/mcp/tool-identity.ts
@@ -5,6 +5,7 @@ export interface CanonicalMcpToolIdentity {
 }
 
 const ALIAS_SAFE_CHARACTER = /[^a-zA-Z0-9_-]/gu;
+const CLOUDFLARE_AGENTS_MCP_TOOL_PREFIX = "tool_";
 
 export const createCanonicalMcpToolIdentity = (
 	serverId: string,
@@ -17,4 +18,30 @@ export const createCanonicalMcpToolIdentity = (
 		serverId,
 		toolName,
 	};
+};
+
+export const createCloudflareAgentsMcpToolName = (serverId: string, toolName: string): string =>
+	`${CLOUDFLARE_AGENTS_MCP_TOOL_PREFIX}${serverId.replaceAll("-", "")}_${toolName}`;
+
+export const parseCloudflareAgentsMcpToolName = (
+	runtimeToolName: string,
+	serverIds: readonly string[],
+): CanonicalMcpToolIdentity | null => {
+	const sortedServerIds = serverIds.toSorted((left, right) => right.length - left.length);
+
+	for (const serverId of sortedServerIds) {
+		const prefix = createCloudflareAgentsMcpToolName(serverId, "");
+
+		if (runtimeToolName.startsWith(prefix)) {
+			const toolName = runtimeToolName.slice(prefix.length);
+
+			if (!toolName) {
+				return null;
+			}
+
+			return createCanonicalMcpToolIdentity(serverId, toolName);
+		}
+	}
+
+	return null;
 };

--- a/packages/api/src/thinkspaces/inspect.test.ts
+++ b/packages/api/src/thinkspaces/inspect.test.ts
@@ -231,6 +231,30 @@ test("completed turns carry the bounded model-only result text", () => {
 	assert.equal(completed.completedAt, 1_717_000_001_000);
 });
 
+test("completed tool-using turns remain attributable to their Agent Profile revision", () => {
+	const completed = mapThinkspaceTurnInspection({
+		resultText: "The external information tool result informed this answer.",
+		snapshot: createSnapshot({
+			completedAt: 1_717_000_001_000,
+			metadata: {
+				profileRevisionId: "profile_revision_tool_using",
+				profileVersion: 7,
+				source: "better-agent",
+				thinkspaceId: "thinkspace_inspect",
+			},
+			startedAt: 1_717_000_000_500,
+			status: "completed",
+		}),
+		submissionId: "submission_tool_using",
+		thinkspaceId: "thinkspace_inspect",
+	});
+
+	assert.equal(completed.status, "completed");
+	assert.equal(completed.profileRevisionId, "profile_revision_tool_using");
+	assert.equal(completed.profileVersion, 7);
+	assert.equal(completed.resultText, "The external information tool result informed this answer.");
+});
+
 test("failed turns keep product-safe messages and drop raw runtime errors", () => {
 	const productSafe = mapThinkspaceTurnInspection({
 		snapshot: createSnapshot({

--- a/packages/api/src/thinkspaces/mcp-runtime-tools.test.ts
+++ b/packages/api/src/thinkspaces/mcp-runtime-tools.test.ts
@@ -1,0 +1,245 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ToolSet } from "ai";
+
+import type { BuiltInMcpServer } from "../mcp/catalog";
+import {
+	createCloudflareAgentsMcpToolName,
+	parseCloudflareAgentsMcpToolName,
+} from "../mcp/tool-identity";
+import type { ActiveAgentProfileRevision } from "./agent-profile";
+import {
+	createMemoryPermissionPolicy,
+	createEnablementOnlyPermissionPolicy,
+} from "./permission-policy";
+import {
+	createThinkspaceMcpDegradationNotice,
+	evaluateMcpRuntimeToolCallPermission,
+	planThinkspaceMcpRuntimeTools,
+	prepareThinkspaceMcpRuntimeTools,
+	selectActiveMcpRuntimeToolNames,
+	THINKSPACE_MCP_TOOL_BLOCKED_REASON,
+} from "./mcp-runtime-tools";
+
+const NOW = new Date("2026-06-11T12:00:00.000Z");
+
+const CLOUD_FLARE_DOCS: BuiltInMcpServer = {
+	authType: "none",
+	description: "Cloudflare documentation.",
+	enabledByDefaultForThinkspaces: false,
+	id: "cloudflare-docs",
+	name: "Cloudflare Docs",
+	riskLevel: "read_only",
+	transport: "streamable_http",
+	url: "https://docs.mcp.cloudflare.com/mcp",
+};
+
+const AWS_KNOWLEDGE: BuiltInMcpServer = {
+	authType: "none",
+	description: "AWS docs.",
+	enabledByDefaultForThinkspaces: false,
+	id: "aws-knowledge",
+	name: "AWS Knowledge",
+	riskLevel: "read_only",
+	transport: "streamable_http",
+	url: "https://knowledge-mcp.global.api.aws",
+};
+
+const CONTEXT7: BuiltInMcpServer = {
+	authType: "api_key_header",
+	description: "Code docs.",
+	enabledByDefaultForThinkspaces: false,
+	id: "context7",
+	name: "Context7",
+	riskLevel: "read_only",
+	transport: "streamable_http",
+	url: "https://mcp.context7.com/mcp",
+};
+
+const MUTATING_SERVER: BuiltInMcpServer = {
+	authType: "none",
+	description: "Mutating tools.",
+	enabledByDefaultForThinkspaces: false,
+	id: "mutating-docs",
+	name: "Mutating Docs",
+	riskLevel: "mutating",
+	transport: "streamable_http",
+	url: "https://mutating.example.com/mcp",
+};
+
+const createRevision = (
+	toolEnablements: ActiveAgentProfileRevision["toolEnablements"],
+): ActiveAgentProfileRevision => ({
+	activatedAt: NOW,
+	createdAt: NOW,
+	id: "profile_revision_mcp_runtime",
+	identity: { displayName: "Docs Agent", instructions: "Use docs when helpful." },
+	modelBehavior: { modelId: "google:gemini-2.5-flash-lite", reasoningLevel: "medium" },
+	routines: [],
+	skillReferences: [],
+	status: "active",
+	thinkspaceId: "thinkspace_mcp_runtime",
+	toolEnablements,
+	updatedAt: NOW,
+	version: 4,
+});
+
+const toolSet = (toolNames: string[]): ToolSet =>
+	Object.fromEntries(toolNames.map((toolName) => [toolName, {} as never])) as ToolSet;
+
+test("Cloudflare Agents MCP tool identity maps product server ids to runtime tool names", () => {
+	const runtimeToolName = createCloudflareAgentsMcpToolName("cloudflare-docs", "search_docs");
+
+	assert.equal(runtimeToolName, "tool_cloudflaredocs_search_docs");
+	assert.deepEqual(parseCloudflareAgentsMcpToolName(runtimeToolName, ["cloudflare-docs"]), {
+		modelAlias: "cloudflare-docs__search_docs",
+		serverId: "cloudflare-docs",
+		toolName: "search_docs",
+	});
+	assert.equal(parseCloudflareAgentsMcpToolName("web_search", ["cloudflare-docs"]), null);
+});
+
+test("turn MCP runtime planning connects only potent grantable built-in servers", () => {
+	const revision = createRevision([
+		{ source: "mcp_server", toolId: "cloudflare-docs" },
+		{ source: "mcp_server", toolId: "aws-knowledge:search" },
+		{ source: "mcp_server", toolId: "context7" },
+		{ source: "mcp_server", toolId: "mutating-docs" },
+		{ source: "built_in", toolId: "web_search" },
+	]);
+
+	const plan = planThinkspaceMcpRuntimeTools({
+		activeProductToolIds: ["web_search", "cloudflare-docs", "context7", "mutating-docs"],
+		builtInMcpServers: [CLOUD_FLARE_DOCS, AWS_KNOWLEDGE, CONTEXT7, MUTATING_SERVER],
+		revision,
+	});
+
+	assert.deepEqual(
+		plan.servers.map((server) => server.id),
+		["cloudflare-docs"],
+	);
+	assert.deepEqual(plan.activeProductToolIds, ["cloudflare-docs"]);
+});
+
+test("inert MCP enablements produce no connection attempts and no active runtime tool", async () => {
+	const revision = createRevision([{ source: "mcp_server", toolId: "cloudflare-docs" }]);
+	const verdicts = await createEnablementOnlyPermissionPolicy().evaluateToolPotency({
+		enablements: revision.toolEnablements,
+		thinkspaceId: revision.thinkspaceId,
+	});
+	const activeProductToolIds = verdicts
+		.filter((verdict) => verdict.potency === "potent")
+		.map((verdict) => verdict.toolId);
+	const plan = planThinkspaceMcpRuntimeTools({
+		activeProductToolIds,
+		builtInMcpServers: [CLOUD_FLARE_DOCS],
+		revision,
+	});
+	let connectionAttempts = 0;
+
+	const prepared = await prepareThinkspaceMcpRuntimeTools({
+		activeProductToolIds: plan.activeProductToolIds,
+		connectServer: () => {
+			connectionAttempts += 1;
+			return Promise.resolve(toolSet(["tool_cloudflaredocs_search_docs"]));
+		},
+		servers: plan.servers,
+	});
+
+	assert.deepEqual(plan.servers, []);
+	assert.equal(connectionAttempts, 0);
+	assert.deepEqual(prepared.activeToolNames, []);
+	assert.deepEqual(prepared.tools, {});
+});
+
+test("preparation registers granted runtime tools and limits active tools to enabled scope", async () => {
+	const runtimeTools = toolSet([
+		"tool_cloudflaredocs_search_docs",
+		"tool_cloudflaredocs_read_page",
+		"tool_awsknowledge_search",
+	]);
+	const prepared = await prepareThinkspaceMcpRuntimeTools({
+		activeProductToolIds: ["cloudflare-docs:search_docs", "aws-knowledge"],
+		connectServer: ({ server }) => {
+			assert.ok(["cloudflare-docs", "aws-knowledge"].includes(server.id));
+			return Promise.resolve(runtimeTools);
+		},
+		servers: [CLOUD_FLARE_DOCS, AWS_KNOWLEDGE],
+	});
+
+	assert.deepEqual(prepared.connectedServerIds, ["cloudflare-docs", "aws-knowledge"]);
+	assert.deepEqual(prepared.activeToolNames, [
+		"tool_cloudflaredocs_search_docs",
+		"tool_awsknowledge_search",
+	]);
+});
+
+test("unreachable MCP servers degrade to model-only with a product-safe notice", async () => {
+	const prepared = await prepareThinkspaceMcpRuntimeTools({
+		activeProductToolIds: ["cloudflare-docs"],
+		connectServer: () => Promise.reject(new Error("connect ECONNREFUSED mcp transport")),
+		servers: [CLOUD_FLARE_DOCS],
+	});
+	const notice = createThinkspaceMcpDegradationNotice(prepared.degradedServers);
+
+	assert.deepEqual(prepared.connectedServerIds, []);
+	assert.deepEqual(prepared.activeToolNames, []);
+	assert.deepEqual(prepared.tools, {});
+	assert.equal(prepared.degradedServers[0]?.serverId, "cloudflare-docs");
+	assert.ok(notice);
+	assert.doesNotMatch(notice, /\b(?:mcp|server|runtime|transport|substrate)\b/iu);
+	assert.match(notice, /external information source/u);
+});
+
+test("active runtime tool selection supports whole-server and one-tool enablements", () => {
+	const activeToolNames = selectActiveMcpRuntimeToolNames({
+		activeProductToolIds: ["cloudflare-docs", "aws-knowledge:search"],
+		runtimeTools: toolSet([
+			"tool_cloudflaredocs_search_docs",
+			"tool_cloudflaredocs_read_page",
+			"tool_awsknowledge_search",
+			"tool_awsknowledge_other",
+		]),
+		serverIds: ["cloudflare-docs", "aws-knowledge"],
+	});
+
+	assert.deepEqual(activeToolNames, [
+		"tool_cloudflaredocs_search_docs",
+		"tool_cloudflaredocs_read_page",
+		"tool_awsknowledge_search",
+	]);
+});
+
+test("before-tool-call authorization uses the Permission policy seam for MCP tools", async () => {
+	const revision = createRevision([{ source: "mcp_server", toolId: "cloudflare-docs" }]);
+	const allowed = await evaluateMcpRuntimeToolCallPermission({
+		builtInMcpServers: [CLOUD_FLARE_DOCS],
+		permissionPolicy: createMemoryPermissionPolicy({ "cloudflare-docs": "potent" }),
+		revision,
+		runtimeToolName: "tool_cloudflaredocs_search_docs",
+		thinkspaceId: revision.thinkspaceId,
+	});
+	const blocked = await evaluateMcpRuntimeToolCallPermission({
+		builtInMcpServers: [CLOUD_FLARE_DOCS],
+		permissionPolicy: createMemoryPermissionPolicy({ "cloudflare-docs": "inert" }),
+		revision,
+		runtimeToolName: "tool_cloudflaredocs_search_docs",
+		thinkspaceId: revision.thinkspaceId,
+	});
+	const notMcp = await evaluateMcpRuntimeToolCallPermission({
+		builtInMcpServers: [CLOUD_FLARE_DOCS],
+		permissionPolicy: createMemoryPermissionPolicy({}),
+		revision,
+		runtimeToolName: "web_search",
+		thinkspaceId: revision.thinkspaceId,
+	});
+
+	assert.equal(allowed.allowed, true);
+	assert.equal(allowed.applies, true);
+	assert.equal(allowed.productToolId, "cloudflare-docs:search_docs");
+	assert.equal(blocked.allowed, false);
+	assert.equal(blocked.reason, THINKSPACE_MCP_TOOL_BLOCKED_REASON);
+	assert.equal(notMcp.applies, false);
+	assert.equal(notMcp.allowed, true);
+});

--- a/packages/api/src/thinkspaces/mcp-runtime-tools.ts
+++ b/packages/api/src/thinkspaces/mcp-runtime-tools.ts
@@ -1,0 +1,241 @@
+import type { ToolSet } from "ai";
+
+import type { BuiltInMcpServer } from "../mcp/catalog";
+import { listBuiltInMcpServers } from "../mcp/catalog";
+import {
+	createCloudflareAgentsMcpToolName,
+	parseCloudflareAgentsMcpToolName,
+} from "../mcp/tool-identity";
+import type { ActiveAgentProfileRevision, ToolEnablement } from "./agent-profile";
+import type { ThinkspacePermissionPolicy } from "./permission-policy";
+import { mcpServerIdFromToolId } from "./permission-policy";
+
+export const THINKSPACE_MCP_TOOL_BLOCKED_REASON =
+	"This external information tool is not currently available for this Thinkspace Agent turn.";
+
+export interface ThinkspaceMcpRuntimePlan {
+	activeProductToolIds: string[];
+	servers: BuiltInMcpServer[];
+}
+
+export interface ThinkspaceMcpRuntimeDegradation {
+	serverId: string;
+	serverName: string;
+}
+
+export interface ThinkspaceMcpRuntimePreparation {
+	activeToolNames: string[];
+	connectedServerIds: string[];
+	degradedServers: ThinkspaceMcpRuntimeDegradation[];
+	tools: ToolSet;
+}
+
+export interface ThinkspaceMcpRuntimeToolCallDecision {
+	allowed: boolean;
+	applies: boolean;
+	productToolId: string | null;
+	reason?: string;
+	serverId: string | null;
+	toolName: string | null;
+}
+
+export type ConnectThinkspaceMcpRuntimeServer = (input: {
+	server: BuiltInMcpServer;
+}) => Promise<ToolSet>;
+
+const unique = <T>(values: T[]): T[] => [...new Set(values)];
+
+export const isGrantableBuiltInMcpServer = (server: BuiltInMcpServer): boolean =>
+	server.authType === "none" && server.riskLevel === "read_only";
+
+const mcpEnablementToolIds = (revision: ActiveAgentProfileRevision): Set<string> =>
+	new Set(
+		revision.toolEnablements
+			.filter((enablement) => enablement.source === "mcp_server")
+			.map((enablement) => enablement.toolId),
+	);
+
+const findBuiltInMcpServer = (
+	serverId: string,
+	catalog: readonly BuiltInMcpServer[],
+): BuiltInMcpServer | null => catalog.find((server) => server.id === serverId) ?? null;
+
+export const planThinkspaceMcpRuntimeTools = ({
+	activeProductToolIds,
+	builtInMcpServers = listBuiltInMcpServers(),
+	revision,
+}: {
+	activeProductToolIds: string[];
+	builtInMcpServers?: readonly BuiltInMcpServer[];
+	revision: ActiveAgentProfileRevision;
+}): ThinkspaceMcpRuntimePlan => {
+	const enabledMcpToolIds = mcpEnablementToolIds(revision);
+	const activeMcpToolIds = activeProductToolIds.filter((toolId) => enabledMcpToolIds.has(toolId));
+	const activeServerIds = unique(activeMcpToolIds.map(mcpServerIdFromToolId));
+
+	const servers = activeServerIds
+		.map((serverId) => findBuiltInMcpServer(serverId, builtInMcpServers))
+		.filter((server): server is BuiltInMcpServer =>
+			Boolean(server && isGrantableBuiltInMcpServer(server)),
+		);
+	const serverIds = new Set(servers.map((server) => server.id));
+
+	return {
+		activeProductToolIds: activeMcpToolIds.filter((toolId) =>
+			serverIds.has(mcpServerIdFromToolId(toolId)),
+		),
+		servers,
+	};
+};
+
+export const selectActiveMcpRuntimeToolNames = ({
+	activeProductToolIds,
+	runtimeTools,
+	serverIds,
+}: {
+	activeProductToolIds: readonly string[];
+	runtimeTools: ToolSet;
+	serverIds: readonly string[];
+}): string[] => {
+	const activeExactToolIds = new Set(activeProductToolIds.filter((toolId) => toolId.includes(":")));
+	const activeWholeServerIds = new Set(
+		activeProductToolIds.filter((toolId) => !toolId.includes(":")),
+	);
+
+	return Object.keys(runtimeTools).filter((runtimeToolName) => {
+		const identity = parseCloudflareAgentsMcpToolName(runtimeToolName, serverIds);
+
+		if (!identity) {
+			return false;
+		}
+
+		return (
+			activeWholeServerIds.has(identity.serverId) ||
+			activeExactToolIds.has(`${identity.serverId}:${identity.toolName}`)
+		);
+	});
+};
+
+export const prepareThinkspaceMcpRuntimeTools = async ({
+	activeProductToolIds,
+	connectServer,
+	servers,
+}: {
+	activeProductToolIds: readonly string[];
+	connectServer: ConnectThinkspaceMcpRuntimeServer;
+	servers: readonly BuiltInMcpServer[];
+}): Promise<ThinkspaceMcpRuntimePreparation> => {
+	const tools: ToolSet = {};
+	const connectedServerIds: string[] = [];
+	const degradedServers: ThinkspaceMcpRuntimeDegradation[] = [];
+
+	for (const server of servers) {
+		try {
+			Object.assign(tools, await connectServer({ server }));
+			connectedServerIds.push(server.id);
+		} catch {
+			degradedServers.push({ serverId: server.id, serverName: server.name });
+		}
+	}
+
+	return {
+		activeToolNames: selectActiveMcpRuntimeToolNames({
+			activeProductToolIds,
+			runtimeTools: tools,
+			serverIds: connectedServerIds,
+		}),
+		connectedServerIds,
+		degradedServers,
+		tools,
+	};
+};
+
+export const createThinkspaceMcpDegradationNotice = (
+	degradedServers: readonly ThinkspaceMcpRuntimeDegradation[],
+): string | null => {
+	if (degradedServers.length === 0) {
+		return null;
+	}
+
+	if (degradedServers.length === 1) {
+		return "A granted external information source is temporarily unavailable for this turn. Continue with the available context, and mention the limitation briefly if it affects the answer.";
+	}
+
+	return "Some granted external information sources are temporarily unavailable for this turn. Continue with the available context, and mention the limitation briefly if it affects the answer.";
+};
+
+const matchingMcpToolCallEnablements = (
+	enablements: readonly ToolEnablement[],
+	serverId: string,
+	toolName: string,
+): ToolEnablement[] => {
+	const exactToolId = `${serverId}:${toolName}`;
+
+	return enablements.filter(
+		(enablement) =>
+			enablement.source === "mcp_server" &&
+			(enablement.toolId === serverId || enablement.toolId === exactToolId),
+	);
+};
+
+export const evaluateMcpRuntimeToolCallPermission = async ({
+	builtInMcpServers = listBuiltInMcpServers(),
+	permissionPolicy,
+	revision,
+	runtimeToolName,
+	thinkspaceId,
+}: {
+	builtInMcpServers?: readonly BuiltInMcpServer[];
+	permissionPolicy: ThinkspacePermissionPolicy;
+	revision: ActiveAgentProfileRevision;
+	runtimeToolName: string;
+	thinkspaceId: string;
+}): Promise<ThinkspaceMcpRuntimeToolCallDecision> => {
+	const identity = parseCloudflareAgentsMcpToolName(
+		runtimeToolName,
+		builtInMcpServers.map((server) => server.id),
+	);
+
+	if (!identity) {
+		return {
+			allowed: true,
+			applies: false,
+			productToolId: null,
+			serverId: null,
+			toolName: null,
+		};
+	}
+
+	const productToolId = `${identity.serverId}:${identity.toolName}`;
+	const server = findBuiltInMcpServer(identity.serverId, builtInMcpServers);
+	const enablements = matchingMcpToolCallEnablements(
+		revision.toolEnablements,
+		identity.serverId,
+		identity.toolName,
+	);
+
+	if (!(server && isGrantableBuiltInMcpServer(server) && enablements.length > 0)) {
+		return {
+			allowed: false,
+			applies: true,
+			productToolId,
+			reason: THINKSPACE_MCP_TOOL_BLOCKED_REASON,
+			serverId: identity.serverId,
+			toolName: identity.toolName,
+		};
+	}
+
+	const verdicts = await permissionPolicy.evaluateToolPotency({ enablements, thinkspaceId });
+	const allowed = verdicts.some((verdict) => verdict.potency === "potent");
+
+	return {
+		allowed,
+		applies: true,
+		productToolId,
+		reason: allowed ? undefined : THINKSPACE_MCP_TOOL_BLOCKED_REASON,
+		serverId: identity.serverId,
+		toolName: identity.toolName,
+	};
+};
+
+export const toCloudflareAgentsMcpToolName = createCloudflareAgentsMcpToolName;

--- a/packages/api/src/thinkspaces/runtime-policy.test.ts
+++ b/packages/api/src/thinkspaces/runtime-policy.test.ts
@@ -61,6 +61,15 @@ test("creates a turn config with no active tools and the policy step bound", () 
 	assert.equal(turnConfig.maxSteps, THINKSPACE_RUNTIME_POLICY.maxSteps);
 });
 
+test("raises the per-turn step bound only when runtime tools are active", () => {
+	const turnConfig = createThinkspaceRuntimeTurnConfig({
+		activeTools: ["tool_cloudflaredocs_search_docs"],
+	});
+
+	assert.deepEqual(turnConfig.activeTools, ["tool_cloudflaredocs_search_docs"]);
+	assert.equal(turnConfig.maxSteps, 2);
+});
+
 test("reports the runtime policy only after Thinkspace ownership is confirmed", async () => {
 	const requestedOwnershipChecks: { ownerUserId: string; thinkspaceId: string }[] = [];
 	const getThinkspaceByOwner = (

--- a/packages/api/src/thinkspaces/runtime-policy.ts
+++ b/packages/api/src/thinkspaces/runtime-policy.ts
@@ -6,6 +6,7 @@ import { getThinkspace } from "./repository";
 export const THINKSPACE_RUNTIME_POLICY_ID = "no_tools_v1" as const;
 export const THINKSPACE_RUNTIME_POLICY_MODE = "model_only" as const;
 export const THINKSPACE_RUNTIME_MAX_STEPS = 1 as const;
+export const THINKSPACE_RUNTIME_TOOL_MAX_STEPS = 2 as const;
 
 export const THINKSPACE_RUNTIME_CAPABILITY_IDS = [
 	"workspace_bash",
@@ -40,7 +41,7 @@ export interface ThinkspaceRuntimePolicyReport extends ThinkspaceRuntimePolicy {
 
 export interface ThinkspaceRuntimeTurnConfig {
 	activeTools: string[];
-	maxSteps: typeof THINKSPACE_RUNTIME_MAX_STEPS;
+	maxSteps: typeof THINKSPACE_RUNTIME_MAX_STEPS | typeof THINKSPACE_RUNTIME_TOOL_MAX_STEPS;
 }
 
 export interface GetOwnedThinkspaceRuntimePolicyInput {
@@ -87,9 +88,14 @@ export const isThinkspaceRuntimeCapabilityEnabled = (
 
 export const createThinkspaceRuntimeToolSet = (): Record<string, never> => ({});
 
-export const createThinkspaceRuntimeTurnConfig = (): ThinkspaceRuntimeTurnConfig => ({
-	activeTools: [],
-	maxSteps: THINKSPACE_RUNTIME_POLICY.maxSteps,
+export const createThinkspaceRuntimeTurnConfig = ({
+	activeTools = [],
+}: {
+	activeTools?: string[];
+} = {}): ThinkspaceRuntimeTurnConfig => ({
+	activeTools,
+	maxSteps:
+		activeTools.length > 0 ? THINKSPACE_RUNTIME_TOOL_MAX_STEPS : THINKSPACE_RUNTIME_POLICY.maxSteps,
 });
 
 export const getOwnedThinkspaceRuntimePolicy = async ({


### PR DESCRIPTION
## Summary
- connect only potent, grantable built-in MCP servers during Thinkspace Agent turn preparation
- register discovered MCP tools with activeTools scoped by Agent Profile enablement and Permission policy
- degrade unreachable external information sources to a model-only turn with a product-safe notice
- recheck the same Permission policy seam in beforeToolCall and preserve revision attribution for tool-using turns

Closes #63

## Validation
- bun test
- bun run check-types
- bun x ultracite check apps/server/src/agents/thinkspace-agent.ts apps/server/src/worker-routes.test.ts packages/api/src/mcp/tool-identity.ts packages/api/src/thinkspaces/inspect.test.ts packages/api/src/thinkspaces/mcp-runtime-tools.ts packages/api/src/thinkspaces/mcp-runtime-tools.test.ts packages/api/src/thinkspaces/runtime-policy.ts packages/api/src/thinkspaces/runtime-policy.test.ts

Note: repo-wide Checking formatting...

apps/web/src/routeTree.gen.ts (0ms)
docs/walkthrough/current-state.html (147ms)
docs/walkthrough/example-agents.html (130ms)
docs/walkthrough/ideal-state.html (175ms)
docs/walkthrough/index.html (155ms)
docs/walkthrough/styles.css (112ms)
docs/walkthrough/think-config.html (163ms)
packages/api/src/models/fixtures/models-dev-api.json (0ms)
packages/db/src/migrations/meta/0003_snapshot.json (0ms)
packages/db/src/migrations/meta/0004_snapshot.json (0ms)
packages/db/src/migrations/meta/0005_snapshot.json (1ms)
packages/db/src/migrations/meta/0006_snapshot.json (0ms)

Format issues found in above 12 files. Run without `--check` to fix.
Finished in 424ms on 192 files using 11 threads.
packages/api/src/mcp/url-policy.ts:6:9: error eslint(prefer-named-capture-group): Capture group should be named. help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
packages/db/src/utils.ts:2:1: error unicorn(import-style): Use default import for module `node:path`. still reports the pre-existing generated/untracked formatting and lint issues called out in the handoff (docs/walkthrough, routeTree.gen.ts, generated DB/model JSON, url-policy.ts, packages/db/src/utils.ts).