### PR TITLE
Show enabled tool potency in Thinkspace detail

### DIFF
--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -57,6 +57,14 @@ interface GrantedPermissionView {
 	resourceScope: string;
 }
 
+type ToolPotencyView = "inert" | "potent";
+
+interface EnabledToolPotencyView {
+	potency: ToolPotencyView;
+	source: string;
+	toolId: string;
+}
+
 interface AgentProfileRevisionView {
 	identity: {
 		displayName: string;
@@ -77,6 +85,36 @@ const toEnabledToolSelection = (enablement: { toolId: string }): EnabledToolSele
 
 	return { risk: "unknown", serverId: serverId ?? enablement.toolId, toolName };
 };
+
+const toProductToolId = (selection: EnabledToolSelection): string =>
+	selection.toolName ? `${selection.serverId}:${selection.toolName}` : selection.serverId;
+
+const formatToolSource = (source: string): string => {
+	if (source === "built_in") {
+		return "Built-in tool";
+	}
+
+	if (source === "mcp_server") {
+		return "External information source";
+	}
+
+	if (source === "connected_account") {
+		return "Connected Account tool";
+	}
+
+	if (source === "local_node") {
+		return "Local Node tool";
+	}
+
+	return "Tool";
+};
+
+const getToolPotencyLabel = (potency: ToolPotencyView): string =>
+	potency === "potent" ? "Potent" : "Inert";
+
+const getToolPotencyBadgeVariant = (
+	potency: ToolPotencyView,
+): "default" | "outline" | "secondary" => (potency === "potent" ? "default" : "secondary");
 
 const formatMcpScope = (scope: McpToolAccessScopeView | undefined): string => {
 	if (!scope) {
@@ -452,6 +490,132 @@ const SubmitTurnSection = ({
 	);
 };
 
+interface McpCatalogServerView {
+	description: string;
+	id: string;
+	name: string;
+	riskLevel: EnabledToolSelection["risk"];
+}
+
+const ToolsSection = ({
+	enabledTools,
+	isArchived,
+	mcpCatalog,
+	onToggleCatalogTool,
+	profileRevision,
+	toolPotencyById,
+	updateToolSelectionsError,
+	updateToolSelectionsPending,
+}: {
+	enabledTools: EnabledToolSelection[];
+	isArchived: boolean;
+	mcpCatalog: McpCatalogServerView[];
+	onToggleCatalogTool: (serverId: string, risk: EnabledToolSelection["risk"]) => void;
+	profileRevision: AgentProfileRevisionView | null;
+	toolPotencyById: ReadonlyMap<string, EnabledToolPotencyView>;
+	updateToolSelectionsError?: Error | null;
+	updateToolSelectionsPending: boolean;
+}) => (
+	<section aria-labelledby="tools-heading" className="grid gap-4">
+		<div className="grid gap-1">
+			<div className="flex items-center gap-2">
+				<h2 className="text-lg font-semibold tracking-tight" id="tools-heading">
+					Tools
+				</h2>
+				{profileRevision ? <Badge variant="outline">{profileRevision.status}</Badge> : null}
+			</div>
+			<p className="text-muted-foreground text-sm">
+				Select catalog tools on the Agent Profile revision. Draft selections take effect after
+				activation; active selections are used for turns.
+			</p>
+		</div>
+		{mcpCatalog.length === 0 ? (
+			<p className="border border-border p-4 text-muted-foreground text-sm">
+				No tools in the catalog.
+			</p>
+		) : (
+			<div className="border border-border">
+				{mcpCatalog.map((server, index) => {
+					const selectedTool = enabledTools.find((tool) => tool.serverId === server.id);
+					const selected = Boolean(selectedTool);
+					const toolPotency = selectedTool
+						? toolPotencyById.get(toProductToolId(selectedTool))
+						: undefined;
+
+					return (
+						<div
+							key={server.id}
+							className={`flex items-center justify-between gap-4 p-4 ${index < mcpCatalog.length - 1 ? "border-b border-border" : ""} ${selected ? "bg-muted/30" : ""}`}
+						>
+							<div className="grid gap-0.5">
+								<div className="flex items-center gap-2">
+									<p className="text-sm font-medium">{server.name}</p>
+									<span className="text-muted-foreground text-xs">{server.riskLevel}</span>
+									{toolPotency ? (
+										<Badge variant={getToolPotencyBadgeVariant(toolPotency.potency)}>
+											{getToolPotencyLabel(toolPotency.potency)}
+										</Badge>
+									) : null}
+								</div>
+								<p className="text-muted-foreground text-sm">{server.description}</p>
+							</div>
+							<Button
+								disabled={isArchived || updateToolSelectionsPending}
+								onClick={() => onToggleCatalogTool(server.id, server.riskLevel)}
+								size="sm"
+								type="button"
+								variant={selected ? "secondary" : "outline"}
+							>
+								{selected ? "Remove" : "Select"}
+							</Button>
+						</div>
+					);
+				})}
+			</div>
+		)}
+		<div className="grid gap-2">
+			<p className="text-sm font-medium">Enabled on Agent Profile</p>
+			{profileRevision?.toolEnablements.length ? (
+				<div className="border border-border">
+					{profileRevision.toolEnablements.map((enablement, index) => {
+						const toolPotency = toolPotencyById.get(enablement.toolId);
+
+						return (
+							<div
+								key={`${enablement.source}:${enablement.toolId}`}
+								className={`flex items-center justify-between gap-4 p-4 ${index < profileRevision.toolEnablements.length - 1 ? "border-b border-border" : ""}`}
+							>
+								<div className="grid gap-0.5">
+									<p className="break-all text-sm font-medium">{enablement.toolId}</p>
+									<p className="text-muted-foreground text-xs">
+										{formatToolSource(enablement.source)}
+									</p>
+								</div>
+								{toolPotency ? (
+									<Badge variant={getToolPotencyBadgeVariant(toolPotency.potency)}>
+										{getToolPotencyLabel(toolPotency.potency)}
+									</Badge>
+								) : (
+									<Badge variant="outline">Activates later</Badge>
+								)}
+							</div>
+						);
+					})}
+				</div>
+			) : (
+				<p className="border border-border p-4 text-muted-foreground text-sm">
+					No tools enabled on this Agent Profile revision.
+				</p>
+			)}
+		</div>
+		{updateToolSelectionsError ? (
+			<p className="text-destructive text-sm" role="alert">
+				{updateToolSelectionsError.message}
+			</p>
+		) : null}
+	</section>
+);
+
 const PermissionsSection = ({
 	grantedPermissions,
 	onRevokeGrantedPermission,
@@ -632,6 +796,10 @@ const RouteComponent = () => {
 	const isArchived = thinkspace.status === "archived";
 	const isDraft = thinkspace.status === "draft";
 	const enabledTools = profileRevision?.toolEnablements.map(toEnabledToolSelection) ?? [];
+	const enabledToolPotencies = (thinkspace.enabledToolPotencies ?? []) as EnabledToolPotencyView[];
+	const toolPotencyById = new Map(
+		enabledToolPotencies.map((toolPotency) => [toolPotency.toolId, toolPotency] as const),
+	);
 	const requestedPermissions = profileRevision?.requestedPermissions ?? [];
 	const grantedPermissions = (thinkspace.grantedPermissions ?? []) as GrantedPermissionView[];
 
@@ -780,59 +948,16 @@ const RouteComponent = () => {
 
 			<Separator />
 
-			<section aria-labelledby="tools-heading" className="grid gap-4">
-				<div className="grid gap-1">
-					<div className="flex items-center gap-2">
-						<h2 className="text-lg font-semibold tracking-tight" id="tools-heading">
-							Tools
-						</h2>
-						{profileRevision ? <Badge variant="outline">{profileRevision.status}</Badge> : null}
-					</div>
-					<p className="text-muted-foreground text-sm">
-						Select catalog tools on the Agent Profile revision. Draft selections take effect after
-						activation; active selections are used for turns.
-					</p>
-				</div>
-				{mcpCatalogQuery.data.length === 0 ? (
-					<p className="border border-border p-4 text-muted-foreground text-sm">
-						No tools in the catalog.
-					</p>
-				) : (
-					<div className="border border-border">
-						{mcpCatalogQuery.data.map((server, index) => {
-							const selected = enabledTools.some((tool) => tool.serverId === server.id);
-							return (
-								<div
-									key={server.id}
-									className={`flex items-center justify-between gap-4 p-4 ${index < mcpCatalogQuery.data.length - 1 ? "border-b border-border" : ""} ${selected ? "bg-muted/30" : ""}`}
-								>
-									<div className="grid gap-0.5">
-										<div className="flex items-center gap-2">
-											<p className="text-sm font-medium">{server.name}</p>
-											<span className="text-muted-foreground text-xs">{server.riskLevel}</span>
-										</div>
-										<p className="text-muted-foreground text-sm">{server.description}</p>
-									</div>
-									<Button
-										disabled={isArchived || updateToolSelectionsMutation.isPending}
-										onClick={() => toggleCatalogTool(server.id, server.riskLevel)}
-										size="sm"
-										type="button"
-										variant={selected ? "secondary" : "outline"}
-									>
-										{selected ? "Remove" : "Select"}
-									</Button>
-								</div>
-							);
-						})}
-					</div>
-				)}
-				{updateToolSelectionsMutation.error ? (
-					<p className="text-destructive text-sm" role="alert">
-						{updateToolSelectionsMutation.error.message}
-					</p>
-				) : null}
-			</section>
+			<ToolsSection
+				enabledTools={enabledTools}
+				isArchived={isArchived}
+				mcpCatalog={mcpCatalogQuery.data}
+				onToggleCatalogTool={toggleCatalogTool}
+				profileRevision={profileRevision}
+				toolPotencyById={toolPotencyById}
+				updateToolSelectionsError={updateToolSelectionsMutation.error}
+				updateToolSelectionsPending={updateToolSelectionsMutation.isPending}
+			/>
 
 			<Separator />
 

--- a/packages/api/src/thinkspaces/router.test.ts
+++ b/packages/api/src/thinkspaces/router.test.ts
@@ -20,6 +20,7 @@ import { encryptCredential } from "../models/credentials";
 import { createMemoryModelCatalog } from "../models/model-catalog";
 import type { ModelCatalog } from "../models/model-catalog";
 import { createTestProductDb } from "../testing/product-db";
+import type { ToolEnablement } from "./agent-profile";
 import { thinkspacesRouter } from "./router";
 import type { ThinkspaceTurnInspection } from "./inspect";
 import type { ThinkspaceTurnAcceptance } from "./turns";
@@ -209,11 +210,13 @@ const seedRealThinkspaceWithProfile = async ({
 	profileStatus = "draft",
 	requestedPermissions = [],
 	thinkspaceStatus = "draft",
+	toolEnablements = [{ source: "mcp_server", toolId: "cloudflare-docs" }],
 }: {
 	db: ProductDb;
 	profileStatus?: "active" | "draft";
 	requestedPermissions?: unknown[];
 	thinkspaceStatus?: "active" | "draft";
+	toolEnablements?: ToolEnablement[];
 }) => {
 	await db.insert(user).values({
 		email: "owner@example.com",
@@ -233,7 +236,7 @@ const seedRealThinkspaceWithProfile = async ({
 		requestedPermissions: JSON.stringify(requestedPermissions),
 		status: profileStatus,
 		thinkspaceId: OWNED_THINKSPACE_ID,
-		toolEnablements: JSON.stringify([{ source: "mcp_server", toolId: "cloudflare-docs" }]),
+		toolEnablements: JSON.stringify(toolEnablements),
 	});
 };
 
@@ -771,6 +774,110 @@ test("Thinkspace detail includes MCP grants and remains owner-gated", async () =
 		),
 		expectCode("NOT_FOUND"),
 	);
+});
+
+test("Thinkspace detail includes active revision tool potency indicators", async () => {
+	const db = createTestProductDb();
+	await seedRealThinkspaceWithProfile({
+		db,
+		profileStatus: "active",
+		thinkspaceStatus: "active",
+		toolEnablements: [
+			{ source: "built_in", toolId: "web_search" },
+			{ source: "mcp_server", toolId: "cloudflare-docs" },
+			{ source: "mcp_server", toolId: "aws-knowledge" },
+			{ source: "connected_account", toolId: "github" },
+			{ source: "local_node", toolId: "local-files" },
+		],
+	});
+	await db.insert(thinkspacePermissions).values([
+		{
+			grantedByUserId: authenticatedSession.user.id,
+			id: "thinkspace_permission_cloudflare_docs",
+			kind: THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS,
+			providerId: "cloudflare-docs",
+			reason: "Allow this Thinkspace Agent to read Cloudflare docs.",
+			resourceScope: JSON.stringify({ type: "server" }),
+			thinkspaceId: OWNED_THINKSPACE_ID,
+		},
+		{
+			grantedByUserId: authenticatedSession.user.id,
+			id: "thinkspace_permission_microsoft_learn",
+			kind: THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS,
+			providerId: "microsoft-learn",
+			reason: "An unenabled grant should not add a tool.",
+			resourceScope: JSON.stringify({ type: "server" }),
+			thinkspaceId: OWNED_THINKSPACE_ID,
+		},
+	]);
+
+	const thinkspace = await call(
+		thinkspacesRouter.get,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+
+	assert.deepEqual(thinkspace.enabledToolPotencies, [
+		{ potency: "potent", source: "built_in", toolId: "web_search" },
+		{ potency: "potent", source: "mcp_server", toolId: "cloudflare-docs" },
+		{ potency: "inert", source: "mcp_server", toolId: "aws-knowledge" },
+		{ potency: "inert", source: "connected_account", toolId: "github" },
+		{ potency: "inert", source: "local_node", toolId: "local-files" },
+	]);
+
+	await assert.rejects(
+		call(
+			thinkspacesRouter.get,
+			{ thinkspaceId: OWNED_THINKSPACE_ID },
+			{
+				context: createCallContext({
+					db,
+					session: { session: { id: "session_other" }, user: { id: "other_user" } },
+				}),
+			},
+		),
+		expectCode("NOT_FOUND"),
+	);
+});
+
+test("Thinkspace detail tool potency indicators reflect Permission revocation on the next read", async () => {
+	const db = createTestProductDb();
+	await seedRealThinkspaceWithProfile({ db, profileStatus: "active", thinkspaceStatus: "active" });
+	await db.insert(thinkspacePermissions).values({
+		grantedByUserId: authenticatedSession.user.id,
+		id: "thinkspace_permission_cloudflare_docs",
+		kind: THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS,
+		providerId: "cloudflare-docs",
+		reason: "Allow this Thinkspace Agent to read Cloudflare docs.",
+		resourceScope: JSON.stringify({ type: "server" }),
+		thinkspaceId: OWNED_THINKSPACE_ID,
+	});
+
+	const granted = await call(
+		thinkspacesRouter.get,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+	await call(
+		thinkspacesRouter.revokePermission,
+		{
+			permissionId: "thinkspace_permission_cloudflare_docs",
+			thinkspaceId: OWNED_THINKSPACE_ID,
+		},
+		{ context: createCallContext({ db }) },
+	);
+	const revoked = await call(
+		thinkspacesRouter.get,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+
+	assert.deepEqual(granted.enabledToolPotencies, [
+		{ potency: "potent", source: "mcp_server", toolId: "cloudflare-docs" },
+	]);
+	assert.deepEqual(revoked.enabledToolPotencies, [
+		{ potency: "inert", source: "mcp_server", toolId: "cloudflare-docs" },
+	]);
 });
 
 test("owners can revoke a granted MCP Permission without mutating Agent Profile revisions", async () => {

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -1,3 +1,4 @@
+import type { ProductDb } from "@better-agent/db";
 import { ORPCError } from "@orpc/server";
 import { z } from "zod";
 
@@ -16,7 +17,11 @@ import {
 	validateAgentProfileIdentity,
 	validateAgentProfileModelBehavior,
 } from "./agent-profile";
-import type { RequestedPermission, ToolEnablement } from "./agent-profile";
+import type {
+	ActiveAgentProfileRevision,
+	RequestedPermission,
+	ToolEnablement,
+} from "./agent-profile";
 import {
 	AgentProfileLifecycleError,
 	createAgentProfileActivation,
@@ -26,7 +31,6 @@ import {
 import {
 	applyAgentProfileActivation,
 	getActiveAgentProfileRevision,
-	getCurrentAgentProfileRevision,
 	getDraftAgentProfileRevision,
 	saveAgentProfileDraft,
 } from "./agent-profile-repository";
@@ -54,6 +58,8 @@ import {
 	getOwnedThinkspaceAgentRuntimeReadiness,
 	ThinkspaceRuntimeResolutionError,
 } from "./runtime";
+import { createPermissionStorePolicy } from "./permission-policy";
+import type { ToolPotency } from "./permission-policy";
 import { getOwnedThinkspaceRuntimePolicy } from "./runtime-policy";
 import {
 	submitOwnedThinkspaceTurn,
@@ -120,6 +126,35 @@ const toRequestedPermissions = (
 	selections: z.infer<typeof toolSelectionSchema>[],
 ): RequestedPermission[] =>
 	selections.map((selection) => createMcpToolAccessPermissionRequest(selection));
+
+export interface EnabledToolPotencyInspection {
+	potency: ToolPotency;
+	source: ToolEnablement["source"];
+	toolId: string;
+}
+
+/**
+ * Inspect projection only: potency itself comes from the same Permission
+ * policy seam that turn assembly and runtime enforcement use.
+ */
+const inspectEnabledToolPotencies = async (
+	db: ProductDb,
+	revision: ActiveAgentProfileRevision,
+): Promise<EnabledToolPotencyInspection[]> => {
+	const verdicts = await createPermissionStorePolicy({ db }).evaluateToolPotency({
+		enablements: revision.toolEnablements,
+		thinkspaceId: revision.thinkspaceId,
+	});
+	const potencyByToolId = new Map(
+		verdicts.map((verdict) => [verdict.toolId, verdict.potency] as const),
+	);
+
+	return revision.toolEnablements.map((enablement) => ({
+		potency: potencyByToolId.get(enablement.toolId) ?? "inert",
+		source: enablement.source,
+		toolId: enablement.toolId,
+	}));
+};
 
 const deriveAgentProfileDisplayName = (goal: string): string => {
 	const normalized = goal.trim();
@@ -334,11 +369,21 @@ export const thinkspacesRouter = {
 			throw toNotFound();
 		}
 
+		const activeRevision = await getActiveAgentProfileRevision(context.db, {
+			thinkspaceId: thinkspace.id,
+		});
+		const agentProfileRevision =
+			activeRevision ??
+			(await getDraftAgentProfileRevision(context.db, {
+				thinkspaceId: thinkspace.id,
+			}));
+
 		return {
 			...thinkspace,
-			agentProfileRevision: await getCurrentAgentProfileRevision(context.db, {
-				thinkspaceId: thinkspace.id,
-			}),
+			agentProfileRevision,
+			enabledToolPotencies: activeRevision
+				? await inspectEnabledToolPotencies(context.db, activeRevision)
+				: [],
 			grantedPermissions: await listThinkspacePermissions(context.db, {
 				thinkspaceId: thinkspace.id,
 			}),


### PR DESCRIPTION
Closes #65

## Summary
- extend the Thinkspace detail payload with per-enabled-tool potency for the active Agent Profile revision
- compute potency through the store-backed Permission policy seam
- distinguish potent and inert enabled tools in the Thinkspace detail UI
- add router coverage for grants, revocations, unenabled grants, default inert sources, and owner gating

## Validation
- bun test
- bun run check-types
- bun x ultracite check packages/api/src/thinkspaces/router.ts packages/api/src/thinkspaces/router.test.ts apps/web/src/routes/thinkspaces.$thinkspaceId.tsx