### PR TITLE
Built-in read tools get their own Permission kinds; enablement alone no longer confers potency

### DIFF
--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -33,10 +33,44 @@ interface EnabledToolSelection {
 
 type McpToolAccessScopeView = { type: "server" } | { toolName: string; type: "tool" };
 
+type BuiltInToolId = "web_search" | "web_fetch" | "source_read";
+
+interface BuiltInToolView {
+	description: string;
+	id: BuiltInToolId;
+	name: string;
+}
+
+const BUILT_IN_TOOLS: readonly BuiltInToolView[] = [
+	{
+		description: "Search the public web. Read-only; potent only with the web reading Permission.",
+		id: "web_search",
+		name: "Web search",
+	},
+	{
+		description:
+			"Fetch and read public web pages. Read-only; potent only with the web reading Permission.",
+		id: "web_fetch",
+		name: "Web fetch",
+	},
+	{
+		description: "Read this Thinkspace's Sources. Potent only with the Source reading Permission.",
+		id: "source_read",
+		name: "Source reading",
+	},
+];
+
+const isBuiltInToolId = (value: string): value is BuiltInToolId =>
+	BUILT_IN_TOOLS.some((tool) => tool.id === value);
+
 interface PermissionRequestView {
 	actions?: string[];
 	approvalRequired?: boolean;
-	kind?: "mcp_tool_access" | "model_provider_credential";
+	kind?:
+		| "built_in_source_read"
+		| "built_in_web_read"
+		| "mcp_tool_access"
+		| "model_provider_credential";
 	providerId?: string;
 	reason?: string;
 	resource?: {
@@ -145,6 +179,14 @@ const parseStoredMcpScope = (value: string): McpToolAccessScopeView | undefined 
 };
 
 const getPermissionRequestTitle = (permission: PermissionRequestView, index: number): string => {
+	if (permission.kind === "built_in_web_read") {
+		return "Web reading (built-in)";
+	}
+
+	if (permission.kind === "built_in_source_read") {
+		return "Source reading (built-in)";
+	}
+
 	if (permission.kind === "model_provider_credential") {
 		return `Model credential: ${permission.providerId}`;
 	}
@@ -170,6 +212,14 @@ const getPermissionRequestDescription = (permission: PermissionRequestView): str
 };
 
 const getGrantedPermissionTitle = (permission: GrantedPermissionView): string => {
+	if (permission.kind === "built_in_web_read") {
+		return "Web reading (built-in)";
+	}
+
+	if (permission.kind === "built_in_source_read") {
+		return "Source reading (built-in)";
+	}
+
 	if (permission.kind === "mcp_tool_access") {
 		return `External information access: ${permission.providerId ?? "scoped source"}`;
 	}
@@ -742,18 +792,22 @@ interface McpCatalogServerView {
 }
 
 const ToolsSection = ({
+	enabledBuiltInToolIds,
 	enabledTools,
 	isArchived,
 	mcpCatalog,
+	onToggleBuiltInTool,
 	onToggleCatalogTool,
 	profileRevision,
 	toolPotencyById,
 	updateToolSelectionsError,
 	updateToolSelectionsPending,
 }: {
+	enabledBuiltInToolIds: BuiltInToolId[];
 	enabledTools: EnabledToolSelection[];
 	isArchived: boolean;
 	mcpCatalog: McpCatalogServerView[];
+	onToggleBuiltInTool: (toolId: BuiltInToolId) => void;
 	onToggleCatalogTool: (serverId: string, risk: EnabledToolSelection["risk"]) => void;
 	profileRevision: AgentProfileRevisionView | null;
 	toolPotencyById: ReadonlyMap<string, EnabledToolPotencyView>;
@@ -772,6 +826,44 @@ const ToolsSection = ({
 				Select catalog tools on the Agent Profile revision. Draft selections take effect after
 				activation; active selections are used for turns.
 			</p>
+		</div>
+		<div className="grid gap-2">
+			<p className="text-sm font-medium">Built-in tools</p>
+			<div className="border border-border">
+				{BUILT_IN_TOOLS.map((tool, index) => {
+					const selected = enabledBuiltInToolIds.includes(tool.id);
+					const toolPotency = selected ? toolPotencyById.get(tool.id) : undefined;
+
+					return (
+						<div
+							key={tool.id}
+							className={`flex items-center justify-between gap-4 p-4 ${index < BUILT_IN_TOOLS.length - 1 ? "border-b border-border" : ""} ${selected ? "bg-muted/30" : ""}`}
+						>
+							<div className="grid gap-0.5">
+								<div className="flex items-center gap-2">
+									<p className="text-sm font-medium">{tool.name}</p>
+									<span className="text-muted-foreground text-xs">read_only</span>
+									{toolPotency ? (
+										<Badge variant={getToolPotencyBadgeVariant(toolPotency.potency)}>
+											{getToolPotencyLabel(toolPotency.potency)}
+										</Badge>
+									) : null}
+								</div>
+								<p className="text-muted-foreground text-sm">{tool.description}</p>
+							</div>
+							<Button
+								disabled={isArchived || updateToolSelectionsPending}
+								onClick={() => onToggleBuiltInTool(tool.id)}
+								size="sm"
+								type="button"
+								variant={selected ? "secondary" : "outline"}
+							>
+								{selected ? "Remove" : "Select"}
+							</Button>
+						</div>
+					);
+				})}
+			</div>
 		</div>
 		{mcpCatalog.length === 0 ? (
 			<p className="border border-border p-4 text-muted-foreground text-sm">
@@ -916,7 +1008,10 @@ const PermissionsSection = ({
 				) : (
 					<div className="border border-border">
 						{grantedPermissions.map((permission, index) => {
-							const canRevoke = permission.kind === "mcp_tool_access";
+							const canRevoke =
+								permission.kind === "mcp_tool_access" ||
+								permission.kind === "built_in_web_read" ||
+								permission.kind === "built_in_source_read";
 							const isRevoking = revokingPermissionId === permission.id;
 
 							return (
@@ -1039,7 +1134,15 @@ const RouteComponent = () => {
 	const profileRevision = thinkspace.agentProfileRevision;
 	const isArchived = thinkspace.status === "archived";
 	const isDraft = thinkspace.status === "draft";
-	const enabledTools = profileRevision?.toolEnablements.map(toEnabledToolSelection) ?? [];
+	const enabledTools =
+		profileRevision?.toolEnablements
+			.filter((enablement) => enablement.source === "mcp_server")
+			.map(toEnabledToolSelection) ?? [];
+	const enabledBuiltInToolIds =
+		profileRevision?.toolEnablements
+			.filter((enablement) => enablement.source === "built_in")
+			.map((enablement) => enablement.toolId)
+			.filter(isBuiltInToolId) ?? [];
 	const enabledToolPotencies = (thinkspace.enabledToolPotencies ?? []) as EnabledToolPotencyView[];
 	const toolPotencyById = new Map(
 		enabledToolPotencies.map((toolPotency) => [toolPotency.toolId, toolPotency] as const),
@@ -1053,7 +1156,24 @@ const RouteComponent = () => {
 			? enabledTools.filter((tool) => tool.serverId !== serverId)
 			: [...enabledTools, { risk, serverId }];
 
-		updateToolSelectionsMutation.mutate({ selections, thinkspaceId });
+		updateToolSelectionsMutation.mutate({
+			builtInToolIds: enabledBuiltInToolIds,
+			selections,
+			thinkspaceId,
+		});
+	};
+
+	const toggleBuiltInTool = (toolId: BuiltInToolId) => {
+		const selected = enabledBuiltInToolIds.includes(toolId);
+		const builtInToolIds = selected
+			? enabledBuiltInToolIds.filter((enabledToolId) => enabledToolId !== toolId)
+			: [...enabledBuiltInToolIds, toolId];
+
+		updateToolSelectionsMutation.mutate({
+			builtInToolIds,
+			selections: enabledTools,
+			thinkspaceId,
+		});
 	};
 
 	const handleActivateAgentProfile = () => {
@@ -1197,9 +1317,11 @@ const RouteComponent = () => {
 			<Separator />
 
 			<ToolsSection
+				enabledBuiltInToolIds={enabledBuiltInToolIds}
 				enabledTools={enabledTools}
 				isArchived={isArchived}
 				mcpCatalog={mcpCatalogQuery.data}
+				onToggleBuiltInTool={toggleBuiltInTool}
 				onToggleCatalogTool={toggleCatalogTool}
 				profileRevision={profileRevision}
 				toolPotencyById={toolPotencyById}

--- a/packages/api/src/thinkspaces/agent-profile.ts
+++ b/packages/api/src/thinkspaces/agent-profile.ts
@@ -125,7 +125,25 @@ export interface McpToolAccessPermissionRequest {
 	serverId: string;
 }
 
+export const BUILT_IN_TOOL_PERMISSION_REQUEST_KINDS = [
+	"built_in_source_read",
+	"built_in_web_read",
+] as const;
+export type BuiltInToolPermissionRequestKind =
+	(typeof BUILT_IN_TOOL_PERMISSION_REQUEST_KINDS)[number];
+
+/**
+ * A request for one of the built-in read tool Permission kinds: web reading
+ * (search and fetch together) or Source reading. The kind itself names the
+ * governed resource, so no extra scope payload is carried.
+ */
+export interface BuiltInToolAccessPermissionRequest {
+	kind: BuiltInToolPermissionRequestKind;
+	reason: string;
+}
+
 export type RequestedPermission =
+	| BuiltInToolAccessPermissionRequest
 	| ModelProviderCredentialPermissionRequest
 	| McpToolAccessPermissionRequest;
 
@@ -345,12 +363,20 @@ const isMcpToolAccessPermissionRequest = (
 	isMcpToolAccessScope(value.scope) &&
 	typeof value.reason === "string";
 
+const isBuiltInToolAccessPermissionRequest = (
+	value: unknown,
+): value is BuiltInToolAccessPermissionRequest =>
+	isRecord(value) &&
+	BUILT_IN_TOOL_PERMISSION_REQUEST_KINDS.includes(value.kind as BuiltInToolPermissionRequestKind) &&
+	typeof value.reason === "string";
+
 const isRequestedPermission = (value: unknown): value is RequestedPermission =>
 	(isRecord(value) &&
 		value.kind === "model_provider_credential" &&
 		MODEL_PROVIDER_IDS.includes(value.providerId as ModelProviderId) &&
 		typeof value.reason === "string") ||
-	isMcpToolAccessPermissionRequest(value);
+	isMcpToolAccessPermissionRequest(value) ||
+	isBuiltInToolAccessPermissionRequest(value);
 
 const parseJsonArray = <T>(
 	label: string,

--- a/packages/api/src/thinkspaces/built-in-tools.ts
+++ b/packages/api/src/thinkspaces/built-in-tools.ts
@@ -1,0 +1,67 @@
+/**
+ * The built-in read tool catalog.
+ *
+ * Built-ins are a first-class tool source in the existing enablement scheme:
+ * an Agent Profile revision makes one present with a stable tool id, and a
+ * Thinkspace-owned Permission of the matching kind makes it potent. Web
+ * search and web fetch share one Permission kind (web reading); Source
+ * reading has its own, so the user can let the agent read their material
+ * without letting it touch the public web, and vice versa (PRD #73).
+ */
+import { THINKSPACE_PERMISSION_KINDS } from "@better-agent/db/schema/permissions";
+
+import type { BuiltInToolAccessPermissionRequest } from "./agent-profile";
+
+export const BUILT_IN_TOOL_IDS = ["web_search", "web_fetch", "source_read"] as const;
+
+export type BuiltInToolId = (typeof BUILT_IN_TOOL_IDS)[number];
+
+export const isBuiltInToolId = (value: string): value is BuiltInToolId =>
+	BUILT_IN_TOOL_IDS.includes(value as BuiltInToolId);
+
+export type BuiltInToolPermissionKind =
+	| typeof THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ
+	| typeof THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ;
+
+/**
+ * Which Permission kind governs each built-in tool. Unknown tool ids map to
+ * nothing, so callers fail closed on ids this catalog does not know.
+ */
+export const builtInToolPermissionKind = (toolId: string): BuiltInToolPermissionKind | null => {
+	if (toolId === "web_search" || toolId === "web_fetch") {
+		return THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ;
+	}
+
+	if (toolId === "source_read") {
+		return THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ;
+	}
+
+	return null;
+};
+
+const BUILT_IN_PERMISSION_REASONS: Record<BuiltInToolPermissionKind, string> = {
+	[THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ]:
+		"Allow this Thinkspace Agent to read this Thinkspace's Sources.",
+	[THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ]:
+		"Allow this Thinkspace Agent to search and read the public web.",
+};
+
+/**
+ * One Permission request per governing kind, however many of its tools are
+ * enabled — enabling both web tools yields a single web reading request.
+ */
+export const createBuiltInToolPermissionRequests = (
+	toolIds: readonly BuiltInToolId[],
+): BuiltInToolAccessPermissionRequest[] => {
+	const kinds = new Set<BuiltInToolPermissionKind>();
+
+	for (const toolId of toolIds) {
+		const kind = builtInToolPermissionKind(toolId);
+
+		if (kind) {
+			kinds.add(kind);
+		}
+	}
+
+	return [...kinds].map((kind) => ({ kind, reason: BUILT_IN_PERMISSION_REASONS[kind] }));
+};

--- a/packages/api/src/thinkspaces/permission-policy.test.ts
+++ b/packages/api/src/thinkspaces/permission-policy.test.ts
@@ -64,12 +64,112 @@ test("MCP toolIds resolve to their server id at both server and tool scope", () 
 	assert.equal(mcpServerIdFromToolId("cloudflare-docs:search_docs"), "cloudflare-docs");
 });
 
-test("built-in enablements are potent with no stored grant", async () => {
+const grantBuiltInPermission = async (
+	db: ProductDb,
+	kind:
+		| typeof THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ
+		| typeof THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ,
+	thinkspaceId = THINKSPACE_ID,
+) => {
+	await db.insert(thinkspacePermissions).values({
+		grantedByUserId: OWNER_USER_ID,
+		id: `thinkspace_permission_${kind}_${thinkspaceId}`,
+		kind,
+		providerId: kind === THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ ? "web" : "sources",
+		thinkspaceId,
+	});
+};
+
+const ALL_BUILT_IN_ENABLEMENTS: ToolEnablement[] = [
+	{ source: "built_in", toolId: "web_search" },
+	{ source: "built_in", toolId: "web_fetch" },
+	{ source: "built_in", toolId: "source_read" },
+];
+
+test("built-in enablements are inert with no stored grant: enablement alone never confers ability", async () => {
 	const db = await createSeededDb();
+
+	const verdicts = await evaluate(db, ALL_BUILT_IN_ENABLEMENTS);
+
+	assert.deepEqual(verdicts, [
+		{ potency: "inert", toolId: "web_search" },
+		{ potency: "inert", toolId: "web_fetch" },
+		{ potency: "inert", toolId: "source_read" },
+	]);
+});
+
+test("a granted web reading Permission makes both web tools potent but never Source reading", async () => {
+	const db = await createSeededDb();
+	await grantBuiltInPermission(db, THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ);
+
+	const verdicts = await evaluate(db, ALL_BUILT_IN_ENABLEMENTS);
+
+	assert.deepEqual(verdicts, [
+		{ potency: "potent", toolId: "web_search" },
+		{ potency: "potent", toolId: "web_fetch" },
+		{ potency: "inert", toolId: "source_read" },
+	]);
+});
+
+test("a granted Source reading Permission makes Source reading potent but never the web tools", async () => {
+	const db = await createSeededDb();
+	await grantBuiltInPermission(db, THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ);
+
+	const verdicts = await evaluate(db, ALL_BUILT_IN_ENABLEMENTS);
+
+	assert.deepEqual(verdicts, [
+		{ potency: "inert", toolId: "web_search" },
+		{ potency: "inert", toolId: "web_fetch" },
+		{ potency: "potent", toolId: "source_read" },
+	]);
+});
+
+test("unknown built-in tool ids stay inert even with every built-in grant present", async () => {
+	const db = await createSeededDb();
+	await grantBuiltInPermission(db, THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ);
+	await grantBuiltInPermission(db, THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ);
+
+	const verdicts = await evaluate(db, [
+		{ source: "built_in", toolId: "workspace_bash" },
+		{ source: "built_in", toolId: "memory_write" },
+	]);
+
+	assert.deepEqual(verdicts, [
+		{ potency: "inert", toolId: "workspace_bash" },
+		{ potency: "inert", toolId: "memory_write" },
+	]);
+});
+
+test("built-in grants are Thinkspace-scoped: another Thinkspace's grant never leaks", async () => {
+	const db = await createSeededDb();
+	await seedThinkspace(db, OTHER_THINKSPACE_ID);
+	await grantBuiltInPermission(
+		db,
+		THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ,
+		OTHER_THINKSPACE_ID,
+	);
 
 	const verdicts = await evaluate(db, [{ source: "built_in", toolId: "web_search" }]);
 
-	assert.deepEqual(verdicts, [{ potency: "potent", toolId: "web_search" }]);
+	assert.deepEqual(verdicts, [{ potency: "inert", toolId: "web_search" }]);
+});
+
+test("a revoked built-in grant makes the still-enabled tool inert on the next evaluation", async () => {
+	const db = await createSeededDb();
+	await grantBuiltInPermission(db, THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ);
+
+	const enablements: ToolEnablement[] = [{ source: "built_in", toolId: "source_read" }];
+	const granted = await evaluate(db, enablements);
+	assert.deepEqual(granted, [{ potency: "potent", toolId: "source_read" }]);
+
+	const revokedGrant = await revokeThinkspacePermission(db, {
+		permissionId: `thinkspace_permission_${THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ}_${THINKSPACE_ID}`,
+		thinkspaceId: THINKSPACE_ID,
+	});
+	assert.ok(revokedGrant);
+
+	const revoked = await evaluate(db, enablements);
+	assert.deepEqual(revoked, [{ potency: "inert", toolId: "source_read" }]);
 });
 
 test("MCP enablements are inert when no matching grant exists", async () => {
@@ -174,6 +274,7 @@ test("a revoked grant makes the still-enabled tool inert on the next evaluation"
 
 test("store-backed verdicts feeding turn assembly never activate tools the revision did not enable", async () => {
 	const db = await createSeededDb();
+	await grantBuiltInPermission(db, THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ);
 	await grantMcpToolAccess(db, "cloudflare-docs");
 	await grantMcpToolAccess(db, "aws-knowledge");
 

--- a/packages/api/src/thinkspaces/permission-policy.ts
+++ b/packages/api/src/thinkspaces/permission-policy.ts
@@ -8,20 +8,24 @@
  * layer. Revoking a Permission never edits the Profile — the tool simply
  * goes inert.
  *
- * Decision rule (fails closed): built-in-source enablements are potent on
- * enablement alone; MCP-source enablements are potent only with a matching
- * granted MCP tool access Permission in Thinkspace Permission storage;
- * Connected Account and Local Node sources are unconditionally inert in this
- * slice.
+ * Decision rule (fails closed): built-in enablements are potent only with a
+ * granted Permission of their governing kind — web reading for web search
+ * and fetch, Source reading for the Source read tool (PRD #73 superseded the
+ * earlier enablement-alone rule for built-ins). MCP-source enablements are
+ * potent only with a matching granted MCP tool access Permission. Connected
+ * Account and Local Node sources, and built-in tool ids the catalog does not
+ * know, are unconditionally inert.
  */
 import type { ProductDb } from "@better-agent/db";
 import {
 	THINKSPACE_PERMISSION_KINDS,
 	thinkspacePermissions,
 } from "@better-agent/db/schema/permissions";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import type { ToolEnablement } from "./agent-profile";
+import { builtInToolPermissionKind } from "./built-in-tools";
+import type { BuiltInToolPermissionKind } from "./built-in-tools";
 
 export type ToolPotency = "potent" | "inert";
 
@@ -51,16 +55,20 @@ export const mcpServerIdFromToolId = (toolId: string): string => {
 	return serverId ?? toolId;
 };
 
-const isPotent = (
-	enablement: ToolEnablement,
-	grantedMcpServerIds: ReadonlySet<string>,
-): boolean => {
+interface ThinkspaceToolGrants {
+	builtInKinds: ReadonlySet<BuiltInToolPermissionKind>;
+	mcpServerIds: ReadonlySet<string>;
+}
+
+const isPotent = (enablement: ToolEnablement, grants: ThinkspaceToolGrants): boolean => {
 	if (enablement.source === "built_in") {
-		return true;
+		const requiredKind = builtInToolPermissionKind(enablement.toolId);
+
+		return requiredKind !== null && grants.builtInKinds.has(requiredKind);
 	}
 
 	if (enablement.source === "mcp_server") {
-		return grantedMcpServerIds.has(mcpServerIdFromToolId(enablement.toolId));
+		return grants.mcpServerIds.has(mcpServerIdFromToolId(enablement.toolId));
 	}
 
 	// Connected Account and Local Node tools stay inert: no grant kind for
@@ -70,19 +78,23 @@ const isPotent = (
 
 const evaluateAgainstGrants = (
 	enablements: ToolEnablement[],
-	grantedMcpServerIds: ReadonlySet<string>,
+	grants: ThinkspaceToolGrants,
 ): ToolPotencyVerdict[] =>
 	enablements.map((enablement) => ({
-		potency: isPotent(enablement, grantedMcpServerIds) ? "potent" : "inert",
+		potency: isPotent(enablement, grants) ? "potent" : "inert",
 		toolId: enablement.toolId,
 	}));
 
-const NO_GRANTS: ReadonlySet<string> = new Set();
+const NO_GRANTS: ThinkspaceToolGrants = {
+	builtInKinds: new Set(),
+	mcpServerIds: new Set(),
+};
 
 /**
- * Source-default rule with no grant lookup: useful where Permission storage
- * is out of reach (pure assembly tests) — equivalent to the store-backed
- * policy when no MCP grant exists.
+ * The decision rule with no grant lookup: useful where Permission storage is
+ * out of reach (pure assembly tests) — equivalent to the store-backed policy
+ * when the Thinkspace holds no grants, so every tool-governing source is
+ * inert.
  */
 export const createEnablementOnlyPermissionPolicy = (): ThinkspacePermissionPolicy => ({
 	evaluateToolPotency: ({ enablements }) =>
@@ -102,35 +114,55 @@ export const createMemoryPermissionPolicy = (
 		),
 });
 
-const listGrantedMcpServerIds = async (
+const BUILT_IN_GRANT_KINDS: readonly BuiltInToolPermissionKind[] = [
+	THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ,
+	THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ,
+];
+
+const isBuiltInGrantKind = (kind: string): kind is BuiltInToolPermissionKind =>
+	BUILT_IN_GRANT_KINDS.includes(kind as BuiltInToolPermissionKind);
+
+const listThinkspaceToolGrants = async (
 	db: ProductDb,
 	thinkspaceId: string,
-): Promise<ReadonlySet<string>> => {
+): Promise<ThinkspaceToolGrants> => {
 	const rows = await db
-		.select({ serverId: thinkspacePermissions.providerId })
+		.select({
+			kind: thinkspacePermissions.kind,
+			providerId: thinkspacePermissions.providerId,
+		})
 		.from(thinkspacePermissions)
 		.where(
 			and(
 				eq(thinkspacePermissions.thinkspaceId, thinkspaceId),
-				eq(thinkspacePermissions.kind, THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS),
+				inArray(thinkspacePermissions.kind, [
+					...BUILT_IN_GRANT_KINDS,
+					THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS,
+				]),
 			),
 		);
 
-	const grantedServerIds: string[] = [];
+	const builtInKinds = new Set<BuiltInToolPermissionKind>();
+	const mcpServerIds = new Set<string>();
 
 	for (const row of rows) {
-		if (row.serverId) {
-			grantedServerIds.push(row.serverId);
+		if (isBuiltInGrantKind(row.kind)) {
+			builtInKinds.add(row.kind);
+			continue;
+		}
+
+		if (row.providerId) {
+			mcpServerIds.add(row.providerId);
 		}
 	}
 
-	return new Set(grantedServerIds);
+	return { builtInKinds, mcpServerIds };
 };
 
 /**
- * The real Permission-storage-backed policy: reads granted MCP tool access
- * Permissions from Thinkspace Permission storage and applies the
- * source-default rule to everything else.
+ * The real Permission-storage-backed policy: reads granted tool Permissions
+ * (built-in read kinds and MCP tool access) from Thinkspace Permission
+ * storage and applies the fail-closed decision rule.
  */
 export const createPermissionStorePolicy = ({
 	db,
@@ -138,11 +170,11 @@ export const createPermissionStorePolicy = ({
 	db: ProductDb;
 }): ThinkspacePermissionPolicy => ({
 	evaluateToolPotency: async ({ enablements, thinkspaceId }) => {
-		const needsGrantLookup = enablements.some((enablement) => enablement.source === "mcp_server");
-		const grantedMcpServerIds = needsGrantLookup
-			? await listGrantedMcpServerIds(db, thinkspaceId)
-			: NO_GRANTS;
+		const needsGrantLookup = enablements.some(
+			(enablement) => enablement.source === "built_in" || enablement.source === "mcp_server",
+		);
+		const grants = needsGrantLookup ? await listThinkspaceToolGrants(db, thinkspaceId) : NO_GRANTS;
 
-		return evaluateAgainstGrants(enablements, grantedMcpServerIds);
+		return evaluateAgainstGrants(enablements, grants);
 	},
 });

--- a/packages/api/src/thinkspaces/permissions.ts
+++ b/packages/api/src/thinkspaces/permissions.ts
@@ -14,7 +14,11 @@ import type { ModelProviderId } from "../models/catalog";
 import { listBuiltInMcpServers } from "../mcp/catalog";
 import type { BuiltInMcpServer } from "../mcp/catalog";
 import { assertSafeMcpServerUrl } from "../mcp/url-policy";
-import type { McpToolAccessPermissionRequest, RequestedPermission } from "./agent-profile";
+import type {
+	BuiltInToolAccessPermissionRequest,
+	McpToolAccessPermissionRequest,
+	RequestedPermission,
+} from "./agent-profile";
 
 export interface GrantThinkspacePermissionInput {
 	grantedByUserId: string;
@@ -40,6 +44,27 @@ export class ThinkspacePermissionGrantError extends Error {
 }
 
 const MODEL_PROVIDER_SCOPE = JSON.stringify({ type: "model_provider" });
+
+/**
+ * Grant rows live on the (thinkspaceId, kind, providerId) unique index, so
+ * each built-in kind gets a stable resource identity: the web for web
+ * reading, this Thinkspace's Sources for Source reading.
+ */
+const BUILT_IN_GRANT_PROVIDER_IDS = {
+	built_in_source_read: "sources",
+	built_in_web_read: "web",
+} as const satisfies Record<BuiltInToolAccessPermissionRequest["kind"], string>;
+
+const BUILT_IN_GRANT_SCOPES = {
+	built_in_source_read: JSON.stringify({ type: "source_read" }),
+	built_in_web_read: JSON.stringify({ type: "web_read" }),
+} as const satisfies Record<BuiltInToolAccessPermissionRequest["kind"], string>;
+
+const isBuiltInToolPermissionRequest = (
+	permission: RequestedPermission,
+): permission is BuiltInToolAccessPermissionRequest =>
+	permission.kind === THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ ||
+	permission.kind === THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ;
 
 const isModelProviderId = (value: string): value is ModelProviderId =>
 	MODEL_PROVIDER_IDS.includes(value as ModelProviderId);
@@ -107,6 +132,18 @@ export const toThinkspacePermissionGrant = (
 			providerId: permission.providerId,
 			reason: permission.reason,
 			resourceScope: MODEL_PROVIDER_SCOPE,
+			thinkspaceId,
+		};
+	}
+
+	if (isBuiltInToolPermissionRequest(permission)) {
+		return {
+			grantedByUserId,
+			id: createPermissionId(),
+			kind: permission.kind,
+			providerId: BUILT_IN_GRANT_PROVIDER_IDS[permission.kind],
+			reason: permission.reason,
+			resourceScope: BUILT_IN_GRANT_SCOPES[permission.kind],
 			thinkspaceId,
 		};
 	}

--- a/packages/api/src/thinkspaces/router.test.ts
+++ b/packages/api/src/thinkspaces/router.test.ts
@@ -443,6 +443,173 @@ test("updating tools writes enablements and permission requests to the draft Age
 	assert.equal("enabledToolIds" in (saved[0] ?? {}), false);
 });
 
+test("enabling built-in tools writes built_in enablements and deduped Permission requests to the draft", async () => {
+	const { db, saved } = createDbForAgentProfileDraftUpdate(
+		ownedThinkspaceRow({ ...ownedAgentProfileColumns("draft"), status: "draft" }),
+	);
+	const context = createCallContext({ db });
+
+	const updated = await call(
+		thinkspacesRouter.updateToolSelections,
+		{
+			builtInToolIds: ["source_read", "web_fetch", "web_search"],
+			selections: [],
+			thinkspaceId: OWNED_THINKSPACE_ID,
+		},
+		{ context },
+	);
+
+	assert.ok(updated);
+	assert.equal(updated.agentProfileRevision.status, "draft");
+	assert.deepEqual(JSON.parse(String(saved[0]?.toolEnablements)), [
+		{ source: "built_in", toolId: "web_search" },
+		{ source: "built_in", toolId: "web_fetch" },
+		{ source: "built_in", toolId: "source_read" },
+	]);
+
+	// Both web tools share one web reading request; Source reading gets its own.
+	const requests = JSON.parse(String(saved[0]?.requestedPermissions)) as { kind: string }[];
+	assert.deepEqual(
+		requests.map((request) => request.kind).toSorted((left, right) => left.localeCompare(right)),
+		["built_in_source_read", "built_in_web_read"],
+	);
+});
+
+test("activating granted built-in requests creates the two Permission kinds with their resource identities", async () => {
+	const db = createTestProductDb();
+	await seedRealThinkspaceWithProfile({
+		db,
+		requestedPermissions: [
+			{ kind: "built_in_web_read", reason: "Web reading for research turns." },
+			{ kind: "built_in_source_read", reason: "Read this Thinkspace's Sources." },
+		],
+		toolEnablements: [
+			{ source: "built_in", toolId: "web_search" },
+			{ source: "built_in", toolId: "web_fetch" },
+			{ source: "built_in", toolId: "source_read" },
+		],
+	});
+
+	const activation = await call(
+		thinkspacesRouter.activateAgentProfile,
+		{ grantedPermissionIndexes: [0, 1], thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+
+	assert.ok(activation);
+	assert.equal(activation.grantedPermissions.length, 2);
+	const grantsByKind = new Map(activation.grantedPermissions.map((grant) => [grant.kind, grant]));
+	assert.equal(grantsByKind.get("built_in_web_read")?.providerId, "web");
+	assert.equal(
+		grantsByKind.get("built_in_web_read")?.resourceScope,
+		JSON.stringify({ type: "web_read" }),
+	);
+	assert.equal(grantsByKind.get("built_in_source_read")?.providerId, "sources");
+	assert.equal(
+		grantsByKind.get("built_in_source_read")?.resourceScope,
+		JSON.stringify({ type: "source_read" }),
+	);
+
+	const detail = await call(
+		thinkspacesRouter.get,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+	assert.deepEqual(detail.enabledToolPotencies, [
+		{ potency: "potent", source: "built_in", toolId: "web_search" },
+		{ potency: "potent", source: "built_in", toolId: "web_fetch" },
+		{ potency: "potent", source: "built_in", toolId: "source_read" },
+	]);
+});
+
+test("declining a built-in request leaves the enabled tool inert after activation", async () => {
+	const db = createTestProductDb();
+	await seedRealThinkspaceWithProfile({
+		db,
+		requestedPermissions: [
+			{ kind: "built_in_web_read", reason: "Web reading for research turns." },
+			{ kind: "built_in_source_read", reason: "Read this Thinkspace's Sources." },
+		],
+		toolEnablements: [
+			{ source: "built_in", toolId: "web_search" },
+			{ source: "built_in", toolId: "source_read" },
+		],
+	});
+
+	const activation = await call(
+		thinkspacesRouter.activateAgentProfile,
+		{ grantedPermissionIndexes: [0], thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+
+	assert.ok(activation);
+	assert.equal(activation.grantedPermissions.length, 1);
+	assert.equal(activation.grantedPermissions[0]?.kind, "built_in_web_read");
+
+	const detail = await call(
+		thinkspacesRouter.get,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+	assert.deepEqual(detail.enabledToolPotencies, [
+		{ potency: "potent", source: "built_in", toolId: "web_search" },
+		{ potency: "inert", source: "built_in", toolId: "source_read" },
+	]);
+});
+
+test("revoking a built-in Permission flips the tool inert on the next read without touching revisions", async () => {
+	const db = createTestProductDb();
+	await seedRealThinkspaceWithProfile({
+		db,
+		profileStatus: "active",
+		thinkspaceStatus: "active",
+		toolEnablements: [{ source: "built_in", toolId: "source_read" }],
+	});
+	await db.insert(thinkspacePermissions).values({
+		grantedByUserId: authenticatedSession.user.id,
+		id: "thinkspace_permission_source_read",
+		kind: THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ,
+		providerId: "sources",
+		reason: "Read this Thinkspace's Sources.",
+		resourceScope: JSON.stringify({ type: "source_read" }),
+		thinkspaceId: OWNED_THINKSPACE_ID,
+	});
+
+	const granted = await call(
+		thinkspacesRouter.get,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+	const revisionsBefore = await db
+		.select()
+		.from(thinkspaceAgentProfiles)
+		.where(eq(thinkspaceAgentProfiles.thinkspaceId, OWNED_THINKSPACE_ID));
+
+	await call(
+		thinkspacesRouter.revokePermission,
+		{ permissionId: "thinkspace_permission_source_read", thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+
+	const revoked = await call(
+		thinkspacesRouter.get,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+	const revisionsAfter = await db
+		.select()
+		.from(thinkspaceAgentProfiles)
+		.where(eq(thinkspaceAgentProfiles.thinkspaceId, OWNED_THINKSPACE_ID));
+
+	assert.deepEqual(granted.enabledToolPotencies, [
+		{ potency: "potent", source: "built_in", toolId: "source_read" },
+	]);
+	assert.deepEqual(revoked.enabledToolPotencies, [
+		{ potency: "inert", source: "built_in", toolId: "source_read" },
+	]);
+	assert.deepEqual(revisionsAfter, revisionsBefore);
+});
+
 test("Agent Profile activation rejects archived Thinkspaces before writes", async () => {
 	const { db, patches } = createDbForAgentProfileActivation(
 		ownedThinkspaceRow({ status: "archived" }),
@@ -821,8 +988,10 @@ test("Thinkspace detail includes active revision tool potency indicators", async
 		{ context: createCallContext({ db }) },
 	);
 
+	// web_search is enabled but ungoverned: built-ins are no longer potent on
+	// enablement alone, so without a web reading grant it reads inert.
 	assert.deepEqual(thinkspace.enabledToolPotencies, [
-		{ potency: "potent", source: "built_in", toolId: "web_search" },
+		{ potency: "inert", source: "built_in", toolId: "web_search" },
 		{ potency: "potent", source: "mcp_server", toolId: "cloudflare-docs" },
 		{ potency: "inert", source: "mcp_server", toolId: "aws-knowledge" },
 		{ potency: "inert", source: "connected_account", toolId: "github" },

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -42,6 +42,8 @@ import {
 	saveThinkspacePermissionGrants,
 	ThinkspacePermissionGrantError,
 } from "./permissions";
+import { BUILT_IN_TOOL_IDS, createBuiltInToolPermissionRequests } from "./built-in-tools";
+import type { BuiltInToolId } from "./built-in-tools";
 import { createMcpToolAccessPermissionRequest, serializeThinkspaceToolSelections } from "./policy";
 import {
 	createThinkspaceArchivePatch,
@@ -93,6 +95,7 @@ const toolSelectionSchema = z.object({
 });
 
 const updateToolSelectionsInput = z.object({
+	builtInToolIds: z.array(z.enum(BUILT_IN_TOOL_IDS)).optional(),
 	selections: z.array(toolSelectionSchema),
 	thinkspaceId: z.string().min(1),
 });
@@ -111,21 +114,46 @@ const submitTurnInput = z.object({
 const createThinkspaceId = (): string => `thinkspace_${crypto.randomUUID()}`;
 const createAgentProfileRevisionId = (): string => `agent_profile_revision_${crypto.randomUUID()}`;
 
-const toToolEnablements = (selections: z.infer<typeof toolSelectionSchema>[]): ToolEnablement[] => {
+/** Deduped, in stable catalog order, however the caller ordered them. */
+const normalizeBuiltInToolIds = (toolIds: readonly BuiltInToolId[]): BuiltInToolId[] => {
+	const requested = new Set(toolIds);
+
+	return BUILT_IN_TOOL_IDS.filter((toolId) => requested.has(toolId));
+};
+
+const toToolEnablements = (
+	builtInToolIds: readonly BuiltInToolId[],
+	selections: z.infer<typeof toolSelectionSchema>[],
+): ToolEnablement[] => {
 	const normalized = JSON.parse(serializeThinkspaceToolSelections(selections)) as z.infer<
 		typeof toolSelectionSchema
 	>[];
 
-	return normalized.map((selection) => ({
-		source: "mcp_server",
-		toolId: selection.toolName ? `${selection.serverId}:${selection.toolName}` : selection.serverId,
-	}));
+	return [
+		...builtInToolIds.map(
+			(toolId): ToolEnablement => ({
+				source: "built_in",
+				toolId,
+			}),
+		),
+		...normalized.map(
+			(selection): ToolEnablement => ({
+				source: "mcp_server",
+				toolId: selection.toolName
+					? `${selection.serverId}:${selection.toolName}`
+					: selection.serverId,
+			}),
+		),
+	];
 };
 
 const toRequestedPermissions = (
+	builtInToolIds: readonly BuiltInToolId[],
 	selections: z.infer<typeof toolSelectionSchema>[],
-): RequestedPermission[] =>
-	selections.map((selection) => createMcpToolAccessPermissionRequest(selection));
+): RequestedPermission[] => [
+	...createBuiltInToolPermissionRequests(builtInToolIds),
+	...selections.map((selection) => createMcpToolAccessPermissionRequest(selection)),
+];
 
 export interface EnabledToolPotencyInspection {
 	potency: ToolPotency;
@@ -573,11 +601,12 @@ export const thinkspacesRouter = {
 					);
 				}
 
+				const builtInToolIds = normalizeBuiltInToolIds(input.builtInToolIds ?? []);
 				const updatedDraft = await saveAgentProfileDraft(context.db, {
 					draft: {
 						...draft,
-						requestedPermissions: toRequestedPermissions(input.selections),
-						toolEnablements: toToolEnablements(input.selections),
+						requestedPermissions: toRequestedPermissions(builtInToolIds, input.selections),
+						toolEnablements: toToolEnablements(builtInToolIds, input.selections),
 						updatedAt: new Date(),
 					},
 				});

--- a/packages/api/src/thinkspaces/turn-assembly.test.ts
+++ b/packages/api/src/thinkspaces/turn-assembly.test.ts
@@ -29,14 +29,14 @@ const REVISION: ActiveAgentProfileRevision = {
 	version: 2,
 };
 
-test("assembly activates only enabled tools the Permission policy judges potent", async () => {
+test("assembly with no grants activates nothing: built-ins are no longer potent on enablement alone", async () => {
 	const verdicts = await createEnablementOnlyPermissionPolicy().evaluateToolPotency({
 		enablements: REVISION.toolEnablements,
 		thinkspaceId: REVISION.thinkspaceId,
 	});
 	const assembly = assembleThinkspaceTurn({ revision: REVISION, toolPotencies: verdicts });
 
-	assert.deepEqual(assembly.activeTools, ["web_search"]);
+	assert.deepEqual(assembly.activeTools, []);
 	assert.equal(assembly.maxSteps, THINKSPACE_RUNTIME_MAX_STEPS);
 	assert.equal(assembly.profileRevisionId, "rev_2");
 	assert.equal(assembly.profileVersion, 2);

--- a/packages/db/src/schema/permissions.ts
+++ b/packages/db/src/schema/permissions.ts
@@ -5,6 +5,10 @@ import { timestampMsNow } from "./common";
 import { thinkspaces } from "./thinkspaces";
 
 export const THINKSPACE_PERMISSION_KINDS = {
+	/** Governs the built-in Source reading tool for one Thinkspace. */
+	BUILT_IN_SOURCE_READ: "built_in_source_read",
+	/** Governs built-in web reading — search and fetch together. */
+	BUILT_IN_WEB_READ: "built_in_web_read",
 	MCP_TOOL_ACCESS: "mcp_tool_access",
 	MODEL_PROVIDER_CREDENTIAL: "model_provider_credential",
 } as const;


### PR DESCRIPTION
Closes #85 (PRD: #73)

## What this does

Builds the governance layer the built-in read tools will be gated by — the second slice of safe_reads_v2:

- **Two new Permission kinds** in the existing `(thinkspaceId, kind, providerId)` Permission store: `built_in_web_read` (governing web search and fetch together, resource identity `web`) and `built_in_source_read` (governing Source reading, resource identity `sources`). No migration needed — kind is text.
- **Lifecycle mirrors MCP tool access exactly**: enabling a built-in on a draft revision records a pending Permission request (deduped — both web tools share one web reading request); activation grants explicitly; declining leaves the tool inert; revoking flips it inert on the next read with no Profile change.
- **The potency rule change**: the old "built_in enablements are potent on enablement alone" rule is removed. Built-ins now follow the same fail-closed intersection as everything else — potent only with a granted Permission of their governing kind, unknown built-in ids inert, missing verdict still inert. The store-backed policy reads built-in and MCP grants in one query.
- **A built-in tool catalog module** (`built-in-tools.ts`) defines the three stable tool ids (`web_search`, `web_fetch`, `source_read`) and maps each to its governing kind.
- **Thinkspace detail UI**: a built-in tools picker alongside the MCP catalog (with potency badges), product-language rendering of the new kinds in requested/granted Permission lists, and revoke buttons for them. Also fixes the enablement derivation to be source-aware so toggling MCP tools can no longer corrupt built-in enablements into MCP selections.

The runtime toolset remains empty — the tools themselves arrive in the next slice.

## Testing

- Permission-policy tests updated to the superseding rule plus new coverage: no-grant inert, web grant makes both web tools potent but never Source reading (and vice versa), unknown built-in ids inert even fully granted, Thinkspace-scoped grants, revocation flips next evaluation.
- Router tests: draft writes built_in enablements + deduped requests, activation creates both kinds with their resource identities, declining leaves the tool inert, revocation flips potency without touching revisions.
- Full suite: `bun test` 188 pass, `bun run check-types` clean, ultracite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)