### PR TITLE
Add the Sources control plane: upload, list, view, and delete Thinkspace Sources

### DIFF
--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -490,6 +490,250 @@ const SubmitTurnSection = ({
 	);
 };
 
+const formatSourceSize = (sizeBytes: number): string => {
+	if (sizeBytes < 1024) {
+		return `${sizeBytes} B`;
+	}
+
+	return `${(sizeBytes / 1024).toFixed(1)} KB`;
+};
+
+const formatSourceContentType = (contentType: string): string =>
+	contentType === "text/markdown" ? "Markdown" : "Plain text";
+
+const SOURCE_CONTENT_TYPE_OPTIONS = [
+	{ label: "Markdown", value: "text/markdown" },
+	{ label: "Plain text", value: "text/plain" },
+] as const;
+
+type SourceContentTypeOption = (typeof SOURCE_CONTENT_TYPE_OPTIONS)[number]["value"];
+
+const SourcesSection = ({
+	isArchived,
+	thinkspaceId,
+}: {
+	isArchived: boolean;
+	thinkspaceId: string;
+}) => {
+	const context = routeApi.useRouteContext();
+	const queryClient = useQueryClient();
+	const [sourceName, setSourceName] = useState("");
+	const [sourceDescription, setSourceDescription] = useState("");
+	const [sourceContentType, setSourceContentType] =
+		useState<SourceContentTypeOption>("text/markdown");
+	const [sourceContent, setSourceContent] = useState("");
+	const [viewedSourceId, setViewedSourceId] = useState<string | null>(null);
+	const [deletingSourceId, setDeletingSourceId] = useState<string | null>(null);
+	const sourcesQuery = useQuery(
+		context.orpc.sources.list.queryOptions({ input: { thinkspaceId } }),
+	);
+	const sourceContentQuery = useQuery(
+		context.orpc.sources.getContent.queryOptions({
+			enabled: Boolean(viewedSourceId),
+			input: { sourceId: viewedSourceId ?? "", thinkspaceId },
+		}),
+	);
+	const invalidateSources = async () => {
+		await queryClient.invalidateQueries({
+			queryKey: context.orpc.sources.list.queryKey({ input: { thinkspaceId } }),
+		});
+	};
+	const uploadSourceMutation = useMutation(
+		context.orpc.sources.upload.mutationOptions({
+			onSuccess: async () => {
+				setSourceName("");
+				setSourceDescription("");
+				setSourceContent("");
+				await invalidateSources();
+			},
+		}),
+	);
+	const deleteSourceMutation = useMutation(
+		context.orpc.sources.delete.mutationOptions({
+			onMutate: ({ sourceId }) => {
+				setDeletingSourceId(sourceId);
+			},
+			onSettled: () => {
+				setDeletingSourceId(null);
+			},
+			onSuccess: async ({ deletedSourceId }) => {
+				setViewedSourceId((current) => (current === deletedSourceId ? null : current));
+				await invalidateSources();
+			},
+		}),
+	);
+	const sources = sourcesQuery.data ?? [];
+	const uploadDisabled =
+		isArchived || !sourceName.trim() || !sourceContent || uploadSourceMutation.isPending;
+
+	return (
+		<section aria-labelledby="sources-heading" className="grid gap-4">
+			<div className="grid gap-1">
+				<h2 className="text-lg font-semibold tracking-tight" id="sources-heading">
+					Sources
+				</h2>
+				<p className="text-muted-foreground text-sm">
+					Material you hand to this Thinkspace — requirement docs, exported notes, ADRs. Sources are
+					scoped to this Thinkspace only.
+				</p>
+			</div>
+			<form
+				className="grid gap-3 border border-border p-4"
+				onSubmit={(event) => {
+					event.preventDefault();
+					if (uploadDisabled) {
+						return;
+					}
+					uploadSourceMutation.mutate({
+						content: sourceContent,
+						contentType: sourceContentType,
+						description: sourceDescription.trim() || undefined,
+						name: sourceName,
+						thinkspaceId,
+					});
+				}}
+			>
+				<div className="grid gap-2 sm:grid-cols-2">
+					<div className="grid gap-2">
+						<Label htmlFor="source-name">Name</Label>
+						<Input
+							disabled={isArchived}
+							id="source-name"
+							maxLength={120}
+							onChange={(event) => setSourceName(event.target.value)}
+							placeholder="Vendor pricing notes"
+							value={sourceName}
+						/>
+					</div>
+					<div className="grid gap-2">
+						<Label htmlFor="source-content-type">Format</Label>
+						<select
+							className="border-input bg-transparent flex h-9 w-full min-w-0 border px-3 py-1 text-sm shadow-xs outline-none disabled:cursor-not-allowed disabled:opacity-50"
+							disabled={isArchived}
+							id="source-content-type"
+							onChange={(event) =>
+								setSourceContentType(event.target.value as SourceContentTypeOption)
+							}
+							value={sourceContentType}
+						>
+							{SOURCE_CONTENT_TYPE_OPTIONS.map((option) => (
+								<option key={option.value} value={option.value}>
+									{option.label}
+								</option>
+							))}
+						</select>
+					</div>
+				</div>
+				<div className="grid gap-2">
+					<Label htmlFor="source-description">Description (optional)</Label>
+					<Input
+						disabled={isArchived}
+						id="source-description"
+						maxLength={500}
+						onChange={(event) => setSourceDescription(event.target.value)}
+						placeholder="What this material is for"
+						value={sourceDescription}
+					/>
+				</div>
+				<div className="grid gap-2">
+					<Label htmlFor="source-content">Content</Label>
+					<Textarea
+						disabled={isArchived}
+						id="source-content"
+						onChange={(event) => setSourceContent(event.target.value)}
+						placeholder="Paste the text or markdown content of this Source."
+						rows={5}
+						value={sourceContent}
+					/>
+				</div>
+				{uploadSourceMutation.isError ? (
+					<p className="text-destructive text-xs" role="alert">
+						{uploadSourceMutation.error.message}
+					</p>
+				) : null}
+				<div>
+					<Button disabled={uploadDisabled} type="submit">
+						{uploadSourceMutation.isPending ? "Uploading…" : "Upload Source"}
+					</Button>
+				</div>
+			</form>
+			{sources.length === 0 ? (
+				<p className="border border-border p-4 text-muted-foreground text-sm">
+					No Sources uploaded to this Thinkspace yet.
+				</p>
+			) : (
+				<div className="border border-border">
+					{sources.map((source, index) => (
+						<div
+							key={source.id}
+							className={`grid gap-2 p-4 ${index < sources.length - 1 ? "border-b border-border" : ""}`}
+						>
+							<div className="flex items-start justify-between gap-4">
+								<div className="grid gap-0.5">
+									<p className="text-sm font-medium">{source.name}</p>
+									{source.description ? (
+										<p className="text-muted-foreground text-xs">{source.description}</p>
+									) : null}
+									<p className="text-muted-foreground text-xs">
+										{formatSourceContentType(source.contentType)} ·{" "}
+										{formatSourceSize(source.sizeBytes)} · Uploaded{" "}
+										{formatDateTime(source.createdAt)}
+									</p>
+								</div>
+								<div className="flex shrink-0 gap-2">
+									<Button
+										onClick={() =>
+											setViewedSourceId((current) => (current === source.id ? null : source.id))
+										}
+										size="sm"
+										type="button"
+										variant="outline"
+									>
+										{viewedSourceId === source.id ? "Hide" : "View"}
+									</Button>
+									<Button
+										disabled={Boolean(deletingSourceId)}
+										onClick={() =>
+											deleteSourceMutation.mutate({ sourceId: source.id, thinkspaceId })
+										}
+										size="sm"
+										type="button"
+										variant="outline"
+									>
+										{deletingSourceId === source.id ? "Deleting…" : "Delete"}
+									</Button>
+								</div>
+							</div>
+							{viewedSourceId === source.id ? (
+								<div className="grid gap-2 border-border border-t pt-3">
+									{sourceContentQuery.isError ? (
+										<p className="text-destructive text-xs" role="alert">
+											{sourceContentQuery.error.message}
+										</p>
+									) : null}
+									{sourceContentQuery.isFetching ? (
+										<p className="text-muted-foreground text-xs">Loading content…</p>
+									) : null}
+									{sourceContentQuery.data && sourceContentQuery.data.id === source.id ? (
+										<p className="max-h-80 overflow-y-auto whitespace-pre-wrap border border-border p-3 text-sm leading-relaxed">
+											{sourceContentQuery.data.content}
+										</p>
+									) : null}
+								</div>
+							) : null}
+						</div>
+					))}
+				</div>
+			)}
+			{deleteSourceMutation.isError ? (
+				<p className="text-destructive text-sm" role="alert">
+					{deleteSourceMutation.error.message}
+				</p>
+			) : null}
+		</section>
+	);
+};
+
 interface McpCatalogServerView {
 	description: string;
 	id: string;
@@ -945,6 +1189,10 @@ const RouteComponent = () => {
 				modelReady={modelReadiness.status === "ready"}
 				thinkspaceId={thinkspaceId}
 			/>
+
+			<Separator />
+
+			<SourcesSection isArchived={isArchived} thinkspaceId={thinkspaceId} />
 
 			<Separator />
 

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -4,6 +4,7 @@ import { mcpRouter } from "../mcp/router";
 import { modelsRouter } from "../models/router";
 import { profileRouter } from "../profile/router";
 import { publicProcedure } from "../procedures";
+import { sourcesRouter } from "../sources/router";
 import { thinkspacesRouter } from "../thinkspaces/router";
 
 export const appRouter = {
@@ -11,6 +12,7 @@ export const appRouter = {
 	mcp: mcpRouter,
 	models: modelsRouter,
 	profile: profileRouter,
+	sources: sourcesRouter,
 	thinkspaces: thinkspacesRouter,
 };
 export type AppRouter = typeof appRouter;

--- a/packages/api/src/sources/content-store.ts
+++ b/packages/api/src/sources/content-store.ts
@@ -1,0 +1,75 @@
+/**
+ * Storage seam for Source content blobs. Index rows live in D1; the verbatim
+ * content lives in the SOURCES_ARTIFACTS R2 bucket (ADR-0002 storage split).
+ * Everything above this seam speaks in Sources; nothing above it learns which
+ * binding or bucket failed when storage is unavailable.
+ */
+
+/**
+ * Raised when Source content storage cannot serve a read or write. The
+ * message is product-safe by construction: callers may surface it verbatim.
+ */
+export class SourceContentStorageError extends Error {
+	constructor() {
+		super("Source storage is unavailable right now. Try again shortly.");
+		this.name = "SourceContentStorageError";
+	}
+}
+
+export interface SourceContentKeyInput {
+	sourceId: string;
+	thinkspaceId: string;
+}
+
+/**
+ * Blob keys carry the owning Thinkspace id so content is namespaced per
+ * Thinkspace all the way down to storage, mirroring the index-row scoping.
+ */
+export const sourceContentKey = ({ sourceId, thinkspaceId }: SourceContentKeyInput): string =>
+	`thinkspaces/${thinkspaceId}/sources/${sourceId}`;
+
+export interface SourceContentStore {
+	deleteContent: (input: SourceContentKeyInput) => Promise<void>;
+	getContent: (input: SourceContentKeyInput) => Promise<string | null>;
+	putContent: (input: SourceContentKeyInput & { content: string }) => Promise<void>;
+}
+
+const guardStorage = async <T>(operation: () => Promise<T>): Promise<T> => {
+	try {
+		return await operation();
+	} catch {
+		throw new SourceContentStorageError();
+	}
+};
+
+export const createSourceContentStore = (env: {
+	SOURCES_ARTIFACTS?: R2Bucket;
+}): SourceContentStore => {
+	const bucket = env.SOURCES_ARTIFACTS;
+
+	if (!bucket) {
+		return {
+			deleteContent: () => Promise.reject(new SourceContentStorageError()),
+			getContent: () => Promise.reject(new SourceContentStorageError()),
+			putContent: () => Promise.reject(new SourceContentStorageError()),
+		};
+	}
+
+	return {
+		deleteContent: (input) => guardStorage(() => bucket.delete(sourceContentKey(input))),
+		getContent: (input) =>
+			guardStorage(async () => {
+				const object = await bucket.get(sourceContentKey(input));
+
+				if (!object) {
+					return null;
+				}
+
+				return await object.text();
+			}),
+		putContent: (input) =>
+			guardStorage(async () => {
+				await bucket.put(sourceContentKey(input), input.content);
+			}),
+	};
+};

--- a/packages/api/src/sources/repository.ts
+++ b/packages/api/src/sources/repository.ts
@@ -1,0 +1,73 @@
+import type { ProductDb } from "@better-agent/db";
+import { thinkspaceSources } from "@better-agent/db/schema/sources";
+import type { ThinkspaceSource } from "@better-agent/db/schema/sources";
+import { and, desc, eq } from "drizzle-orm";
+
+export interface CreateThinkspaceSourceInput {
+	record: typeof thinkspaceSources.$inferInsert;
+}
+
+export interface GetThinkspaceSourceInput {
+	sourceId: string;
+	thinkspaceId: string;
+}
+
+export interface ListThinkspaceSourcesInput {
+	thinkspaceId: string;
+}
+
+export const createThinkspaceSource = async (
+	db: ProductDb,
+	{ record }: CreateThinkspaceSourceInput,
+): Promise<ThinkspaceSource> => {
+	const [created] = await db.insert(thinkspaceSources).values(record).returning();
+
+	if (!created) {
+		throw new Error("Source was not persisted.");
+	}
+
+	return created;
+};
+
+/**
+ * Every read and delete is keyed by (thinkspaceId, sourceId) together, so a
+ * Source id forged from another Thinkspace can never resolve here.
+ */
+export const getThinkspaceSource = async (
+	db: ProductDb,
+	{ sourceId, thinkspaceId }: GetThinkspaceSourceInput,
+): Promise<ThinkspaceSource | null> => {
+	const [source] = await db
+		.select()
+		.from(thinkspaceSources)
+		.where(
+			and(eq(thinkspaceSources.id, sourceId), eq(thinkspaceSources.thinkspaceId, thinkspaceId)),
+		)
+		.limit(1);
+
+	return source ?? null;
+};
+
+export const listThinkspaceSources = async (
+	db: ProductDb,
+	{ thinkspaceId }: ListThinkspaceSourcesInput,
+): Promise<ThinkspaceSource[]> =>
+	await db
+		.select()
+		.from(thinkspaceSources)
+		.where(eq(thinkspaceSources.thinkspaceId, thinkspaceId))
+		.orderBy(desc(thinkspaceSources.createdAt));
+
+export const deleteThinkspaceSource = async (
+	db: ProductDb,
+	{ sourceId, thinkspaceId }: GetThinkspaceSourceInput,
+): Promise<ThinkspaceSource | null> => {
+	const [deleted] = await db
+		.delete(thinkspaceSources)
+		.where(
+			and(eq(thinkspaceSources.id, sourceId), eq(thinkspaceSources.thinkspaceId, thinkspaceId)),
+		)
+		.returning();
+
+	return deleted ?? null;
+};

--- a/packages/api/src/sources/router.test.ts
+++ b/packages/api/src/sources/router.test.ts
@@ -1,0 +1,498 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+import { user } from "@better-agent/db/schema/auth";
+import { thinkspaces } from "@better-agent/db/schema/thinkspaces";
+import { ORPCError, call } from "@orpc/server";
+import type { AnyProcedure } from "@orpc/server";
+
+import type { Context } from "../context";
+import { createTestProductDb } from "../testing/product-db";
+import { sourcesRouter } from "./router";
+import { SOURCE_CONTENT_MAX_BYTES } from "./source-upload";
+
+const OWNED_THINKSPACE_ID = "thinkspace_sources";
+const OTHER_THINKSPACE_ID = "thinkspace_sources_other";
+
+const authenticatedSession = {
+	session: { id: "session_1" },
+	user: { id: "owner_user" },
+};
+
+const nonOwnerSession = {
+	session: { id: "session_2" },
+	user: { id: "other_user" },
+};
+
+/**
+ * A db that fails the test if any query is attempted. Used to prove that
+ * rejected requests never reach product storage.
+ */
+const untouchableDb = new Proxy({} as Record<string, unknown>, {
+	get(_target, property) {
+		throw new Error(`Product storage must not be touched (accessed ${String(property)}).`);
+	},
+}) as unknown as ProductDb;
+
+/**
+ * An R2 bucket that fails the test if any blob operation is attempted. Used
+ * to prove that rejected uploads never reach content storage.
+ */
+const untouchableBucket = new Proxy({} as Record<string, unknown>, {
+	get(_target, property) {
+		throw new Error(`Content storage must not be touched (accessed ${String(property)}).`);
+	},
+}) as unknown as R2Bucket;
+
+/**
+ * Minimal structural in-memory stand-in for the SOURCES_ARTIFACTS R2 bucket:
+ * just the get/put/delete surface the content store seam uses.
+ */
+const createMemoryBucket = () => {
+	const blobs = new Map<string, string>();
+	const bucket = {
+		delete: (key: string) => {
+			blobs.delete(key);
+			return Promise.resolve();
+		},
+		get: (key: string) => {
+			const content = blobs.get(key);
+
+			if (content === undefined) {
+				return Promise.resolve(null);
+			}
+
+			return Promise.resolve({ text: () => Promise.resolve(content) });
+		},
+		put: (key: string, value: string) => {
+			blobs.set(key, value);
+			return Promise.resolve(null);
+		},
+	};
+
+	return { blobs, bucket: bucket as unknown as R2Bucket };
+};
+
+const createCallContext = ({
+	bucket,
+	db,
+	session = authenticatedSession,
+}: {
+	bucket?: R2Bucket;
+	db: ProductDb;
+	session?: typeof authenticatedSession | null;
+}): Context =>
+	({
+		db,
+		env: bucket ? { SOURCES_ARTIFACTS: bucket } : {},
+		executionCtx: undefined,
+		headers: new Headers(),
+		modelCatalog: undefined,
+		session,
+	}) as unknown as Context;
+
+const seedOwnedThinkspaces = async (db: ProductDb) => {
+	await db.insert(user).values({
+		email: "owner@example.com",
+		id: authenticatedSession.user.id,
+		name: "Owner",
+	});
+	await db.insert(thinkspaces).values([
+		{
+			goal: "Decide between observability vendors",
+			id: OWNED_THINKSPACE_ID,
+			ownerUserId: authenticatedSession.user.id,
+			status: "active",
+		},
+		{
+			goal: "Plan the database migration",
+			id: OTHER_THINKSPACE_ID,
+			ownerUserId: authenticatedSession.user.id,
+			status: "active",
+		},
+	]);
+};
+
+const uploadInput = (overrides: Record<string, unknown> = {}) => ({
+	content: "# Vendor pricing\n\nVendor A: $99/mo.",
+	contentType: "text/markdown" as const,
+	description: "Exported pricing notes",
+	name: "Vendor pricing",
+	thinkspaceId: OWNED_THINKSPACE_ID,
+	...overrides,
+});
+
+const expectCode =
+	(code: string) =>
+	(error: unknown): boolean =>
+		error instanceof ORPCError && error.code === code;
+
+const expectProductSafeStorageFailure = (error: unknown): boolean => {
+	assert.ok(error instanceof ORPCError);
+	assert.equal(error.code, "INTERNAL_SERVER_ERROR");
+	assert.doesNotMatch(error.message, /R2/u);
+	assert.doesNotMatch(error.message, /binding/iu);
+	assert.doesNotMatch(error.message, /SOURCES_ARTIFACTS/u);
+	assert.doesNotMatch(error.message, /bucket/iu);
+	return true;
+};
+
+test("a Source round-trips verbatim through upload, list, getContent, and delete", async () => {
+	const db = createTestProductDb();
+	const { blobs, bucket } = createMemoryBucket();
+	await seedOwnedThinkspaces(db);
+	const context = createCallContext({ bucket, db });
+
+	const uploaded = await call(sourcesRouter.upload, uploadInput(), { context });
+
+	assert.ok(uploaded);
+	assert.equal(uploaded.name, "Vendor pricing");
+	assert.equal(uploaded.description, "Exported pricing notes");
+	assert.equal(uploaded.contentType, "text/markdown");
+	assert.equal(uploaded.sizeBytes, 35);
+	assert.equal(uploaded.thinkspaceId, OWNED_THINKSPACE_ID);
+	assert.equal("content" in uploaded, false);
+
+	const listed = await call(sourcesRouter.list, { thinkspaceId: OWNED_THINKSPACE_ID }, { context });
+	assert.equal(listed.length, 1);
+	assert.equal(listed[0]?.id, uploaded.id);
+	assert.equal(listed[0]?.sizeBytes, 35);
+	assert.ok(listed[0]?.createdAt instanceof Date);
+
+	const content = await call(
+		sourcesRouter.getContent,
+		{ sourceId: uploaded.id, thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context },
+	);
+	assert.ok(content);
+	assert.equal(content.content, "# Vendor pricing\n\nVendor A: $99/mo.");
+	assert.equal(content.name, "Vendor pricing");
+
+	const deleted = await call(
+		sourcesRouter.delete,
+		{ sourceId: uploaded.id, thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context },
+	);
+	assert.equal(deleted.deletedSourceId, uploaded.id);
+	assert.equal(blobs.size, 0);
+
+	const afterDelete = await call(
+		sourcesRouter.list,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context },
+	);
+	assert.deepEqual(afterDelete, []);
+
+	await assert.rejects(
+		call(
+			sourcesRouter.getContent,
+			{ sourceId: uploaded.id, thinkspaceId: OWNED_THINKSPACE_ID },
+			{ context },
+		),
+		expectCode("NOT_FOUND"),
+	);
+});
+
+test("the size cap is enforced in bytes before any storage is touched", async () => {
+	const db = createTestProductDb();
+	await seedOwnedThinkspaces(db);
+	const context = createCallContext({ bucket: untouchableBucket, db });
+
+	// One past the cap in plain ASCII.
+	await assert.rejects(
+		call(sourcesRouter.upload, uploadInput({ content: "x".repeat(SOURCE_CONTENT_MAX_BYTES + 1) }), {
+			context,
+		}),
+		(error: unknown) => {
+			assert.ok(error instanceof ORPCError);
+			assert.equal(error.code, "BAD_REQUEST");
+			assert.match(error.message, /KB/u);
+			return true;
+		},
+	);
+
+	// Under the cap in characters but over it in UTF-8 bytes (3 bytes each).
+	await assert.rejects(
+		call(
+			sourcesRouter.upload,
+			uploadInput({ content: "縦".repeat(Math.floor(SOURCE_CONTENT_MAX_BYTES / 3) + 1) }),
+			{ context },
+		),
+		expectCode("BAD_REQUEST"),
+	);
+});
+
+test("unsupported content types and malformed uploads reject at the boundary without touching storage", async () => {
+	const context = createCallContext({ bucket: untouchableBucket, db: untouchableDb });
+	const malformed: Record<string, unknown>[] = [
+		uploadInput({ contentType: "application/pdf" }),
+		uploadInput({ contentType: "text/html" }),
+		uploadInput({ content: "" }),
+		uploadInput({ name: "" }),
+		uploadInput({ name: "n".repeat(121) }),
+		uploadInput({ description: "d".repeat(501) }),
+	];
+
+	for (const input of malformed) {
+		await assert.rejects(
+			call(sourcesRouter.upload as AnyProcedure, input, { context }),
+			expectCode("BAD_REQUEST"),
+		);
+	}
+});
+
+test("a name of only whitespace rejects after thinkspace verification with a product-safe message", async () => {
+	const db = createTestProductDb();
+	await seedOwnedThinkspaces(db);
+	const context = createCallContext({ bucket: untouchableBucket, db });
+
+	await assert.rejects(
+		call(sourcesRouter.upload, uploadInput({ name: "   " }), { context }),
+		(error: unknown) => {
+			assert.ok(error instanceof ORPCError);
+			assert.equal(error.code, "BAD_REQUEST");
+			assert.match(error.message, /name/u);
+			return true;
+		},
+	);
+});
+
+test("unauthenticated requests cannot reach any Sources operation", async () => {
+	const operations: { input: Record<string, unknown>; name: string; procedure: AnyProcedure }[] = [
+		{ input: uploadInput(), name: "upload", procedure: sourcesRouter.upload },
+		{
+			input: { thinkspaceId: OWNED_THINKSPACE_ID },
+			name: "list",
+			procedure: sourcesRouter.list,
+		},
+		{
+			input: { sourceId: "source_1", thinkspaceId: OWNED_THINKSPACE_ID },
+			name: "getContent",
+			procedure: sourcesRouter.getContent,
+		},
+		{
+			input: { sourceId: "source_1", thinkspaceId: OWNED_THINKSPACE_ID },
+			name: "delete",
+			procedure: sourcesRouter.delete,
+		},
+	];
+
+	for (const operation of operations) {
+		await assert.rejects(
+			call(operation.procedure, operation.input, {
+				context: createCallContext({
+					bucket: untouchableBucket,
+					db: untouchableDb,
+					session: null,
+				}),
+			}),
+			expectCode("UNAUTHORIZED"),
+			`${operation.name} must reject unauthenticated requests`,
+		);
+	}
+});
+
+test("authenticated non-owners get NOT_FOUND for every Sources operation", async () => {
+	const db = createTestProductDb();
+	const { bucket } = createMemoryBucket();
+	await seedOwnedThinkspaces(db);
+	const ownerContext = createCallContext({ bucket, db });
+	const uploaded = await call(sourcesRouter.upload, uploadInput(), { context: ownerContext });
+
+	assert.ok(uploaded);
+
+	const nonOwnerContext = createCallContext({ bucket, db, session: nonOwnerSession });
+	const operations: { input: Record<string, unknown>; name: string; procedure: AnyProcedure }[] = [
+		{ input: uploadInput(), name: "upload", procedure: sourcesRouter.upload },
+		{
+			input: { thinkspaceId: OWNED_THINKSPACE_ID },
+			name: "list",
+			procedure: sourcesRouter.list,
+		},
+		{
+			input: { sourceId: uploaded.id, thinkspaceId: OWNED_THINKSPACE_ID },
+			name: "getContent",
+			procedure: sourcesRouter.getContent,
+		},
+		{
+			input: { sourceId: uploaded.id, thinkspaceId: OWNED_THINKSPACE_ID },
+			name: "delete",
+			procedure: sourcesRouter.delete,
+		},
+	];
+
+	for (const operation of operations) {
+		await assert.rejects(
+			call(operation.procedure, operation.input, { context: nonOwnerContext }),
+			expectCode("NOT_FOUND"),
+			`${operation.name} must hide other users' Thinkspaces`,
+		);
+	}
+
+	const stillThere = await call(
+		sourcesRouter.list,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: ownerContext },
+	);
+	assert.equal(stillThere.length, 1);
+});
+
+test("guessed Thinkspace and Source ids cannot resolve any Sources operation", async () => {
+	const db = createTestProductDb();
+	const { bucket } = createMemoryBucket();
+	await seedOwnedThinkspaces(db);
+	const context = createCallContext({ bucket, db });
+
+	await assert.rejects(
+		call(sourcesRouter.list, { thinkspaceId: "thinkspace_guessed" }, { context }),
+		expectCode("NOT_FOUND"),
+	);
+	await assert.rejects(
+		call(
+			sourcesRouter.getContent,
+			{ sourceId: "source_guessed", thinkspaceId: OWNED_THINKSPACE_ID },
+			{ context },
+		),
+		expectCode("NOT_FOUND"),
+	);
+	await assert.rejects(
+		call(
+			sourcesRouter.delete,
+			{ sourceId: "source_guessed", thinkspaceId: OWNED_THINKSPACE_ID },
+			{ context },
+		),
+		expectCode("NOT_FOUND"),
+	);
+});
+
+test("a Source is sealed to its own Thinkspace even with a forged id from a sibling", async () => {
+	const db = createTestProductDb();
+	const { bucket } = createMemoryBucket();
+	await seedOwnedThinkspaces(db);
+	const context = createCallContext({ bucket, db });
+	const uploaded = await call(sourcesRouter.upload, uploadInput(), { context });
+
+	assert.ok(uploaded);
+	// Same owner, different Thinkspace: the forged cross-Thinkspace read and
+	// delete must both be indistinguishable from the Source not existing.
+	await assert.rejects(
+		call(
+			sourcesRouter.getContent,
+			{ sourceId: uploaded.id, thinkspaceId: OTHER_THINKSPACE_ID },
+			{ context },
+		),
+		expectCode("NOT_FOUND"),
+	);
+	await assert.rejects(
+		call(
+			sourcesRouter.delete,
+			{ sourceId: uploaded.id, thinkspaceId: OTHER_THINKSPACE_ID },
+			{ context },
+		),
+		expectCode("NOT_FOUND"),
+	);
+
+	const siblingList = await call(
+		sourcesRouter.list,
+		{ thinkspaceId: OTHER_THINKSPACE_ID },
+		{ context },
+	);
+	assert.deepEqual(siblingList, []);
+
+	const ownList = await call(
+		sourcesRouter.list,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context },
+	);
+	assert.equal(ownList.length, 1);
+});
+
+test("a missing storage binding surfaces a product-safe error without binding detail", async () => {
+	const db = createTestProductDb();
+	await seedOwnedThinkspaces(db);
+	const context = createCallContext({ db });
+
+	await assert.rejects(
+		call(sourcesRouter.upload, uploadInput(), { context }),
+		expectProductSafeStorageFailure,
+	);
+
+	// The failed upload must not leave a phantom index row behind.
+	const listed = await call(sourcesRouter.list, { thinkspaceId: OWNED_THINKSPACE_ID }, { context });
+	assert.deepEqual(listed, []);
+});
+
+test("a Source whose blob is missing degrades with a product-safe error", async () => {
+	const db = createTestProductDb();
+	const { blobs, bucket } = createMemoryBucket();
+	await seedOwnedThinkspaces(db);
+	const context = createCallContext({ bucket, db });
+	const uploaded = await call(sourcesRouter.upload, uploadInput(), { context });
+
+	assert.ok(uploaded);
+	blobs.clear();
+
+	await assert.rejects(
+		call(
+			sourcesRouter.getContent,
+			{ sourceId: uploaded.id, thinkspaceId: OWNED_THINKSPACE_ID },
+			{ context },
+		),
+		expectProductSafeStorageFailure,
+	);
+});
+
+test("a failed blob delete keeps the index row so the delete reports honestly", async () => {
+	const db = createTestProductDb();
+	const { bucket } = createMemoryBucket();
+	await seedOwnedThinkspaces(db);
+	const uploaded = await call(sourcesRouter.upload, uploadInput(), {
+		context: createCallContext({ bucket, db }),
+	});
+
+	assert.ok(uploaded);
+
+	const failingBucket = {
+		delete: () => Promise.reject(new Error("transport detail must not leak")),
+	} as unknown as R2Bucket;
+	const failingContext = createCallContext({ bucket: failingBucket, db });
+
+	await assert.rejects(
+		call(
+			sourcesRouter.delete,
+			{ sourceId: uploaded.id, thinkspaceId: OWNED_THINKSPACE_ID },
+			{ context: failingContext },
+		),
+		(error: unknown) => {
+			assert.ok(error instanceof ORPCError);
+			assert.equal(error.code, "INTERNAL_SERVER_ERROR");
+			assert.doesNotMatch(error.message, /transport detail/u);
+			return true;
+		},
+	);
+
+	const listed = await call(
+		sourcesRouter.list,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ bucket, db }) },
+	);
+	assert.equal(listed.length, 1);
+});
+
+test("uploads trim the name and description and default the description to empty", async () => {
+	const db = createTestProductDb();
+	const { bucket } = createMemoryBucket();
+	await seedOwnedThinkspaces(db);
+	const context = createCallContext({ bucket, db });
+
+	const uploaded = await call(
+		sourcesRouter.upload,
+		uploadInput({ description: undefined, name: "  Requirements doc  " }),
+		{ context },
+	);
+
+	assert.ok(uploaded);
+	assert.equal(uploaded.name, "Requirements doc");
+	assert.equal(uploaded.description, "");
+});

