### PR TITLE
Supersede no_tools_v1 with the safe_reads_v2 runtime policy

### DIFF
--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -918,7 +918,7 @@ const RouteComponent = () => {
 						<div className="flex items-center justify-between gap-4">
 							<p className="text-sm font-medium">Runtime safety policy</p>
 							<Badge variant="outline">
-								{runtimePolicy.mode === "model_only" ? "model-only" : runtimePolicy.mode}
+								{runtimePolicy.mode === "read_only" ? "read-only" : runtimePolicy.mode}
 							</Badge>
 						</div>
 						<p className="text-muted-foreground text-sm">{runtimePolicy.message}</p>

--- a/packages/api/src/thinkspaces/runtime-policy.test.ts
+++ b/packages/api/src/thinkspaces/runtime-policy.test.ts
@@ -9,10 +9,11 @@ import {
 	getOwnedThinkspaceRuntimePolicy,
 	isThinkspaceRuntimeCapabilityEnabled,
 	THINKSPACE_RUNTIME_CAPABILITY_IDS,
+	THINKSPACE_RUNTIME_DISABLED_CAPABILITY_IDS,
 	THINKSPACE_RUNTIME_POLICY,
 } from "./runtime-policy";
 
-test("disables workspace Bash for the first Thinkspace Agent runtime", () => {
+test("disables workspace Bash against the runtime default", () => {
 	assert.equal(THINKSPACE_RUNTIME_POLICY.workspaceBash, false);
 	assert.equal(
 		isThinkspaceRuntimeCapabilityEnabled(THINKSPACE_RUNTIME_POLICY, "workspace_bash"),
@@ -20,8 +21,9 @@ test("disables workspace Bash for the first Thinkspace Agent runtime", () => {
 	);
 });
 
-test("disables every unsafe capability in the no-tools baseline", () => {
+test("enables only built-in read tools and disables every mutation-shaped capability", () => {
 	const expectedCapabilityIds = [
+		"builtin_read_tools",
 		"workspace_bash",
 		"workspace_mutations",
 		"mcp_tools",
@@ -30,22 +32,37 @@ test("disables every unsafe capability in the no-tools baseline", () => {
 		"memory_writes",
 		"artifact_publishing",
 	];
+	const expectedDisabledCapabilityIds = expectedCapabilityIds.filter(
+		(id) => id !== "builtin_read_tools",
+	);
 
 	assert.deepEqual([...THINKSPACE_RUNTIME_CAPABILITY_IDS], expectedCapabilityIds);
+	assert.deepEqual([...THINKSPACE_RUNTIME_DISABLED_CAPABILITY_IDS], expectedDisabledCapabilityIds);
 	assert.equal(THINKSPACE_RUNTIME_POLICY.capabilities.length, expectedCapabilityIds.length);
 
+	assert.equal(
+		isThinkspaceRuntimeCapabilityEnabled(THINKSPACE_RUNTIME_POLICY, "builtin_read_tools"),
+		true,
+	);
+
 	for (const capability of THINKSPACE_RUNTIME_POLICY.capabilities) {
-		assert.equal(capability.enabled, false, `${capability.id} must be disabled`);
+		const expectedEnabled = capability.id === "builtin_read_tools";
+
+		assert.equal(
+			capability.enabled,
+			expectedEnabled,
+			`${capability.id} must be ${expectedEnabled ? "enabled" : "disabled"}`,
+		);
 		assert.equal(
 			isThinkspaceRuntimeCapabilityEnabled(THINKSPACE_RUNTIME_POLICY, capability.id),
-			false,
+			expectedEnabled,
 		);
 	}
 });
 
-test("declares a model-only runtime mode with a bounded step count", () => {
-	assert.equal(THINKSPACE_RUNTIME_POLICY.mode, "model_only");
-	assert.equal(THINKSPACE_RUNTIME_POLICY.policyId, "no_tools_v1");
+test("declares a read-only runtime mode with bounded step counts", () => {
+	assert.equal(THINKSPACE_RUNTIME_POLICY.mode, "read_only");
+	assert.equal(THINKSPACE_RUNTIME_POLICY.policyId, "safe_reads_v2");
 	assert.equal(THINKSPACE_RUNTIME_POLICY.maxSteps, 1);
 });
 
@@ -67,7 +84,7 @@ test("raises the per-turn step bound only when runtime tools are active", () => 
 	});
 
 	assert.deepEqual(turnConfig.activeTools, ["tool_cloudflaredocs_search_docs"]);
-	assert.equal(turnConfig.maxSteps, 2);
+	assert.equal(turnConfig.maxSteps, 8);
 });
 
 test("reports the runtime policy only after Thinkspace ownership is confirmed", async () => {
@@ -99,7 +116,7 @@ test("reports the runtime policy only after Thinkspace ownership is confirmed", 
 	});
 
 	assert.equal(ownerPolicy?.thinkspaceId, "thinkspace_owned");
-	assert.equal(ownerPolicy?.policyId, "no_tools_v1");
+	assert.equal(ownerPolicy?.policyId, "safe_reads_v2");
 	assert.equal(ownerPolicy?.workspaceBash, false);
 	assert.equal(nonOwnerPolicy, null);
 	assert.deepEqual(requestedOwnershipChecks, [

--- a/packages/api/src/thinkspaces/runtime-policy.ts
+++ b/packages/api/src/thinkspaces/runtime-policy.ts
@@ -3,12 +3,13 @@ import type { Thinkspace } from "@better-agent/db/schema/thinkspaces";
 
 import { getThinkspace } from "./repository";
 
-export const THINKSPACE_RUNTIME_POLICY_ID = "no_tools_v1" as const;
-export const THINKSPACE_RUNTIME_POLICY_MODE = "model_only" as const;
+export const THINKSPACE_RUNTIME_POLICY_ID = "safe_reads_v2" as const;
+export const THINKSPACE_RUNTIME_POLICY_MODE = "read_only" as const;
 export const THINKSPACE_RUNTIME_MAX_STEPS = 1 as const;
-export const THINKSPACE_RUNTIME_TOOL_MAX_STEPS = 2 as const;
+export const THINKSPACE_RUNTIME_TOOL_MAX_STEPS = 8 as const;
 
 export const THINKSPACE_RUNTIME_CAPABILITY_IDS = [
+	"builtin_read_tools",
 	"workspace_bash",
 	"workspace_mutations",
 	"mcp_tools",
@@ -20,8 +21,13 @@ export const THINKSPACE_RUNTIME_CAPABILITY_IDS = [
 
 export type ThinkspaceRuntimeCapabilityId = (typeof THINKSPACE_RUNTIME_CAPABILITY_IDS)[number];
 
+/** Every capability except built-in read-only tools stays disabled (PRD #73). */
+export const THINKSPACE_RUNTIME_DISABLED_CAPABILITY_IDS = THINKSPACE_RUNTIME_CAPABILITY_IDS.filter(
+	(id) => id !== "builtin_read_tools",
+);
+
 export interface ThinkspaceRuntimeCapability {
-	enabled: false;
+	enabled: boolean;
 	id: ThinkspaceRuntimeCapabilityId;
 	label: string;
 }
@@ -58,6 +64,7 @@ type GetThinkspaceByOwner = (
 
 const CAPABILITY_LABELS: Record<ThinkspaceRuntimeCapabilityId, string> = {
 	artifact_publishing: "Artifact publishing",
+	builtin_read_tools: "Built-in read-only tools",
 	connected_account_tools: "Connected Account tools",
 	external_mutations: "External mutation tools",
 	mcp_tools: "MCP tools",
@@ -68,13 +75,13 @@ const CAPABILITY_LABELS: Record<ThinkspaceRuntimeCapabilityId, string> = {
 
 export const THINKSPACE_RUNTIME_POLICY: ThinkspaceRuntimePolicy = {
 	capabilities: THINKSPACE_RUNTIME_CAPABILITY_IDS.map((id) => ({
-		enabled: false,
+		enabled: id === "builtin_read_tools",
 		id,
 		label: CAPABILITY_LABELS[id],
 	})),
 	maxSteps: THINKSPACE_RUNTIME_MAX_STEPS,
 	message:
-		"This Thinkspace Agent runs model-only. No tools are enabled in this slice; future tool use requires Thinkspace-scoped Permission policy.",
+		"This Thinkspace Agent can read but never mutate: built-in read-only tools are the only enabled capability, and each tool still requires enablement on the active Agent Profile revision plus a potent Permission verdict.",
 	mode: THINKSPACE_RUNTIME_POLICY_MODE,
 	policyId: THINKSPACE_RUNTIME_POLICY_ID,
 	workspaceBash: false,


### PR DESCRIPTION
Closes #81 (first slice of PRD #73)

## What changed

- The runtime policy module now declares `safe_reads_v2` / `read_only` as the single policy applied to all Thinkspace Agent turns, superseding `no_tools_v1` / `model_only`
- A new `builtin_read_tools` capability is the only enabled capability; all seven mutation-shaped capabilities (workspace bash, workspace mutations, MCP tools, Connected Account tools, external mutations, memory writes, artifact publishing) remain disabled, and workspace bash remains explicitly forced off against the runtime default
- The tool-loop step ceiling rises from 2 to 8, still applied only when a turn has active tools; model-only turns keep a step bound of 1
- The capability type widens from `enabled: false` to `enabled: boolean`, with a `THINKSPACE_RUNTIME_DISABLED_CAPABILITY_IDS` constant naming everything that must stay off
- The Thinkspace detail surface renders the new mode as "read-only" in product language; the capability list renders generically as before
- No built-in tools are introduced: the runtime toolset stays empty and turn assembly is unchanged, so a Thinkspace with no enabled-and-potent tools behaves exactly as it does today

## Verification

- bun test (167 pass, 0 fail)
- bun run check-types
- bun x ultracite check on the changed files
- grep confirms no stale `no_tools_v1` / `model_only` references remain in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)