### PR TITLE
Add Thinkspace Permission revocation

### DIFF
--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -80,10 +80,10 @@ const toEnabledToolSelection = (enablement: { toolId: string }): EnabledToolSele
 
 const formatMcpScope = (scope: McpToolAccessScopeView | undefined): string => {
 	if (!scope) {
-		return "server scope";
+		return "source scope";
 	}
 
-	return scope.type === "server" ? "server scope" : `tool: ${scope.toolName}`;
+	return scope.type === "server" ? "source scope" : `specific tool: ${scope.toolName}`;
 };
 
 const parseStoredMcpScope = (value: string): McpToolAccessScopeView | undefined => {
@@ -112,7 +112,7 @@ const getPermissionRequestTitle = (permission: PermissionRequestView, index: num
 	}
 
 	if (permission.kind === "mcp_tool_access") {
-		return `MCP tool access: ${permission.serverId}`;
+		return `External information access: ${permission.serverId}`;
 	}
 
 	return `${permission.resource?.serverId ?? `Permission request ${index + 1}`}${
@@ -133,7 +133,7 @@ const getPermissionRequestDescription = (permission: PermissionRequestView): str
 
 const getGrantedPermissionTitle = (permission: GrantedPermissionView): string => {
 	if (permission.kind === "mcp_tool_access") {
-		return `MCP tool access: ${permission.providerId ?? "scoped server"}`;
+		return `External information access: ${permission.providerId ?? "scoped source"}`;
 	}
 
 	if (permission.kind === "model_provider_credential") {
@@ -454,10 +454,16 @@ const SubmitTurnSection = ({
 
 const PermissionsSection = ({
 	grantedPermissions,
+	onRevokeGrantedPermission,
 	requestedPermissions,
+	revokePermissionError,
+	revokingPermissionId,
 }: {
 	grantedPermissions: GrantedPermissionView[];
+	onRevokeGrantedPermission: (permissionId: string) => void;
 	requestedPermissions: PermissionRequestView[];
+	revokePermissionError?: Error | null;
+	revokingPermissionId: string | null;
 }) => (
 	<section aria-labelledby="permissions-heading" className="grid gap-4">
 		<div className="grid gap-1">
@@ -501,19 +507,42 @@ const PermissionsSection = ({
 					</p>
 				) : (
 					<div className="border border-border">
-						{grantedPermissions.map((permission, index) => (
-							<div
-								key={permission.id}
-								className={`grid gap-0.5 p-4 ${index < grantedPermissions.length - 1 ? "border-b border-border" : ""}`}
-							>
-								<p className="text-sm font-medium">{getGrantedPermissionTitle(permission)}</p>
-								<p className="text-muted-foreground text-xs">
-									{getGrantedPermissionDescription(permission)}
-								</p>
-							</div>
-						))}
+						{grantedPermissions.map((permission, index) => {
+							const canRevoke = permission.kind === "mcp_tool_access";
+							const isRevoking = revokingPermissionId === permission.id;
+
+							return (
+								<div
+									key={permission.id}
+									className={`flex items-start justify-between gap-4 p-4 ${index < grantedPermissions.length - 1 ? "border-b border-border" : ""}`}
+								>
+									<div className="grid gap-0.5">
+										<p className="text-sm font-medium">{getGrantedPermissionTitle(permission)}</p>
+										<p className="text-muted-foreground text-xs">
+											{getGrantedPermissionDescription(permission)}
+										</p>
+									</div>
+									{canRevoke ? (
+										<Button
+											disabled={Boolean(revokingPermissionId)}
+											onClick={() => onRevokeGrantedPermission(permission.id)}
+											size="sm"
+											type="button"
+											variant="outline"
+										>
+											{isRevoking ? "Revoking…" : "Revoke"}
+										</Button>
+									) : null}
+								</div>
+							);
+						})}
 					</div>
 				)}
+				{revokePermissionError ? (
+					<p className="text-destructive text-sm" role="alert">
+						{revokePermissionError.message}
+					</p>
+				) : null}
 			</div>
 		</div>
 	</section>
@@ -523,6 +552,7 @@ const RouteComponent = () => {
 	const { thinkspaceId } = routeApi.useParams();
 	const context = routeApi.useRouteContext();
 	const queryClient = useQueryClient();
+	const [revokingPermissionId, setRevokingPermissionId] = useState<string | null>(null);
 	const thinkspaceQuery = useSuspenseQuery(
 		context.orpc.thinkspaces.get.queryOptions({ input: { thinkspaceId } }),
 	);
@@ -578,6 +608,21 @@ const RouteComponent = () => {
 			},
 		}),
 	);
+	const revokePermissionMutation = useMutation(
+		context.orpc.thinkspaces.revokePermission.mutationOptions({
+			onMutate: ({ permissionId }) => {
+				setRevokingPermissionId(permissionId);
+			},
+			onSettled: () => {
+				setRevokingPermissionId(null);
+			},
+			onSuccess: async () => {
+				await queryClient.invalidateQueries({
+					queryKey: context.orpc.thinkspaces.get.queryKey({ input: { thinkspaceId } }),
+				});
+			},
+		}),
+	);
 
 	const thinkspace = thinkspaceQuery.data;
 	const runtimeReadiness = runtimeReadinessQuery.data;
@@ -616,6 +661,14 @@ const RouteComponent = () => {
 		}
 
 		archiveMutation.mutate({ thinkspaceId });
+	};
+
+	const handleRevokePermission = (permissionId: string) => {
+		if (revokePermissionMutation.isPending) {
+			return;
+		}
+
+		revokePermissionMutation.mutate({ permissionId, thinkspaceId });
 	};
 
 	return (
@@ -785,7 +838,10 @@ const RouteComponent = () => {
 
 			<PermissionsSection
 				grantedPermissions={grantedPermissions}
+				onRevokeGrantedPermission={handleRevokePermission}
 				requestedPermissions={requestedPermissions}
+				revokePermissionError={revokePermissionMutation.error}
+				revokingPermissionId={revokingPermissionId}
 			/>
 
 			{isArchived || isDraft ? null : (

--- a/packages/api/src/thinkspaces/mcp-runtime-tools.test.ts
+++ b/packages/api/src/thinkspaces/mcp-runtime-tools.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { user } from "@better-agent/db/schema/auth";
+import {
+	THINKSPACE_PERMISSION_KINDS,
+	thinkspacePermissions,
+} from "@better-agent/db/schema/permissions";
+import { thinkspaces } from "@better-agent/db/schema/thinkspaces";
 import type { ToolSet } from "ai";
 
 import type { BuiltInMcpServer } from "../mcp/catalog";
@@ -8,11 +14,15 @@ import {
 	createCloudflareAgentsMcpToolName,
 	parseCloudflareAgentsMcpToolName,
 } from "../mcp/tool-identity";
+import { createTestProductDb } from "../testing/product-db";
 import type { ActiveAgentProfileRevision } from "./agent-profile";
+import { revokeThinkspacePermission } from "./permissions";
 import {
 	createMemoryPermissionPolicy,
 	createEnablementOnlyPermissionPolicy,
+	createPermissionStorePolicy,
 } from "./permission-policy";
+import { assembleThinkspaceTurn } from "./turn-assembly";
 import {
 	createThinkspaceMcpDegradationNotice,
 	evaluateMcpRuntimeToolCallPermission,
@@ -87,6 +97,31 @@ const createRevision = (
 
 const toolSet = (toolNames: string[]): ToolSet =>
 	Object.fromEntries(toolNames.map((toolName) => [toolName, {} as never])) as ToolSet;
+
+const seedGrantedMcpRuntimeDb = async () => {
+	const db = createTestProductDb();
+
+	await db.insert(user).values({
+		email: "mcp-runtime-owner@example.com",
+		id: "user_mcp_runtime",
+		name: "Owner",
+	});
+	await db.insert(thinkspaces).values({
+		goal: "Read docs.",
+		id: "thinkspace_mcp_runtime",
+		ownerUserId: "user_mcp_runtime",
+	});
+	await db.insert(thinkspacePermissions).values({
+		grantedByUserId: "user_mcp_runtime",
+		id: "thinkspace_permission_cloudflare_docs",
+		kind: THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS,
+		providerId: "cloudflare-docs",
+		resourceScope: JSON.stringify({ type: "server" }),
+		thinkspaceId: "thinkspace_mcp_runtime",
+	});
+
+	return db;
+};
 
 test("Cloudflare Agents MCP tool identity maps product server ids to runtime tool names", () => {
 	const runtimeToolName = createCloudflareAgentsMcpToolName("cloudflare-docs", "search_docs");
@@ -173,6 +208,50 @@ test("preparation registers granted runtime tools and limits active tools to ena
 		"tool_cloudflaredocs_search_docs",
 		"tool_awsknowledge_search",
 	]);
+});
+
+test("revoked MCP grants make next-turn preparation skip the server connection", async () => {
+	const db = await seedGrantedMcpRuntimeDb();
+	const revision = createRevision([{ source: "mcp_server", toolId: "cloudflare-docs" }]);
+	const policy = createPermissionStorePolicy({ db });
+	const grantedVerdicts = await policy.evaluateToolPotency({
+		enablements: revision.toolEnablements,
+		thinkspaceId: revision.thinkspaceId,
+	});
+	assert.deepEqual(grantedVerdicts, [{ potency: "potent", toolId: "cloudflare-docs" }]);
+
+	const revoked = await revokeThinkspacePermission(db, {
+		permissionId: "thinkspace_permission_cloudflare_docs",
+		thinkspaceId: revision.thinkspaceId,
+	});
+	assert.ok(revoked);
+
+	const revokedVerdicts = await policy.evaluateToolPotency({
+		enablements: revision.toolEnablements,
+		thinkspaceId: revision.thinkspaceId,
+	});
+	const assembly = assembleThinkspaceTurn({ revision, toolPotencies: revokedVerdicts });
+	const plan = planThinkspaceMcpRuntimeTools({
+		activeProductToolIds: assembly.activeTools,
+		builtInMcpServers: [CLOUD_FLARE_DOCS],
+		revision,
+	});
+	let connectionAttempts = 0;
+
+	const prepared = await prepareThinkspaceMcpRuntimeTools({
+		activeProductToolIds: plan.activeProductToolIds,
+		connectServer: () => {
+			connectionAttempts += 1;
+			return Promise.resolve(toolSet(["tool_cloudflaredocs_search_docs"]));
+		},
+		servers: plan.servers,
+	});
+
+	assert.deepEqual(revokedVerdicts, [{ potency: "inert", toolId: "cloudflare-docs" }]);
+	assert.deepEqual(assembly.activeTools, []);
+	assert.deepEqual(plan.servers, []);
+	assert.equal(connectionAttempts, 0);
+	assert.deepEqual(prepared.activeToolNames, []);
 });
 
 test("unreachable MCP servers degrade to model-only with a product-safe notice", async () => {

--- a/packages/api/src/thinkspaces/permission-policy.test.ts
+++ b/packages/api/src/thinkspaces/permission-policy.test.ts
@@ -8,10 +8,9 @@ import {
 	thinkspacePermissions,
 } from "@better-agent/db/schema/permissions";
 import { thinkspaces } from "@better-agent/db/schema/thinkspaces";
-import { eq } from "drizzle-orm";
-
 import { createTestProductDb } from "../testing/product-db";
 import type { ActiveAgentProfileRevision, ToolEnablement } from "./agent-profile";
+import { revokeThinkspacePermission } from "./permissions";
 import { createPermissionStorePolicy, mcpServerIdFromToolId } from "./permission-policy";
 import { assembleThinkspaceTurn } from "./turn-assembly";
 
@@ -40,6 +39,9 @@ const createSeededDb = async (): Promise<ProductDb> => {
 	return db;
 };
 
+const mcpGrantId = (serverId: string, thinkspaceId = THINKSPACE_ID): string =>
+	`thinkspace_permission_${serverId}_${thinkspaceId}`;
+
 const grantMcpToolAccess = async (
 	db: ProductDb,
 	serverId: string,
@@ -47,7 +49,7 @@ const grantMcpToolAccess = async (
 ) => {
 	await db.insert(thinkspacePermissions).values({
 		grantedByUserId: OWNER_USER_ID,
-		id: `thinkspace_permission_${serverId}_${thinkspaceId}`,
+		id: mcpGrantId(serverId, thinkspaceId),
 		kind: THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS,
 		providerId: serverId,
 		thinkspaceId,
@@ -141,20 +143,33 @@ test("Connected Account and Local Node enablements stay inert even with grants p
 	]);
 });
 
-test("a revoked grant makes the tool inert on the next evaluation", async () => {
+test("a revoked grant makes the still-enabled tool inert on the next evaluation", async () => {
 	const db = await createSeededDb();
 	await grantMcpToolAccess(db, "cloudflare-docs");
 
 	const enablements: ToolEnablement[] = [{ source: "mcp_server", toolId: "cloudflare-docs" }];
+	const revision = {
+		id: "profile_revision_revoked_grant",
+		identity: { displayName: "Release Monitor", instructions: "Watch releases." },
+		modelBehavior: { modelId: "google:gemini-2.5-flash-lite", reasoningLevel: "medium" },
+		status: "active",
+		toolEnablements: enablements,
+		version: 3,
+	} as unknown as ActiveAgentProfileRevision;
 	const granted = await evaluate(db, enablements);
 	assert.deepEqual(granted, [{ potency: "potent", toolId: "cloudflare-docs" }]);
 
-	await db
-		.delete(thinkspacePermissions)
-		.where(eq(thinkspacePermissions.providerId, "cloudflare-docs"));
+	const revokedGrant = await revokeThinkspacePermission(db, {
+		permissionId: mcpGrantId("cloudflare-docs"),
+		thinkspaceId: THINKSPACE_ID,
+	});
+	assert.ok(revokedGrant);
 
 	const revoked = await evaluate(db, enablements);
+	const assembly = assembleThinkspaceTurn({ revision, toolPotencies: revoked });
+
 	assert.deepEqual(revoked, [{ potency: "inert", toolId: "cloudflare-docs" }]);
+	assert.deepEqual(assembly.activeTools, []);
 });
 
 test("store-backed verdicts feeding turn assembly never activate tools the revision did not enable", async () => {

--- a/packages/api/src/thinkspaces/permissions.test.ts
+++ b/packages/api/src/thinkspaces/permissions.test.ts
@@ -9,7 +9,9 @@ import type { BuiltInMcpServer } from "../mcp/catalog";
 import { createTestProductDb } from "../testing/product-db";
 import type { McpToolAccessPermissionRequest } from "./agent-profile";
 import {
+	listThinkspacePermissions,
 	prepareThinkspacePermissionGrants,
+	revokeThinkspacePermission,
 	saveThinkspacePermissionGrants,
 	ThinkspacePermissionGrantError,
 	toThinkspacePermissionGrant,
@@ -146,4 +148,33 @@ test("MCP grants keep per-Thinkspace uniqueness by kind and server id", async ()
 	assert.equal(saved[0]?.providerId, "docs");
 	assert.equal(saved[0]?.reason, "Allow one docs tool.");
 	assert.equal(saved[0]?.resourceScope, JSON.stringify({ toolName: "search_docs", type: "tool" }));
+});
+
+test("revoking a Thinkspace Permission deletes only the matching grant row", async () => {
+	const db = await createSeededDb();
+	const [grant] = await saveThinkspacePermissionGrants(
+		db,
+		prepareThinkspacePermissionGrants([grantInput()], {
+			builtInMcpServers: [readOnlyAuthFreeServer],
+		}),
+	);
+	assert.ok(grant);
+
+	const mismatchedThinkspace = await revokeThinkspacePermission(db, {
+		permissionId: grant.id,
+		thinkspaceId: "thinkspace_other",
+	});
+	assert.equal(mismatchedThinkspace, null);
+	const grantsAfterMismatchedRevoke = await listThinkspacePermissions(db, {
+		thinkspaceId: THINKSPACE_ID,
+	});
+	assert.equal(grantsAfterMismatchedRevoke.length, 1);
+
+	const revoked = await revokeThinkspacePermission(db, {
+		permissionId: grant.id,
+		thinkspaceId: THINKSPACE_ID,
+	});
+
+	assert.equal(revoked?.id, grant.id);
+	assert.deepEqual(await listThinkspacePermissions(db, { thinkspaceId: THINKSPACE_ID }), []);
 });

--- a/packages/api/src/thinkspaces/permissions.ts
+++ b/packages/api/src/thinkspaces/permissions.ts
@@ -27,6 +27,11 @@ export interface ThinkspacePermissionGrantOptions {
 	builtInMcpServers?: BuiltInMcpServer[];
 }
 
+export interface RevokeThinkspacePermissionInput {
+	permissionId: string;
+	thinkspaceId: string;
+}
+
 export class ThinkspacePermissionGrantError extends Error {
 	constructor(message: string) {
 		super(message);
@@ -199,3 +204,20 @@ export const listThinkspacePermissions = async (
 		.select()
 		.from(thinkspacePermissions)
 		.where(eq(thinkspacePermissions.thinkspaceId, input.thinkspaceId));
+
+export const revokeThinkspacePermission = async (
+	db: ProductDb,
+	input: RevokeThinkspacePermissionInput,
+): Promise<ThinkspacePermission | null> => {
+	const [revoked] = await db
+		.delete(thinkspacePermissions)
+		.where(
+			and(
+				eq(thinkspacePermissions.id, input.permissionId),
+				eq(thinkspacePermissions.thinkspaceId, input.thinkspaceId),
+			),
+		)
+		.returning();
+
+	return revoked ?? null;
+};

--- a/packages/api/src/thinkspaces/router.test.ts
+++ b/packages/api/src/thinkspaces/router.test.ts
@@ -772,3 +772,86 @@ test("Thinkspace detail includes MCP grants and remains owner-gated", async () =
 		expectCode("NOT_FOUND"),
 	);
 });
+
+test("owners can revoke a granted MCP Permission without mutating Agent Profile revisions", async () => {
+	const db = createTestProductDb();
+	await seedRealThinkspaceWithProfile({ db, profileStatus: "active", thinkspaceStatus: "active" });
+	await db.insert(thinkspacePermissions).values({
+		grantedByUserId: authenticatedSession.user.id,
+		id: "thinkspace_permission_cloudflare_docs",
+		kind: THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS,
+		providerId: "cloudflare-docs",
+		reason: "Allow this Thinkspace Agent to read Cloudflare docs.",
+		resourceScope: JSON.stringify({ type: "server" }),
+		thinkspaceId: OWNED_THINKSPACE_ID,
+	});
+	const revisionsBefore = await db
+		.select()
+		.from(thinkspaceAgentProfiles)
+		.where(eq(thinkspaceAgentProfiles.thinkspaceId, OWNED_THINKSPACE_ID));
+
+	const revoked = await call(
+		thinkspacesRouter.revokePermission,
+		{
+			permissionId: "thinkspace_permission_cloudflare_docs",
+			thinkspaceId: OWNED_THINKSPACE_ID,
+		},
+		{ context: createCallContext({ db }) },
+	);
+	const remainingGrants = await db
+		.select()
+		.from(thinkspacePermissions)
+		.where(eq(thinkspacePermissions.thinkspaceId, OWNED_THINKSPACE_ID));
+	const revisionsAfter = await db
+		.select()
+		.from(thinkspaceAgentProfiles)
+		.where(eq(thinkspaceAgentProfiles.thinkspaceId, OWNED_THINKSPACE_ID));
+	const detailAfterRevocation = await call(
+		thinkspacesRouter.get,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+
+	assert.equal(revoked.revokedPermissionId, "thinkspace_permission_cloudflare_docs");
+	assert.equal(revoked.thinkspaceId, OWNED_THINKSPACE_ID);
+	assert.deepEqual(remainingGrants, []);
+	assert.deepEqual(detailAfterRevocation.grantedPermissions, []);
+	assert.deepEqual(revisionsAfter, revisionsBefore);
+});
+
+test("non-owners cannot revoke another user's Thinkspace Permission", async () => {
+	const db = createTestProductDb();
+	await seedRealThinkspaceWithProfile({ db, profileStatus: "active", thinkspaceStatus: "active" });
+	await db.insert(thinkspacePermissions).values({
+		grantedByUserId: authenticatedSession.user.id,
+		id: "thinkspace_permission_cloudflare_docs",
+		kind: THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS,
+		providerId: "cloudflare-docs",
+		reason: "Allow this Thinkspace Agent to read Cloudflare docs.",
+		resourceScope: JSON.stringify({ type: "server" }),
+		thinkspaceId: OWNED_THINKSPACE_ID,
+	});
+
+	await assert.rejects(
+		call(
+			thinkspacesRouter.revokePermission,
+			{
+				permissionId: "thinkspace_permission_cloudflare_docs",
+				thinkspaceId: OWNED_THINKSPACE_ID,
+			},
+			{
+				context: createCallContext({
+					db,
+					session: { session: { id: "session_other" }, user: { id: "other_user" } },
+				}),
+			},
+		),
+		expectCode("NOT_FOUND"),
+	);
+
+	const [remainingGrant] = await db
+		.select()
+		.from(thinkspacePermissions)
+		.where(eq(thinkspacePermissions.id, "thinkspace_permission_cloudflare_docs"));
+	assert.equal(remainingGrant?.id, "thinkspace_permission_cloudflare_docs");
+});

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -34,6 +34,7 @@ import { inspectOwnedThinkspaceTurn, THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH } 
 import {
 	listThinkspacePermissions,
 	prepareThinkspacePermissionGrants,
+	revokeThinkspacePermission,
 	saveThinkspacePermissionGrants,
 	ThinkspacePermissionGrantError,
 } from "./permissions";
@@ -69,6 +70,10 @@ const createThinkspaceInput = z.object({
 
 const thinkspaceIdInput = z.object({
 	thinkspaceId: z.string().min(1),
+});
+
+const revokePermissionInput = thinkspaceIdInput.extend({
+	permissionId: z.string().min(1),
 });
 
 const activateAgentProfileInput = thinkspaceIdInput.extend({
@@ -386,6 +391,32 @@ export const thinkspacesRouter = {
 			}
 
 			return readiness;
+		}),
+	revokePermission: protectedProcedure
+		.input(revokePermissionInput)
+		.handler(async ({ context, input }) => {
+			const thinkspace = await getThinkspace(context.db, {
+				ownerUserId: context.session.user.id,
+				thinkspaceId: input.thinkspaceId,
+			});
+
+			if (!thinkspace) {
+				throw toNotFound();
+			}
+
+			const revokedPermission = await revokeThinkspacePermission(context.db, {
+				permissionId: input.permissionId,
+				thinkspaceId: thinkspace.id,
+			});
+
+			if (!revokedPermission) {
+				throw toNotFound();
+			}
+
+			return {
+				revokedPermissionId: revokedPermission.id,
+				thinkspaceId: thinkspace.id,
+			};
 		}),
 	runtimePolicy: protectedProcedure.input(thinkspaceIdInput).handler(async ({ context, input }) => {
 		const policy = await getOwnedThinkspaceRuntimePolicy({


### PR DESCRIPTION
Closes #64

## Summary
- add an owner-gated Thinkspace Permission revocation operation
- keep Agent Profile revisions untouched when a grant is removed
- add UI support to revoke granted external information Permissions
- cover revoked grants becoming inert and skipping MCP connections on the next turn

## Validation
- bun test
- bun run check-types
- bun x ultracite check packages/api/src/thinkspaces/permissions.ts packages/api/src/thinkspaces/permissions.test.ts packages/api/src/thinkspaces/permission-policy.test.ts packages/api/src/thinkspaces/mcp-runtime-tools.test.ts packages/api/src/thinkspaces/router.ts packages/api/src/thinkspaces/router.test.ts apps/web/src/routes/thinkspaces.$thinkspaceId.tsx