--- a/packages/api/src/sources/router.ts
+++ b/packages/api/src/sources/router.ts
@@ -1,0 +1,207 @@
+import type { ThinkspaceSource } from "@better-agent/db/schema/sources";
+import { ORPCError } from "@orpc/server";
+import { z } from "zod";
+
+import { protectedProcedure } from "../procedures";
+import { getThinkspace } from "../thinkspaces/repository";
+import { createSourceContentStore, SourceContentStorageError } from "./content-store";
+import {
+	createThinkspaceSource,
+	deleteThinkspaceSource,
+	getThinkspaceSource,
+	listThinkspaceSources,
+} from "./repository";
+import {
+	SOURCE_CONTENT_TYPES,
+	SOURCE_DESCRIPTION_MAX_LENGTH,
+	SOURCE_NAME_MAX_LENGTH,
+	SourceUploadValidationError,
+	validateSourceUpload,
+} from "./source-upload";
+
+const thinkspaceIdInput = z.object({
+	thinkspaceId: z.string().min(1),
+});
+
+const sourceIdInput = thinkspaceIdInput.extend({
+	sourceId: z.string().min(1),
+});
+
+const uploadSourceInput = thinkspaceIdInput.extend({
+	content: z.string().min(1),
+	contentType: z.enum(SOURCE_CONTENT_TYPES),
+	description: z.string().max(SOURCE_DESCRIPTION_MAX_LENGTH).optional(),
+	name: z.string().min(1).max(SOURCE_NAME_MAX_LENGTH),
+});
+
+const createSourceId = (): string => `source_${crypto.randomUUID()}`;
+
+const toNotFound = (): ORPCError<"NOT_FOUND", undefined> =>
+	new ORPCError("NOT_FOUND", { message: "Thinkspace was not found." });
+
+const toSourceNotFound = (): ORPCError<"NOT_FOUND", undefined> =>
+	new ORPCError("NOT_FOUND", { message: "Source was not found." });
+
+const toStorageUnavailable = (error: SourceContentStorageError) =>
+	new ORPCError("INTERNAL_SERVER_ERROR", { message: error.message });
+
+const throwProductSafeSourceError = (error: unknown): never => {
+	if (error instanceof SourceUploadValidationError) {
+		throw new ORPCError("BAD_REQUEST", { message: error.message });
+	}
+
+	if (error instanceof SourceContentStorageError) {
+		throw toStorageUnavailable(error);
+	}
+
+	throw error;
+};
+
+const toSourceSummary = (source: ThinkspaceSource) => ({
+	contentType: source.contentType,
+	createdAt: source.createdAt,
+	description: source.description,
+	id: source.id,
+	name: source.name,
+	sizeBytes: source.sizeBytes,
+	thinkspaceId: source.thinkspaceId,
+});
+
+export const sourcesRouter = {
+	delete: protectedProcedure.input(sourceIdInput).handler(async ({ context, input }) => {
+		const thinkspace = await getThinkspace(context.db, {
+			ownerUserId: context.session.user.id,
+			thinkspaceId: input.thinkspaceId,
+		});
+
+		if (!thinkspace) {
+			throw toNotFound();
+		}
+
+		const source = await getThinkspaceSource(context.db, {
+			sourceId: input.sourceId,
+			thinkspaceId: thinkspace.id,
+		});
+
+		if (!source) {
+			throw toSourceNotFound();
+		}
+
+		try {
+			// Blob first: if storage is unavailable the index row survives and
+			// the delete reports failure, instead of leaving an orphaned blob
+			// behind a row that no longer exists.
+			await createSourceContentStore(context.env).deleteContent({
+				sourceId: source.id,
+				thinkspaceId: thinkspace.id,
+			});
+		} catch (error) {
+			throwProductSafeSourceError(error);
+		}
+
+		const deleted = await deleteThinkspaceSource(context.db, {
+			sourceId: source.id,
+			thinkspaceId: thinkspace.id,
+		});
+
+		if (!deleted) {
+			throw toSourceNotFound();
+		}
+
+		return {
+			deletedSourceId: deleted.id,
+			thinkspaceId: thinkspace.id,
+		};
+	}),
+	getContent: protectedProcedure.input(sourceIdInput).handler(async ({ context, input }) => {
+		const thinkspace = await getThinkspace(context.db, {
+			ownerUserId: context.session.user.id,
+			thinkspaceId: input.thinkspaceId,
+		});
+
+		if (!thinkspace) {
+			throw toNotFound();
+		}
+
+		const source = await getThinkspaceSource(context.db, {
+			sourceId: input.sourceId,
+			thinkspaceId: thinkspace.id,
+		});
+
+		if (!source) {
+			throw toSourceNotFound();
+		}
+
+		try {
+			const content = await createSourceContentStore(context.env).getContent({
+				sourceId: source.id,
+				thinkspaceId: thinkspace.id,
+			});
+
+			if (content === null) {
+				throw new SourceContentStorageError();
+			}
+
+			return { ...toSourceSummary(source), content };
+		} catch (error) {
+			throwProductSafeSourceError(error);
+		}
+	}),
+	list: protectedProcedure.input(thinkspaceIdInput).handler(async ({ context, input }) => {
+		const thinkspace = await getThinkspace(context.db, {
+			ownerUserId: context.session.user.id,
+			thinkspaceId: input.thinkspaceId,
+		});
+
+		if (!thinkspace) {
+			throw toNotFound();
+		}
+
+		const sources = await listThinkspaceSources(context.db, { thinkspaceId: thinkspace.id });
+
+		return sources.map(toSourceSummary);
+	}),
+	upload: protectedProcedure.input(uploadSourceInput).handler(async ({ context, input }) => {
+		const thinkspace = await getThinkspace(context.db, {
+			ownerUserId: context.session.user.id,
+			thinkspaceId: input.thinkspaceId,
+		});
+
+		if (!thinkspace) {
+			throw toNotFound();
+		}
+
+		try {
+			const upload = validateSourceUpload({
+				content: input.content,
+				contentType: input.contentType,
+				description: input.description,
+				name: input.name,
+			});
+			const sourceId = createSourceId();
+
+			// Blob before index row: a failed insert can orphan a blob, but the
+			// reverse order could index a Source whose content never landed.
+			await createSourceContentStore(context.env).putContent({
+				content: upload.content,
+				sourceId,
+				thinkspaceId: thinkspace.id,
+			});
+
+			const created = await createThinkspaceSource(context.db, {
+				record: {
+					contentType: upload.contentType,
+					description: upload.description,
+					id: sourceId,
+					name: upload.name,
+					sizeBytes: upload.sizeBytes,
+					thinkspaceId: thinkspace.id,
+				},
+			});
+
+			return toSourceSummary(created);
+		} catch (error) {
+			throwProductSafeSourceError(error);
+		}
+	}),
+};

--- a/packages/api/src/sources/source-upload.ts
+++ b/packages/api/src/sources/source-upload.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure validation for Source uploads. Upload is text-first and verbatim: the
+ * product accepts plain text and markdown, enforces a fixed per-file byte
+ * cap, and performs no extraction or transformation. Every rejection message
+ * is product-safe and states the boundary the caller hit.
+ */
+
+export const SOURCE_NAME_MAX_LENGTH = 120;
+export const SOURCE_DESCRIPTION_MAX_LENGTH = 500;
+
+/**
+ * Fixed per-file cap on the UTF-8 encoded content. Measured in bytes, not
+ * characters, so multibyte text cannot slip past the boundary.
+ */
+export const SOURCE_CONTENT_MAX_BYTES = 262_144;
+
+export const SOURCE_CONTENT_TYPES = ["text/markdown", "text/plain"] as const;
+
+export type SourceContentType = (typeof SOURCE_CONTENT_TYPES)[number];
+
+export class SourceUploadValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "SourceUploadValidationError";
+	}
+}
+
+export interface ValidatedSourceUpload {
+	content: string;
+	contentType: SourceContentType;
+	description: string;
+	name: string;
+	sizeBytes: number;
+}
+
+export const validateSourceUpload = (input: {
+	content: string;
+	contentType: SourceContentType;
+	description?: string;
+	name: string;
+}): ValidatedSourceUpload => {
+	const name = input.name.trim();
+
+	if (!name) {
+		throw new SourceUploadValidationError("A Source needs a name.");
+	}
+
+	if (name.length > SOURCE_NAME_MAX_LENGTH) {
+		throw new SourceUploadValidationError(
+			`A Source name can be at most ${SOURCE_NAME_MAX_LENGTH} characters.`,
+		);
+	}
+
+	const description = input.description?.trim() ?? "";
+
+	if (description.length > SOURCE_DESCRIPTION_MAX_LENGTH) {
+		throw new SourceUploadValidationError(
+			`A Source description can be at most ${SOURCE_DESCRIPTION_MAX_LENGTH} characters.`,
+		);
+	}
+
+	if (!input.content) {
+		throw new SourceUploadValidationError("A Source needs content.");
+	}
+
+	const sizeBytes = new TextEncoder().encode(input.content).byteLength;
+
+	if (sizeBytes > SOURCE_CONTENT_MAX_BYTES) {
+		throw new SourceUploadValidationError(
+			`A Source can be at most ${Math.floor(SOURCE_CONTENT_MAX_BYTES / 1024)} KB of text. This upload is ${Math.ceil(sizeBytes / 1024)} KB.`,
+		);
+	}
+
+	return {
+		content: input.content,
+		contentType: input.contentType,
+		description,
+		name,
+		sizeBytes,
+	};
+};

--- a/packages/db/src/migrations/0008_aspiring_spacker_dave.sql
+++ b/packages/db/src/migrations/0008_aspiring_spacker_dave.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `thinkspace_sources` (
+	`content_type` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`description` text DEFAULT '' NOT NULL,
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`size_bytes` integer NOT NULL,
+	`thinkspace_id` text NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`thinkspace_id`) REFERENCES `thinkspaces`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_thinkspace_sources_thinkspace_created` ON `thinkspace_sources` (`thinkspace_id`,`created_at`);

--- a/packages/db/src/migrations/meta/0008_snapshot.json
+++ b/packages/db/src/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1263 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0a46a7a6-d0ed-46e9-b702-2773fd9fdc3e",
+  "prevId": "d4e00b60-83f3-4e98-b9f1-edd33d18b1d8",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_account_provider_account": {
+          "name": "idx_account_provider_account",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_server_catalog": {
+      "name": "mcp_server_catalog",
+      "columns": {
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'streamable_http'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_agent_profiles": {
+      "name": "thinkspace_agent_profiles",
+      "columns": {
+        "activated_at": {
+          "name": "activated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_permissions": {
+          "name": "requested_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "routines": {
+          "name": "routines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "skill_references": {
+          "name": "skill_references",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_enablements": {
+          "name": "tool_enablements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_agent_profiles_thinkspace_version": {
+          "name": "uq_agent_profiles_thinkspace_version",
+          "columns": [
+            "thinkspace_id",
+            "version"
+          ],
+          "isUnique": true
+        },
+        "uq_agent_profiles_thinkspace_active": {
+          "name": "uq_agent_profiles_thinkspace_active",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'active'"
+        },
+        "uq_agent_profiles_thinkspace_draft": {
+          "name": "uq_agent_profiles_thinkspace_draft",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'draft'"
+        },
+        "idx_agent_profiles_thinkspace_status": {
+          "name": "idx_agent_profiles_thinkspace_status",
+          "columns": [
+            "thinkspace_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_agent_profiles_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_agent_profiles_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_agent_profiles",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_permissions": {
+      "name": "thinkspace_permissions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "resource_scope": {
+          "name": "resource_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_thinkspace_permissions_thinkspace": {
+          "name": "idx_thinkspace_permissions_thinkspace",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": false
+        },
+        "uidx_thinkspace_permissions_model_provider": {
+          "name": "uidx_thinkspace_permissions_model_provider",
+          "columns": [
+            "thinkspace_id",
+            "kind",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_permissions_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_permissions_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_permissions",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_sources": {
+      "name": "thinkspace_sources",
+      "columns": {
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_thinkspace_sources_thinkspace_created": {
+          "name": "idx_thinkspace_sources_thinkspace_created",
+          "columns": [
+            "thinkspace_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_sources_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_sources_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_sources",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspaces": {
+      "name": "thinkspaces",
+      "columns": {
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration_summary": {
+          "name": "configuration_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memory_governance": {
+          "name": "memory_governance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_thinkspaces_owner_status_updated": {
+          "name": "idx_thinkspaces_owner_status_updated",
+          "columns": [
+            "owner_user_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "idx_thinkspaces_owner_created": {
+          "name": "idx_thinkspaces_owner_created",
+          "columns": [
+            "owner_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_thinkspaces_owner_archived": {
+          "name": "idx_thinkspaces_owner_archived",
+          "columns": [
+            "owner_user_id",
+            "archived_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thinkspaces_owner_user_id_user_id_fk": {
+          "name": "thinkspaces_owner_user_id_user_id_fk",
+          "tableFrom": "thinkspaces",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_mcp_connections": {
+      "name": "user_mcp_connections",
+      "columns": {
+        "catalog_visible": {
+          "name": "catalog_visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_headers": {
+          "name": "encrypted_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'streamable_http'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_mcp_connections_user": {
+          "name": "idx_user_mcp_connections_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_mcp_connections_server": {
+          "name": "idx_user_mcp_connections_server",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_mcp_connections_server_id_mcp_server_catalog_id_fk": {
+          "name": "user_mcp_connections_server_id_mcp_server_catalog_id_fk",
+          "tableFrom": "user_mcp_connections",
+          "tableTo": "mcp_server_catalog",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_mcp_connections_user_id_user_id_fk": {
+          "name": "user_mcp_connections_user_id_user_id_fk",
+          "tableFrom": "user_mcp_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_product_settings": {
+      "name": "user_product_settings",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_product_settings_user_id_user_id_fk": {
+          "name": "user_product_settings_user_id_user_id_fk",
+          "tableFrom": "user_product_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_provider_credentials": {
+      "name": "user_provider_credentials",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_provider_credentials_user": {
+          "name": "idx_user_provider_credentials_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_provider_credentials_user_provider": {
+          "name": "idx_user_provider_credentials_user_provider",
+          "columns": [
+            "user_id",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_provider_credentials_user_id_user_id_fk": {
+          "name": "user_provider_credentials_user_id_user_id_fk",
+          "tableFrom": "user_provider_credentials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        },
+        "idx_verification_expires_at": {
+          "name": "idx_verification_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1,62 +1,69 @@
 {
-	"version": "7",
-	"dialect": "sqlite",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "6",
-			"when": 1780029615327,
-			"tag": "0000_fuzzy_dexter_bennett",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "6",
-			"when": 1780032873037,
-			"tag": "0001_left_thunderbird",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "6",
-			"when": 1781125034998,
-			"tag": "0002_adorable_star_brand",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "6",
-			"when": 1781129074166,
-			"tag": "0003_hard_archangel",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "6",
-			"when": 1781139208245,
-			"tag": "0004_quick_thunderbird",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "6",
-			"when": 1781141072949,
-			"tag": "0005_thick_baron_strucker",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "6",
-			"when": 1781142185393,
-			"tag": "0006_gray_talisman",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "6",
-			"when": 1781217593374,
-			"tag": "0007_zippy_living_lightning",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1780029615327,
+      "tag": "0000_fuzzy_dexter_bennett",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1780032873037,
+      "tag": "0001_left_thunderbird",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1781125034998,
+      "tag": "0002_adorable_star_brand",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1781129074166,
+      "tag": "0003_hard_archangel",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1781139208245,
+      "tag": "0004_quick_thunderbird",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1781141072949,
+      "tag": "0005_thick_baron_strucker",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1781142185393,
+      "tag": "0006_gray_talisman",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1781217593374,
+      "tag": "0007_zippy_living_lightning",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1781285043540,
+      "tag": "0008_aspiring_spacker_dave",
+      "breakpoints": true
+    }
+  ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -43,6 +43,12 @@ export {
 	userProviderCredentialsRelations,
 } from "./settings";
 export {
+	type NewThinkspaceSource,
+	thinkspaceSourceRelations,
+	type ThinkspaceSource,
+	thinkspaceSources,
+} from "./sources";
+export {
 	type NewThinkspace,
 	THINKSPACE_STATUS,
 	type Thinkspace,

--- a/packages/db/src/schema/sources.ts
+++ b/packages/db/src/schema/sources.ts
@@ -1,0 +1,46 @@
+import { relations } from "drizzle-orm";
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+import { timestampMsNow } from "./common";
+import { thinkspaces } from "./thinkspaces";
+
+/**
+ * A Source is material the user hands to one Thinkspace — requirement docs,
+ * exported PDFs as text, ADRs — so the Thinkspace Agent can ground its work
+ * in the user's material instead of training data. This table is the D1
+ * index half of the storage split (ADR-0002): metadata lives here, the
+ * verbatim content blob lives in the SOURCES_ARTIFACTS R2 bucket. Sources
+ * are scoped to exactly one Thinkspace; material shared for one Goal never
+ * leaks into another Thinkspace's turns.
+ */
+export const thinkspaceSources = sqliteTable(
+	"thinkspace_sources",
+	{
+		contentType: text("content_type").notNull(),
+		createdAt: integer("created_at", { mode: "timestamp_ms" }).default(timestampMsNow).notNull(),
+		description: text("description").default("").notNull(),
+		id: text("id").primaryKey(),
+		name: text("name").notNull(),
+		sizeBytes: integer("size_bytes").notNull(),
+		thinkspaceId: text("thinkspace_id")
+			.notNull()
+			.references(() => thinkspaces.id, { onDelete: "cascade" }),
+		updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+			.default(timestampMsNow)
+			.$onUpdate(() => new Date())
+			.notNull(),
+	},
+	(table) => [
+		index("idx_thinkspace_sources_thinkspace_created").on(table.thinkspaceId, table.createdAt),
+	],
+);
+
+export const thinkspaceSourceRelations = relations(thinkspaceSources, ({ one }) => ({
+	thinkspace: one(thinkspaces, {
+		fields: [thinkspaceSources.thinkspaceId],
+		references: [thinkspaces.id],
+	}),
+}));
+
+export type ThinkspaceSource = typeof thinkspaceSources.$inferSelect;
+export type NewThinkspaceSource = typeof thinkspaceSources.$inferInsert;


### PR DESCRIPTION
Closes #83 (PRD: #73)

## What this does

Gives Sources a governed home in the control plane — the first beat of the safe_reads_v2 PRD's flagship flow ("the user dumps material in as Sources and the agent reads it"):

- **New `sources` oRPC router** (`upload`, `list`, `getContent`, `delete`), all owner-verifying with the sealed 404-first posture.
- **Text-first upload**: `text/plain` and `text/markdown` only, 256 KB byte cap (measured in UTF-8 bytes so multibyte text cannot slip past), name + optional description, content stored verbatim — no extraction pipeline.
- **ADR-0002 storage split**: blob content in the `SOURCES_ARTIFACTS` R2 bucket behind a `SourceContentStore` seam; index rows in a new `thinkspace_sources` D1 table (migration `0008`, cascade on Thinkspace delete).
- **Cross-Thinkspace sealing**: every read/delete is keyed by `(thinkspaceId, sourceId)` together and blob keys are namespaced per Thinkspace, so a forged Source id can never resolve across Thinkspaces.
- **Product-safe failure semantics**: missing binding, missing blob, and failed blob deletes surface clean errors with no binding/bucket/transport detail. A failed blob delete keeps the index row so the delete reports honestly.
- **Thinkspace detail UI**: a Sources section with upload form, list (name/format/size/upload date), inline content viewer, and delete.

No runtime behavior changes: the runtime toolset stays empty, no new Permission kinds, no manifest injection. The agent cannot read Sources yet — that arrives with the built-in read tools slice.

## Testing

- 12 new seam-behavior tests (node:test, real in-memory SQLite via `createTestProductDb`, structural R2 fake): verbatim round trip, byte-cap enforcement before storage, malformed uploads rejected at the boundary without touching storage, unauthenticated/non-owner/guessed-id/forged-cross-Thinkspace adversarial cases, missing-binding and missing-blob product-safe degradation.
- Full suite: `bun test` 179 pass, `bun run check-types` clean, ultracite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)