### PR TITLE
Run the built-in read tools in the turn loop with Source manifest injection

### DIFF
--- a/apps/server/src/agents/thinkspace-agent.ts
+++ b/apps/server/src/agents/thinkspace-agent.ts
@@ -15,6 +15,14 @@ import type {
 import type { BuiltInMcpServer } from "@better-agent/api/mcp/catalog";
 import { listBuiltInMcpServers } from "@better-agent/api/mcp/catalog";
 import {
+	assertThinkspaceRuntimePolicySupportsBuiltInTools,
+	evaluateBuiltInRuntimeToolCallPermission,
+	prepareThinkspaceBuiltInRuntimeTools,
+	THINKSPACE_BUILT_IN_TOOL_BLOCKED_REASON,
+} from "@better-agent/api/thinkspaces/built-in-runtime-tools";
+import { createFetchWebReader } from "@better-agent/api/thinkspaces/web-reader";
+import { createThinkspaceSourceReader } from "@better-agent/api/sources/reader";
+import {
 	createThinkspaceMcpDegradationNotice,
 	evaluateMcpRuntimeToolCallPermission,
 	planThinkspaceMcpRuntimeTools,
@@ -208,6 +216,19 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 			revision: resolved.activeRevision,
 			toolPotencies,
 		});
+		assertThinkspaceRuntimePolicySupportsBuiltInTools({
+			activeProductToolIds: assembly.activeTools,
+		});
+
+		const builtInPreparation = await prepareThinkspaceBuiltInRuntimeTools({
+			activeProductToolIds: assembly.activeTools,
+			sourceReader: createThinkspaceSourceReader({
+				db,
+				env: this.env,
+				thinkspaceId: turnContext.thinkspaceId,
+			}),
+			webReader: createFetchWebReader(),
+		});
 		const mcpPlan = planThinkspaceMcpRuntimeTools({
 			activeProductToolIds: assembly.activeTools,
 			revision: resolved.activeRevision,
@@ -221,17 +242,18 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 			servers: mcpPlan.servers,
 		});
 		const turnConfig = createThinkspaceRuntimeTurnConfig({
-			activeTools: mcpPreparation.activeToolNames,
+			activeTools: [...builtInPreparation.activeToolNames, ...mcpPreparation.activeToolNames],
 		});
-		const degradationNotice = createThinkspaceMcpDegradationNotice(mcpPreparation.degradedServers);
+		const systemNotices = [
+			builtInPreparation.sourceManifestNotice,
+			createThinkspaceMcpDegradationNotice(mcpPreparation.degradedServers),
+		].filter((notice): notice is string => notice !== null);
 
 		return {
 			...turnConfig,
 			model: resolved.model,
-			system: degradationNotice
-				? `${assembly.systemPrompt}\n\n${degradationNotice}`
-				: assembly.systemPrompt,
-			tools: mcpPreparation.tools,
+			system: [assembly.systemPrompt, ...systemNotices].join("\n\n"),
+			tools: { ...builtInPreparation.tools, ...mcpPreparation.tools },
 		};
 	}
 
@@ -270,8 +292,27 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 		try {
 			const db = createDb(this.env.DB);
 			const resolved = await this.resolveTurnModel(db, turnContext);
+			const permissionPolicy = createPermissionStorePolicy({ db });
+			const builtInDecision = await evaluateBuiltInRuntimeToolCallPermission({
+				permissionPolicy,
+				revision: resolved.activeRevision,
+				runtimeToolName: ctx.toolName,
+				thinkspaceId: turnContext.thinkspaceId,
+			});
+
+			if (builtInDecision.applies) {
+				if (builtInDecision.allowed) {
+					return;
+				}
+
+				return {
+					action: "block",
+					reason: builtInDecision.reason ?? THINKSPACE_BUILT_IN_TOOL_BLOCKED_REASON,
+				};
+			}
+
 			const decision = await evaluateMcpRuntimeToolCallPermission({
-				permissionPolicy: createPermissionStorePolicy({ db }),
+				permissionPolicy,
 				revision: resolved.activeRevision,
 				runtimeToolName: ctx.toolName,
 				thinkspaceId: turnContext.thinkspaceId,

--- a/apps/server/src/worker-routes.test.ts
+++ b/apps/server/src/worker-routes.test.ts
@@ -69,6 +69,13 @@ test("the Thinkspace Agent runtime registers MCP tools only through grant-gated 
 test("the Thinkspace Agent runtime rechecks Permission policy before MCP tool execution", () => {
 	assert.match(agentSource, /override async beforeToolCall/u);
 	assert.match(agentSource, /evaluateMcpRuntimeToolCallPermission/u);
-	assert.match(agentSource, /permissionPolicy: createPermissionStorePolicy\(\{ db \}\)/u);
+	assert.match(agentSource, /const permissionPolicy = createPermissionStorePolicy\(\{ db \}\)/u);
 	assert.match(agentSource, /action: "block"/u);
+});
+
+test("the Thinkspace Agent runtime gates built-in tools through the policy guard and call recheck", () => {
+	assert.match(agentSource, /assertThinkspaceRuntimePolicySupportsBuiltInTools/u);
+	assert.match(agentSource, /prepareThinkspaceBuiltInRuntimeTools/u);
+	assert.match(agentSource, /evaluateBuiltInRuntimeToolCallPermission/u);
+	assert.match(agentSource, /createThinkspaceSourceReader/u);
 });

--- a/packages/api/src/sources/reader.test.ts
+++ b/packages/api/src/sources/reader.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+import { user } from "@better-agent/db/schema/auth";
+import { thinkspaceSources } from "@better-agent/db/schema/sources";
+import { thinkspaces } from "@better-agent/db/schema/thinkspaces";
+
+import { createTestProductDb } from "../testing/product-db";
+import { SourceContentStorageError, sourceContentKey } from "./content-store";
+import type { SourceContentStore } from "./content-store";
+import { createThinkspaceSourceReader } from "./reader";
+
+const THINKSPACE_A = "thinkspace_reader_a";
+const THINKSPACE_B = "thinkspace_reader_b";
+
+const seedThinkspacesWithSource = async (db: ProductDb) => {
+	await db.insert(user).values({
+		email: "owner@example.com",
+		id: "owner_user",
+		name: "Owner",
+	});
+	await db.insert(thinkspaces).values([
+		{ goal: "Vendor decision", id: THINKSPACE_A, ownerUserId: "owner_user" },
+		{ goal: "Migration planning", id: THINKSPACE_B, ownerUserId: "owner_user" },
+	]);
+	await db.insert(thinkspaceSources).values({
+		contentType: "text/markdown",
+		description: "Pricing notes",
+		id: "source_a",
+		name: "Vendor pricing",
+		sizeBytes: 17,
+		thinkspaceId: THINKSPACE_A,
+	});
+};
+
+const memoryContentStore = (blobs: Record<string, string>): SourceContentStore => ({
+	deleteContent: () => Promise.resolve(),
+	getContent: ({ sourceId, thinkspaceId }) =>
+		Promise.resolve(blobs[sourceContentKey({ sourceId, thinkspaceId })] ?? null),
+	putContent: () => Promise.resolve(),
+});
+
+test("the reader lists the bound Thinkspace's manifest and reads content through the store", async () => {
+	const db = createTestProductDb();
+	await seedThinkspacesWithSource(db);
+	const reader = createThinkspaceSourceReader({
+		contentStore: memoryContentStore({
+			[sourceContentKey({ sourceId: "source_a", thinkspaceId: THINKSPACE_A })]: "Vendor A: $99/mo.",
+		}),
+		db,
+		thinkspaceId: THINKSPACE_A,
+	});
+
+	const manifest = await reader.listManifest();
+	assert.deepEqual(manifest, [
+		{ description: "Pricing notes", id: "source_a", name: "Vendor pricing", sizeBytes: 17 },
+	]);
+
+	const document = await reader.read("source_a");
+	assert.equal(document?.content, "Vendor A: $99/mo.");
+	assert.equal(document?.name, "Vendor pricing");
+});
+
+test("a reader bound to a sibling Thinkspace cannot see or read the Source, even with the real id", async () => {
+	const db = createTestProductDb();
+	await seedThinkspacesWithSource(db);
+	const reader = createThinkspaceSourceReader({
+		contentStore: memoryContentStore({
+			[sourceContentKey({ sourceId: "source_a", thinkspaceId: THINKSPACE_A })]: "Vendor A: $99/mo.",
+		}),
+		db,
+		thinkspaceId: THINKSPACE_B,
+	});
+
+	assert.deepEqual(await reader.listManifest(), []);
+	assert.equal(await reader.read("source_a"), null);
+});
+
+test("a Source whose blob is gone reads as unavailable rather than leaking storage state", async () => {
+	const db = createTestProductDb();
+	await seedThinkspacesWithSource(db);
+	const reader = createThinkspaceSourceReader({
+		contentStore: memoryContentStore({}),
+		db,
+		thinkspaceId: THINKSPACE_A,
+	});
+
+	assert.equal(await reader.read("source_a"), null);
+});
+
+test("a missing storage binding surfaces the content store's product-safe error", async () => {
+	const db = createTestProductDb();
+	await seedThinkspacesWithSource(db);
+	const reader = createThinkspaceSourceReader({ db, thinkspaceId: THINKSPACE_A });
+
+	await assert.rejects(reader.read("source_a"), SourceContentStorageError);
+});

--- a/packages/api/src/sources/reader.ts
+++ b/packages/api/src/sources/reader.ts
@@ -1,0 +1,77 @@
+/**
+ * The governed read seam the Thinkspace Agent runtime uses to reach Sources.
+ * A reader is constructed bound to exactly one Thinkspace: every lookup is
+ * keyed by (thinkspaceId, sourceId) together, so even a confused model
+ * holding a forged Source id from another Thinkspace reads "not found".
+ * Storage failures stay behind the content-store seam's product-safe error.
+ */
+import type { ProductDb } from "@better-agent/db";
+
+import { createSourceContentStore } from "./content-store";
+import type { SourceContentStore } from "./content-store";
+import { getThinkspaceSource, listThinkspaceSources } from "./repository";
+
+export interface ThinkspaceSourceManifestEntry {
+	description: string;
+	id: string;
+	name: string;
+	sizeBytes: number;
+}
+
+export interface ThinkspaceSourceDocument extends ThinkspaceSourceManifestEntry {
+	content: string;
+}
+
+export interface ThinkspaceSourceReader {
+	listManifest: () => Promise<ThinkspaceSourceManifestEntry[]>;
+	/** Resolves null when no Source with this id exists in the bound Thinkspace. */
+	read: (sourceId: string) => Promise<ThinkspaceSourceDocument | null>;
+}
+
+export const createThinkspaceSourceReader = ({
+	contentStore,
+	db,
+	env,
+	thinkspaceId,
+}: {
+	contentStore?: SourceContentStore;
+	db: ProductDb;
+	env?: { SOURCES_ARTIFACTS?: R2Bucket };
+	thinkspaceId: string;
+}): ThinkspaceSourceReader => {
+	const store = contentStore ?? createSourceContentStore(env ?? {});
+
+	return {
+		listManifest: async () => {
+			const sources = await listThinkspaceSources(db, { thinkspaceId });
+
+			return sources.map((source) => ({
+				description: source.description,
+				id: source.id,
+				name: source.name,
+				sizeBytes: source.sizeBytes,
+			}));
+		},
+		read: async (sourceId) => {
+			const source = await getThinkspaceSource(db, { sourceId, thinkspaceId });
+
+			if (!source) {
+				return null;
+			}
+
+			const content = await store.getContent({ sourceId: source.id, thinkspaceId });
+
+			if (content === null) {
+				return null;
+			}
+
+			return {
+				content,
+				description: source.description,
+				id: source.id,
+				name: source.name,
+				sizeBytes: source.sizeBytes,
+			};
+		},
+	};
+};

--- a/packages/api/src/thinkspaces/built-in-runtime-tools.test.ts
+++ b/packages/api/src/thinkspaces/built-in-runtime-tools.test.ts
@@ -1,0 +1,279 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { Tool, ToolCallOptions } from "ai";
+
+import { SourceContentStorageError } from "../sources/content-store";
+import type { ThinkspaceSourceReader } from "../sources/reader";
+import type { ActiveAgentProfileRevision } from "./agent-profile";
+import {
+	assertThinkspaceRuntimePolicySupportsBuiltInTools,
+	buildThinkspaceSourceManifest,
+	evaluateBuiltInRuntimeToolCallPermission,
+	prepareThinkspaceBuiltInRuntimeTools,
+} from "./built-in-runtime-tools";
+import { createMemoryPermissionPolicy } from "./permission-policy";
+import { THINKSPACE_RUNTIME_POLICY } from "./runtime-policy";
+import { ThinkspaceWebReadError } from "./web-reader";
+import type { ThinkspaceWebReader } from "./web-reader";
+
+const TOOL_CALL_OPTIONS = { messages: [], toolCallId: "tool_call_1" } as ToolCallOptions;
+
+const executeTool = async (toolDefinition: Tool | undefined, input: unknown): Promise<string> => {
+	assert.ok(toolDefinition?.execute, "tool must be constructed with an execute handler");
+
+	return (await toolDefinition.execute(input as never, TOOL_CALL_OPTIONS)) as string;
+};
+
+const stubWebReader = (overrides: Partial<ThinkspaceWebReader> = {}): ThinkspaceWebReader => ({
+	fetchPage: () => Promise.resolve("page content"),
+	search: () => Promise.resolve("search results"),
+	...overrides,
+});
+
+const stubSourceReader = (
+	overrides: Partial<ThinkspaceSourceReader> = {},
+): ThinkspaceSourceReader => ({
+	listManifest: () => Promise.resolve([]),
+	read: () => Promise.resolve(null),
+	...overrides,
+});
+
+test("only active built-in tools are constructed; unknown and MCP ids construct nothing", async () => {
+	const preparation = await prepareThinkspaceBuiltInRuntimeTools({
+		activeProductToolIds: ["web_search", "cloudflare-docs:search_docs", "workspace_bash"],
+		sourceReader: stubSourceReader(),
+		webReader: stubWebReader(),
+	});
+
+	assert.deepEqual(preparation.activeToolNames, ["web_search"]);
+	assert.deepEqual(Object.keys(preparation.tools), ["web_search"]);
+	assert.equal(preparation.sourceManifestNotice, null);
+});
+
+test("an empty active set keeps the toolset empty with no manifest", async () => {
+	const preparation = await prepareThinkspaceBuiltInRuntimeTools({
+		activeProductToolIds: [],
+		sourceReader: stubSourceReader(),
+		webReader: stubWebReader(),
+	});
+
+	assert.deepEqual(preparation.tools, {});
+	assert.deepEqual(preparation.activeToolNames, []);
+	assert.equal(preparation.sourceManifestNotice, null);
+});
+
+test("source_read returns the Source content and a product-safe not-found for forged ids", async () => {
+	const preparation = await prepareThinkspaceBuiltInRuntimeTools({
+		activeProductToolIds: ["source_read"],
+		sourceReader: stubSourceReader({
+			listManifest: () =>
+				Promise.resolve([
+					{ description: "Pricing notes", id: "source_a", name: "Vendor pricing", sizeBytes: 2048 },
+				]),
+			read: (sourceId) =>
+				Promise.resolve(
+					sourceId === "source_a"
+						? {
+								content: "Vendor A: $99/mo.",
+								description: "Pricing notes",
+								id: "source_a",
+								name: "Vendor pricing",
+								sizeBytes: 2048,
+							}
+						: null,
+				),
+		}),
+		webReader: stubWebReader(),
+	});
+
+	const found = await executeTool(preparation.tools.source_read, { sourceId: "source_a" });
+	assert.match(found, /Vendor pricing/u);
+	assert.match(found, /Vendor A: \$99\/mo\./u);
+
+	// A forged or stale id resolves to a product-safe sentence, not an error.
+	const forged = await executeTool(preparation.tools.source_read, {
+		sourceId: "source_from_another_thinkspace",
+	});
+	assert.match(forged, /not available in this Thinkspace/u);
+	assert.doesNotMatch(forged, /R2|bucket|binding/iu);
+});
+
+test("the Source manifest is injected when source_read is active and reflects the Thinkspace's Sources", async () => {
+	const preparation = await prepareThinkspaceBuiltInRuntimeTools({
+		activeProductToolIds: ["source_read", "web_search"],
+		sourceReader: stubSourceReader({
+			listManifest: () =>
+				Promise.resolve([
+					{ description: "Pricing notes", id: "source_a", name: "Vendor pricing", sizeBytes: 2048 },
+					{ description: "", id: "source_b", name: "Requirements", sizeBytes: 100 },
+				]),
+		}),
+		webReader: stubWebReader(),
+	});
+
+	assert.ok(preparation.sourceManifestNotice);
+	assert.match(
+		preparation.sourceManifestNotice,
+		/source_a: "Vendor pricing" \(2\.0 KB\) — Pricing notes/u,
+	);
+	assert.match(preparation.sourceManifestNotice, /source_b: "Requirements" \(100 B\)/u);
+	assert.match(preparation.sourceManifestNotice, /source_read/u);
+});
+
+test("a Thinkspace with no Sources gets an explicit empty manifest", () => {
+	const manifest = buildThinkspaceSourceManifest([]);
+
+	assert.match(manifest, /no Sources yet/u);
+});
+
+test("a manifest listing failure degrades into a product-safe notice instead of failing the turn", async () => {
+	const preparation = await prepareThinkspaceBuiltInRuntimeTools({
+		activeProductToolIds: ["source_read"],
+		sourceReader: stubSourceReader({
+			listManifest: () => Promise.reject(new Error("D1_ERROR: no such table")),
+		}),
+		webReader: stubWebReader(),
+	});
+
+	assert.ok(preparation.sourceManifestNotice);
+	assert.match(preparation.sourceManifestNotice, /temporarily unavailable/u);
+	assert.doesNotMatch(preparation.sourceManifestNotice, /D1_ERROR/u);
+	assert.deepEqual(preparation.activeToolNames, ["source_read"]);
+});
+
+test("web and Source tool failures resolve to product-safe messages without transport detail", async () => {
+	const preparation = await prepareThinkspaceBuiltInRuntimeTools({
+		activeProductToolIds: ["web_search", "web_fetch", "source_read"],
+		sourceReader: stubSourceReader({
+			read: () => Promise.reject(new SourceContentStorageError()),
+		}),
+		webReader: stubWebReader({
+			fetchPage: () =>
+				Promise.reject(
+					new ThinkspaceWebReadError("That web page could not be fetched for this turn."),
+				),
+			search: () => Promise.reject(new Error("ECONNREFUSED 104.16.0.1:443")),
+		}),
+	});
+
+	const searchFailure = await executeTool(preparation.tools.web_search, { query: "anything" });
+	assert.match(searchFailure, /failed unexpectedly/u);
+	assert.doesNotMatch(searchFailure, /ECONNREFUSED/u);
+
+	const fetchFailure = await executeTool(preparation.tools.web_fetch, {
+		url: "https://example.com",
+	});
+	assert.match(fetchFailure, /could not be fetched/u);
+
+	const sourceFailure = await executeTool(preparation.tools.source_read, { sourceId: "source_a" });
+	assert.match(sourceFailure, /Source storage is unavailable right now/u);
+	assert.doesNotMatch(sourceFailure, /R2|bucket|binding/iu);
+});
+
+test("the policy guard passes for the shipped policy and active built-ins", () => {
+	assert.doesNotThrow(() =>
+		assertThinkspaceRuntimePolicySupportsBuiltInTools({
+			activeProductToolIds: ["web_search", "source_read"],
+		}),
+	);
+});
+
+test("the policy guard fails closed before inference when the capability and assembly disagree", () => {
+	const disabledPolicy = {
+		...THINKSPACE_RUNTIME_POLICY,
+		capabilities: THINKSPACE_RUNTIME_POLICY.capabilities.map((capability) => ({
+			...capability,
+			enabled: false,
+		})),
+	};
+
+	assert.throws(
+		() =>
+			assertThinkspaceRuntimePolicySupportsBuiltInTools({
+				activeProductToolIds: ["web_search"],
+				policy: disabledPolicy,
+			}),
+		/thinkspace-turn-product-safe:.*runtime safety policy/u,
+	);
+
+	// No active built-ins: the disabled capability is consistent with assembly.
+	assert.doesNotThrow(() =>
+		assertThinkspaceRuntimePolicySupportsBuiltInTools({
+			activeProductToolIds: ["cloudflare-docs"],
+			policy: disabledPolicy,
+		}),
+	);
+});
+
+test("the policy guard fails closed if workspace bash is ever not forced off", () => {
+	const bashPolicy = {
+		...THINKSPACE_RUNTIME_POLICY,
+		workspaceBash: true as unknown as false,
+	};
+
+	assert.throws(
+		() =>
+			assertThinkspaceRuntimePolicySupportsBuiltInTools({
+				activeProductToolIds: [],
+				policy: bashPolicy,
+			}),
+		/thinkspace-turn-product-safe:/u,
+	);
+});
+
+const REVISION_WITH_BUILT_INS = {
+	id: "rev_built_in",
+	identity: { displayName: "Vendor Analyst", instructions: "Research vendors." },
+	modelBehavior: { modelId: "google:gemini-2.5-flash-lite", reasoningLevel: "medium" },
+	status: "active",
+	toolEnablements: [
+		{ source: "built_in", toolId: "web_search" },
+		{ source: "built_in", toolId: "source_read" },
+	],
+	version: 1,
+} as unknown as ActiveAgentProfileRevision;
+
+test("beforeToolCall enforcement allows potent built-ins, blocks inert ones, and ignores other tools", async () => {
+	const permissionPolicy = createMemoryPermissionPolicy({ web_search: "potent" });
+
+	const potent = await evaluateBuiltInRuntimeToolCallPermission({
+		permissionPolicy,
+		revision: REVISION_WITH_BUILT_INS,
+		runtimeToolName: "web_search",
+		thinkspaceId: "thinkspace_1",
+	});
+	assert.deepEqual(
+		{ allowed: potent.allowed, applies: potent.applies },
+		{ allowed: true, applies: true },
+	);
+
+	const inert = await evaluateBuiltInRuntimeToolCallPermission({
+		permissionPolicy,
+		revision: REVISION_WITH_BUILT_INS,
+		runtimeToolName: "source_read",
+		thinkspaceId: "thinkspace_1",
+	});
+	assert.equal(inert.allowed, false);
+	assert.equal(inert.applies, true);
+	assert.match(inert.reason ?? "", /not currently available/u);
+
+	const notEnabled = await evaluateBuiltInRuntimeToolCallPermission({
+		permissionPolicy: createMemoryPermissionPolicy({ web_fetch: "potent" }),
+		revision: REVISION_WITH_BUILT_INS,
+		runtimeToolName: "web_fetch",
+		thinkspaceId: "thinkspace_1",
+	});
+	assert.equal(notEnabled.allowed, false);
+
+	const notBuiltIn = await evaluateBuiltInRuntimeToolCallPermission({
+		permissionPolicy,
+		revision: REVISION_WITH_BUILT_INS,
+		runtimeToolName: "mcp_cloudflare-docs_search_docs",
+		thinkspaceId: "thinkspace_1",
+	});
+	assert.deepEqual(
+		{ allowed: notBuiltIn.allowed, applies: notBuiltIn.applies },
+		{ allowed: true, applies: false },
+	);
+});

--- a/packages/api/src/thinkspaces/built-in-runtime-tools.ts
+++ b/packages/api/src/thinkspaces/built-in-runtime-tools.ts
@@ -1,0 +1,257 @@
+/**
+ * Built-in read tools for the Thinkspace Agent turn loop.
+ *
+ * The factory constructs tool definitions for exactly the built-in tools the
+ * turn assembly judged active (enabled ∩ potent) — an empty active set keeps
+ * the toolset empty and the turn model-only. Every tool execution failure
+ * resolves to a product-safe message inside the turn so the agent can
+ * continue or report the gap; transport detail never reaches the model and
+ * the durable turn machinery never aborts on a read failure.
+ */
+import { tool } from "ai";
+import type { ToolSet } from "ai";
+import { z } from "zod";
+
+import { SourceContentStorageError } from "../sources/content-store";
+import type { ThinkspaceSourceManifestEntry, ThinkspaceSourceReader } from "../sources/reader";
+import type { ActiveAgentProfileRevision } from "./agent-profile";
+import { isBuiltInToolId } from "./built-in-tools";
+import type { BuiltInToolId } from "./built-in-tools";
+import { markThinkspaceTurnProductSafeError } from "./inspect";
+import type { ThinkspacePermissionPolicy } from "./permission-policy";
+import { isThinkspaceRuntimeCapabilityEnabled, THINKSPACE_RUNTIME_POLICY } from "./runtime-policy";
+import type { ThinkspaceRuntimePolicy } from "./runtime-policy";
+import { ThinkspaceWebReadError } from "./web-reader";
+import type { ThinkspaceWebReader } from "./web-reader";
+
+export const THINKSPACE_BUILT_IN_TOOL_BLOCKED_REASON =
+	"This built-in tool is not currently available for this Thinkspace Agent turn.";
+
+const SOURCE_NOT_FOUND_MESSAGE =
+	"That Source is not available in this Thinkspace. It may have been deleted. Check the Source manifest for what exists.";
+const SOURCE_MANIFEST_UNAVAILABLE_NOTICE =
+	"The Source manifest is temporarily unavailable for this turn. Sources may still be readable by id if the user provided one.";
+const UNEXPECTED_TOOL_FAILURE_MESSAGE =
+	"This tool failed unexpectedly for this turn. Continue with the available context, and mention the limitation briefly if it affects the answer.";
+
+const POLICY_ASSEMBLY_MISMATCH_MESSAGE =
+	"This Thinkspace Agent turn was stopped before it started: the runtime safety policy and the assembled tools disagree.";
+
+/**
+ * Read failures become tool results, not exceptions: the model sees a clean
+ * product-safe sentence and the bounded loop keeps running.
+ */
+const toProductSafeToolFailure = (error: unknown): string => {
+	if (error instanceof ThinkspaceWebReadError || error instanceof SourceContentStorageError) {
+		return error.message;
+	}
+
+	return UNEXPECTED_TOOL_FAILURE_MESSAGE;
+};
+
+export interface PrepareThinkspaceBuiltInRuntimeToolsInput {
+	activeProductToolIds: readonly string[];
+	sourceReader: ThinkspaceSourceReader;
+	webReader: ThinkspaceWebReader;
+}
+
+export interface ThinkspaceBuiltInRuntimePreparation {
+	activeToolNames: string[];
+	/** Appended to the system prompt when Source reading is active. */
+	sourceManifestNotice: string | null;
+	tools: ToolSet;
+}
+
+const formatManifestSize = (sizeBytes: number): string =>
+	sizeBytes < 1024 ? `${sizeBytes} B` : `${(sizeBytes / 1024).toFixed(1)} KB`;
+
+export const buildThinkspaceSourceManifest = (
+	entries: readonly ThinkspaceSourceManifestEntry[],
+): string => {
+	if (entries.length === 0) {
+		return "This Thinkspace has no Sources yet. The source_read tool will only work once the user uploads material.";
+	}
+
+	const lines = entries.map((entry) => {
+		const description = entry.description ? ` — ${entry.description}` : "";
+
+		return `- ${entry.id}: "${entry.name}" (${formatManifestSize(entry.sizeBytes)})${description}`;
+	});
+
+	return `This Thinkspace has the following Sources, readable with the source_read tool by id:\n${lines.join("\n")}`;
+};
+
+const createWebSearchTool = (webReader: ThinkspaceWebReader) =>
+	tool({
+		description:
+			"Search the public web. Read-only. Returns a compact list of results with URLs that can be read with web_fetch.",
+		execute: async ({ query }) => {
+			try {
+				return await webReader.search(query);
+			} catch (error) {
+				return toProductSafeToolFailure(error);
+			}
+		},
+		inputSchema: z.object({
+			query: z.string().min(1).max(400).describe("The web search query."),
+		}),
+	});
+
+const createWebFetchTool = (webReader: ThinkspaceWebReader) =>
+	tool({
+		description:
+			"Fetch one public web page by http(s) URL and return its content as text. Read-only.",
+		execute: async ({ url }) => {
+			try {
+				return await webReader.fetchPage(url);
+			} catch (error) {
+				return toProductSafeToolFailure(error);
+			}
+		},
+		inputSchema: z.object({
+			url: z.string().min(1).max(2000).describe("The http(s) URL of the page to read."),
+		}),
+	});
+
+const createSourceReadTool = (sourceReader: ThinkspaceSourceReader) =>
+	tool({
+		description:
+			"Read one of this Thinkspace's Sources by id. The available Sources and their ids are listed in the Source manifest.",
+		execute: async ({ sourceId }) => {
+			try {
+				const document = await sourceReader.read(sourceId);
+
+				if (!document) {
+					return SOURCE_NOT_FOUND_MESSAGE;
+				}
+
+				return `Source ${document.id}: "${document.name}"\n\n${document.content}`;
+			} catch (error) {
+				return toProductSafeToolFailure(error);
+			}
+		},
+		inputSchema: z.object({
+			sourceId: z.string().min(1).max(200).describe("The Source id from the manifest."),
+		}),
+	});
+
+const activeBuiltInToolIds = (activeProductToolIds: readonly string[]): BuiltInToolId[] =>
+	activeProductToolIds.filter(isBuiltInToolId);
+
+/**
+ * Builds the built-in half of the turn's toolset from the active set. The
+ * Source manifest is fetched only when Source reading is active; a manifest
+ * listing failure degrades into a product-safe notice instead of failing the
+ * turn, mirroring the MCP degradation path.
+ */
+export const prepareThinkspaceBuiltInRuntimeTools = async ({
+	activeProductToolIds,
+	sourceReader,
+	webReader,
+}: PrepareThinkspaceBuiltInRuntimeToolsInput): Promise<ThinkspaceBuiltInRuntimePreparation> => {
+	const activeToolIds = activeBuiltInToolIds(activeProductToolIds);
+	const tools: ToolSet = {};
+	let sourceManifestNotice: string | null = null;
+
+	for (const toolId of activeToolIds) {
+		if (toolId === "web_search") {
+			tools.web_search = createWebSearchTool(webReader);
+		}
+
+		if (toolId === "web_fetch") {
+			tools.web_fetch = createWebFetchTool(webReader);
+		}
+
+		if (toolId === "source_read") {
+			tools.source_read = createSourceReadTool(sourceReader);
+
+			try {
+				sourceManifestNotice = buildThinkspaceSourceManifest(await sourceReader.listManifest());
+			} catch {
+				sourceManifestNotice = SOURCE_MANIFEST_UNAVAILABLE_NOTICE;
+			}
+		}
+	}
+
+	return {
+		activeToolNames: Object.keys(tools),
+		sourceManifestNotice,
+		tools,
+	};
+};
+
+/**
+ * The zero-blast-radius guarantee must survive bugs (PRD #73): if assembly
+ * produced an active built-in tool while the runtime policy has the
+ * capability disabled, or workspace bash is not forced off, the turn fails
+ * product-safely before any inference happens.
+ */
+export const assertThinkspaceRuntimePolicySupportsBuiltInTools = ({
+	activeProductToolIds,
+	policy = THINKSPACE_RUNTIME_POLICY,
+}: {
+	activeProductToolIds: readonly string[];
+	policy?: ThinkspaceRuntimePolicy;
+}): void => {
+	if (policy.workspaceBash !== false) {
+		throw new Error(markThinkspaceTurnProductSafeError(POLICY_ASSEMBLY_MISMATCH_MESSAGE));
+	}
+
+	if (
+		activeBuiltInToolIds(activeProductToolIds).length > 0 &&
+		!isThinkspaceRuntimeCapabilityEnabled(policy, "builtin_read_tools")
+	) {
+		throw new Error(markThinkspaceTurnProductSafeError(POLICY_ASSEMBLY_MISMATCH_MESSAGE));
+	}
+};
+
+export interface ThinkspaceBuiltInToolCallDecision {
+	allowed: boolean;
+	applies: boolean;
+	reason?: string;
+	toolId: BuiltInToolId | null;
+}
+
+/**
+ * Defense in depth at the call boundary, mirroring the MCP enforcement: a
+ * built-in tool call is allowed only while its enablement is still potent.
+ * Tools outside the built-in catalog are not this evaluator's concern.
+ */
+export const evaluateBuiltInRuntimeToolCallPermission = async ({
+	permissionPolicy,
+	revision,
+	runtimeToolName,
+	thinkspaceId,
+}: {
+	permissionPolicy: ThinkspacePermissionPolicy;
+	revision: ActiveAgentProfileRevision;
+	runtimeToolName: string;
+	thinkspaceId: string;
+}): Promise<ThinkspaceBuiltInToolCallDecision> => {
+	if (!isBuiltInToolId(runtimeToolName)) {
+		return { allowed: true, applies: false, toolId: null };
+	}
+
+	const enablements = revision.toolEnablements.filter(
+		(enablement) => enablement.source === "built_in" && enablement.toolId === runtimeToolName,
+	);
+
+	if (enablements.length === 0) {
+		return {
+			allowed: false,
+			applies: true,
+			reason: THINKSPACE_BUILT_IN_TOOL_BLOCKED_REASON,
+			toolId: runtimeToolName,
+		};
+	}
+
+	const verdicts = await permissionPolicy.evaluateToolPotency({ enablements, thinkspaceId });
+	const allowed = verdicts.some((verdict) => verdict.potency === "potent");
+
+	return {
+		allowed,
+		applies: true,
+		reason: allowed ? undefined : THINKSPACE_BUILT_IN_TOOL_BLOCKED_REASON,
+		toolId: runtimeToolName,
+	};
+};

--- a/packages/api/src/thinkspaces/web-reader.test.ts
+++ b/packages/api/src/thinkspaces/web-reader.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	assertFetchableWebUrl,
+	createFetchWebReader,
+	ThinkspaceWebReadError,
+	WEB_FETCH_CONTENT_MAX_CHARS,
+} from "./web-reader";
+
+const jsonResponse = (body: unknown): Response => Response.json(body);
+
+test("only http(s) URLs are fetchable; everything else is rejected product-safely", () => {
+	assert.equal(assertFetchableWebUrl("https://example.com/pricing").hostname, "example.com");
+	assert.equal(assertFetchableWebUrl("http://example.com").protocol, "http:");
+
+	const scriptScheme = "java";
+	const rejectedUrls = [
+		"ftp://example.com",
+		"file:///etc/passwd",
+		`${scriptScheme}script:alert(1)`,
+		"not a url",
+	];
+
+	for (const url of rejectedUrls) {
+		assert.throws(() => assertFetchableWebUrl(url), ThinkspaceWebReadError);
+	}
+});
+
+test("fetchPage performs a GET and truncates oversized content to the cap", async () => {
+	const requests: { method?: string; url: string }[] = [];
+	const reader = createFetchWebReader((input, init) => {
+		requests.push({ method: init?.method, url: String(input) });
+		return Promise.resolve(new Response("x".repeat(WEB_FETCH_CONTENT_MAX_CHARS + 500)));
+	});
+
+	const content = await reader.fetchPage("https://example.com/pricing");
+
+	assert.equal(requests[0]?.method, "GET");
+	assert.equal(requests[0]?.url, "https://example.com/pricing");
+	assert.ok(content.length < WEB_FETCH_CONTENT_MAX_CHARS + 100);
+	assert.match(content, /\[Content truncated\.\]/u);
+});
+
+test("fetch failures and non-OK responses surface product-safe errors without transport detail", async () => {
+	const failingReader = createFetchWebReader(() =>
+		Promise.reject(new Error("getaddrinfo ENOTFOUND internal-host")),
+	);
+	await assert.rejects(failingReader.fetchPage("https://example.com"), (error: unknown) => {
+		assert.ok(error instanceof ThinkspaceWebReadError);
+		assert.doesNotMatch(error.message, /ENOTFOUND|internal-host/u);
+		return true;
+	});
+
+	const notOkReader = createFetchWebReader(() =>
+		Promise.resolve(new Response("forbidden", { status: 403 })),
+	);
+	await assert.rejects(notOkReader.fetchPage("https://example.com"), ThinkspaceWebReadError);
+});
+
+test("search formats the instant answer and related topics into compact result lines", async () => {
+	const reader = createFetchWebReader((input) => {
+		const url = new URL(String(input));
+		assert.equal(url.origin, "https://api.duckduckgo.com");
+		assert.equal(url.searchParams.get("q"), "observability vendors");
+
+		return Promise.resolve(
+			jsonResponse({
+				AbstractText: "Observability is the ability to infer internal state.",
+				AbstractURL: "https://en.wikipedia.org/wiki/Observability",
+				Heading: "Observability",
+				RelatedTopics: [
+					{ FirstURL: "https://example.com/a", Text: "Vendor A overview" },
+					{ Topics: [{ FirstURL: "https://example.com/b", Text: "Vendor B overview" }] },
+				],
+			}),
+		);
+	});
+
+	const results = await reader.search("observability vendors");
+
+	assert.match(results, /Observability: Observability is the ability/u);
+	assert.match(results, /- Vendor A overview \(https:\/\/example\.com\/a\)/u);
+	assert.match(results, /- Vendor B overview \(https:\/\/example\.com\/b\)/u);
+});
+
+test("an empty answer reports no results rather than an empty string", async () => {
+	const reader = createFetchWebReader(() => Promise.resolve(jsonResponse({})));
+
+	const results = await reader.search("a query with no answers");
+
+	assert.match(results, /No web results were found/u);
+});
+
+test("search transport failures surface a product-safe unavailability error", async () => {
+	const reader = createFetchWebReader(() => Promise.reject(new Error("socket hang up")));
+
+	await assert.rejects(reader.search("anything"), (error: unknown) => {
+		assert.ok(error instanceof ThinkspaceWebReadError);
+		assert.match(error.message, /temporarily unavailable/u);
+		assert.doesNotMatch(error.message, /socket/u);
+		return true;
+	});
+});

--- a/packages/api/src/thinkspaces/web-reader.test.ts
+++ b/packages/api/src/thinkspaces/web-reader.test.ts
@@ -27,6 +27,64 @@ test("only http(s) URLs are fetchable; everything else is rejected product-safel
 	}
 });
 
+test("loopback and private-network hosts are rejected before any request is made", () => {
+	const privateUrls = [
+		"http://localhost:8787/admin",
+		"https://127.0.0.1/secrets",
+		"http://0.0.0.0:6379",
+		"http://10.0.0.5/internal",
+		"https://192.168.1.1/router",
+		"http://172.16.0.1/metadata",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://[::1]:8080",
+		"https://service.local/api",
+	];
+
+	for (const url of privateUrls) {
+		assert.throws(
+			() => assertFetchableWebUrl(url),
+			ThinkspaceWebReadError,
+			`${url} must be rejected`,
+		);
+	}
+});
+
+test("redirect hops are re-validated: a public page cannot bounce the fetch onto a private host", async () => {
+	const requestedUrls: string[] = [];
+	const reader = createFetchWebReader((input) => {
+		requestedUrls.push(String(input));
+		return Promise.resolve(
+			new Response(null, {
+				headers: { location: "http://127.0.0.1:6379/" },
+				status: 302,
+			}),
+		);
+	});
+
+	await assert.rejects(reader.fetchPage("https://example.com/page"), ThinkspaceWebReadError);
+	assert.deepEqual(requestedUrls, ["https://example.com/page"]);
+});
+
+test("legitimate redirects are followed to the final page with a hop cap", async () => {
+	const reader = createFetchWebReader((input) => {
+		const url = String(input);
+
+		if (url === "https://example.com/old") {
+			return Promise.resolve(new Response(null, { headers: { location: "/new" }, status: 301 }));
+		}
+
+		assert.equal(url, "https://example.com/new");
+		return Promise.resolve(new Response("the moved page"));
+	});
+
+	assert.equal(await reader.fetchPage("https://example.com/old"), "the moved page");
+
+	const loopingReader = createFetchWebReader(() =>
+		Promise.resolve(new Response(null, { headers: { location: "/loop" }, status: 302 })),
+	);
+	await assert.rejects(loopingReader.fetchPage("https://example.com/loop"), ThinkspaceWebReadError);
+});
+
 test("fetchPage performs a GET and truncates oversized content to the cap", async () => {
 	const requests: { method?: string; url: string }[] = [];
 	const reader = createFetchWebReader((input, init) => {

--- a/packages/api/src/thinkspaces/web-reader.ts
+++ b/packages/api/src/thinkspaces/web-reader.ts
@@ -1,0 +1,137 @@
+/**
+ * The web reading seam behind the built-in web tools. The concrete provider
+ * is an implementation detail with two product guarantees: it requires no
+ * user credential and performs no writes (GET only). Failures are signalled
+ * with a product-safe error so the tool layer can degrade inside the turn.
+ */
+
+export const WEB_SEARCH_RESULT_MAX_CHARS = 8000;
+export const WEB_FETCH_CONTENT_MAX_CHARS = 16_000;
+
+/** Product-safe by construction: callers may surface the message verbatim. */
+export class ThinkspaceWebReadError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ThinkspaceWebReadError";
+	}
+}
+
+export interface ThinkspaceWebReader {
+	fetchPage: (url: string) => Promise<string>;
+	search: (query: string) => Promise<string>;
+}
+
+const WEB_FETCH_UNSUPPORTED_URL_MESSAGE =
+	"Only public http(s) URLs can be fetched by this Thinkspace Agent.";
+const WEB_FETCH_UNAVAILABLE_MESSAGE =
+	"That web page could not be fetched for this turn. It may be unavailable or unreachable.";
+const WEB_SEARCH_UNAVAILABLE_MESSAGE =
+	"Web search is temporarily unavailable for this turn. Continue with the available context.";
+
+export const assertFetchableWebUrl = (url: string): URL => {
+	let parsed: URL;
+
+	try {
+		parsed = new URL(url);
+	} catch {
+		throw new ThinkspaceWebReadError(WEB_FETCH_UNSUPPORTED_URL_MESSAGE);
+	}
+
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		throw new ThinkspaceWebReadError(WEB_FETCH_UNSUPPORTED_URL_MESSAGE);
+	}
+
+	return parsed;
+};
+
+const truncate = (text: string, maxChars: number): string =>
+	text.length > maxChars ? `${text.slice(0, maxChars)}\n\n[Content truncated.]` : text;
+
+interface DuckDuckGoTopic {
+	FirstURL?: string;
+	Text?: string;
+	Topics?: DuckDuckGoTopic[];
+}
+
+interface DuckDuckGoAnswer {
+	AbstractText?: string;
+	AbstractURL?: string;
+	Heading?: string;
+	RelatedTopics?: DuckDuckGoTopic[];
+}
+
+const flattenSearchTopics = (topics: readonly DuckDuckGoTopic[]): DuckDuckGoTopic[] =>
+	topics.flatMap((topic) => (topic.Topics ? flattenSearchTopics(topic.Topics) : [topic]));
+
+const formatSearchAnswer = (query: string, answer: DuckDuckGoAnswer): string => {
+	const lines: string[] = [];
+
+	if (answer.AbstractText) {
+		lines.push(`${answer.Heading ?? query}: ${answer.AbstractText}`);
+
+		if (answer.AbstractURL) {
+			lines.push(`Source: ${answer.AbstractURL}`);
+		}
+	}
+
+	const topics = flattenSearchTopics(answer.RelatedTopics ?? []).filter(
+		(topic) => topic.Text && topic.FirstURL,
+	);
+
+	for (const topic of topics) {
+		lines.push(`- ${topic.Text} (${topic.FirstURL})`);
+	}
+
+	if (lines.length === 0) {
+		return `No web results were found for "${query}".`;
+	}
+
+	return truncate(lines.join("\n"), WEB_SEARCH_RESULT_MAX_CHARS);
+};
+
+/**
+ * Credential-free provider on the platform fetch: search through the
+ * DuckDuckGo Instant Answer API, page reads as plain GET requests.
+ */
+export const createFetchWebReader = (fetchImpl: typeof fetch = fetch): ThinkspaceWebReader => ({
+	fetchPage: async (url) => {
+		const parsed = assertFetchableWebUrl(url);
+
+		let response: Response;
+
+		try {
+			response = await fetchImpl(parsed.toString(), { method: "GET", redirect: "follow" });
+		} catch {
+			throw new ThinkspaceWebReadError(WEB_FETCH_UNAVAILABLE_MESSAGE);
+		}
+
+		if (!response.ok) {
+			throw new ThinkspaceWebReadError(WEB_FETCH_UNAVAILABLE_MESSAGE);
+		}
+
+		return truncate(await response.text(), WEB_FETCH_CONTENT_MAX_CHARS);
+	},
+	search: async (query) => {
+		const endpoint = new URL("https://api.duckduckgo.com/");
+		endpoint.searchParams.set("q", query);
+		endpoint.searchParams.set("format", "json");
+		endpoint.searchParams.set("no_html", "1");
+		endpoint.searchParams.set("skip_disambig", "1");
+
+		let answer: DuckDuckGoAnswer;
+
+		try {
+			const response = await fetchImpl(endpoint.toString(), { method: "GET" });
+
+			if (!response.ok) {
+				throw new Error("search responded with a non-OK status");
+			}
+
+			answer = (await response.json()) as DuckDuckGoAnswer;
+		} catch {
+			throw new ThinkspaceWebReadError(WEB_SEARCH_UNAVAILABLE_MESSAGE);
+		}
+
+		return formatSearchAnswer(query, answer);
+	},
+});

--- a/packages/api/src/thinkspaces/web-reader.ts
+++ b/packages/api/src/thinkspaces/web-reader.ts
@@ -28,6 +28,30 @@ const WEB_FETCH_UNAVAILABLE_MESSAGE =
 const WEB_SEARCH_UNAVAILABLE_MESSAGE =
 	"Web search is temporarily unavailable for this turn. Continue with the available context.";
 
+const PRIVATE_HOSTNAME_PATTERNS = [
+	/^localhost$/iu,
+	/\.local(?:host|domain)?$/iu,
+	/^127\./u,
+	/^0\.0\.0\.0$/u,
+	/^10\./u,
+	/^192\.168\./u,
+	/^172\.(?:1[6-9]|2\d|3[01])\./u,
+	/^169\.254\./u,
+	/^\[?::1\]?$/u,
+	/^\[?f[cd][0-9a-f]{2}:/iu,
+	/^\[?fe80:/iu,
+];
+
+const isPrivateHostname = (hostname: string): boolean =>
+	PRIVATE_HOSTNAME_PATTERNS.some((pattern) => pattern.test(hostname));
+
+/**
+ * Scheme and obvious-private-host gate, applied to the requested URL and to
+ * every redirect hop. The deployed Workers platform blocks private-network
+ * egress anyway; this keeps local and future runtimes from reaching loopback
+ * or RFC1918 hosts through the agent. A public hostname resolving privately
+ * is the platform's job to stop — DNS is not visible at this layer.
+ */
 export const assertFetchableWebUrl = (url: string): URL => {
 	let parsed: URL;
 
@@ -38,6 +62,10 @@ export const assertFetchableWebUrl = (url: string): URL => {
 	}
 
 	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		throw new ThinkspaceWebReadError(WEB_FETCH_UNSUPPORTED_URL_MESSAGE);
+	}
+
+	if (isPrivateHostname(parsed.hostname)) {
 		throw new ThinkspaceWebReadError(WEB_FETCH_UNSUPPORTED_URL_MESSAGE);
 	}
 
@@ -93,23 +121,45 @@ const formatSearchAnswer = (query: string, answer: DuckDuckGoAnswer): string => 
  * Credential-free provider on the platform fetch: search through the
  * DuckDuckGo Instant Answer API, page reads as plain GET requests.
  */
+const WEB_FETCH_MAX_REDIRECTS = 5;
+
+const isRedirectStatus = (status: number): boolean => status >= 300 && status < 400;
+
 export const createFetchWebReader = (fetchImpl: typeof fetch = fetch): ThinkspaceWebReader => ({
+	// Redirects are followed manually so every hop passes the same URL gate
+	// the requested URL did — a public page cannot bounce the agent onto a
+	// loopback or private host.
 	fetchPage: async (url) => {
-		const parsed = assertFetchableWebUrl(url);
+		let target = assertFetchableWebUrl(url);
 
-		let response: Response;
+		for (let hop = 0; hop <= WEB_FETCH_MAX_REDIRECTS; hop += 1) {
+			let response: Response;
 
-		try {
-			response = await fetchImpl(parsed.toString(), { method: "GET", redirect: "follow" });
-		} catch {
-			throw new ThinkspaceWebReadError(WEB_FETCH_UNAVAILABLE_MESSAGE);
+			try {
+				response = await fetchImpl(target.toString(), { method: "GET", redirect: "manual" });
+			} catch {
+				throw new ThinkspaceWebReadError(WEB_FETCH_UNAVAILABLE_MESSAGE);
+			}
+
+			if (isRedirectStatus(response.status)) {
+				const location = response.headers.get("location");
+
+				if (!location) {
+					throw new ThinkspaceWebReadError(WEB_FETCH_UNAVAILABLE_MESSAGE);
+				}
+
+				target = assertFetchableWebUrl(new URL(location, target).toString());
+				continue;
+			}
+
+			if (!response.ok) {
+				throw new ThinkspaceWebReadError(WEB_FETCH_UNAVAILABLE_MESSAGE);
+			}
+
+			return truncate(await response.text(), WEB_FETCH_CONTENT_MAX_CHARS);
 		}
 
-		if (!response.ok) {
-			throw new ThinkspaceWebReadError(WEB_FETCH_UNAVAILABLE_MESSAGE);
-		}
-
-		return truncate(await response.text(), WEB_FETCH_CONTENT_MAX_CHARS);
+		throw new ThinkspaceWebReadError(WEB_FETCH_UNAVAILABLE_MESSAGE);
 	},
 	search: async (query) => {
 		const endpoint = new URL("https://api.duckduckgo.com/");


### PR DESCRIPTION
Closes #87 (PRD: #73)

## What this does

Opens the gate built by the previous two slices — the agent can now actually search the web, fetch pages, and read Sources in a bounded turn loop:

- **Tool construction gated by the active set**: `prepareThinkspaceBuiltInRuntimeTools` builds `web_search` / `web_fetch` / `source_read` tool definitions for exactly the built-in ids in the assembly's active set (enabled ∩ potent). Unknown or inactive ids construct nothing; an empty active set keeps the toolset empty and the turn model-only with step bound 1 — system prompt byte-for-byte unchanged.
- **Source reading sealed to the bound Thinkspace**: a `ThinkspaceSourceReader` constructed per turn keys every lookup by `(thinkspaceId, sourceId)` through the existing content-store seam; a forged id from a sibling Thinkspace reads as a product-safe not-found inside the turn.
- **Source manifest injection**: when `source_read` is active the system prompt carries a compact manifest (id, name, description, size); an empty Thinkspace says so explicitly; a listing failure degrades into a product-safe notice, mirroring the MCP degradation path.
- **Credential-free, GET-only web reading** behind a `ThinkspaceWebReader` seam: search via the DuckDuckGo Instant Answer API, fetch restricted to http(s) URLs, both truncated to fixed caps.
- **Product-safe failure semantics**: tool execution failures become clean result sentences (never exceptions) — no `ECONNREFUSED`, bucket, or binding detail reaches the model, and the durable turn machinery never aborts on a read failure.
- **Fail closed before inference**: `assertThinkspaceRuntimePolicySupportsBuiltInTools` stops the turn product-safely if a built-in tool is active while `builtin_read_tools` is disabled or workspace bash is not forced off.
- **Defense in depth**: `beforeToolCall` now blocks built-in tool calls whose enablement is no longer potent, alongside the existing MCP enforcement.

With this slice, the PRD's completion flow is live end to end: upload Sources → enable + grant built-ins → submit a turn → the agent reads Sources and the web across up to 8 steps. Remaining: inspection rendering + the smoke checklist section.

## Testing

- 22 new tests across three suites: active-set gating, cross-Thinkspace isolation (reader bound to sibling sees nothing even with the real id), manifest content/empty/degraded cases, product-safe failure semantics for all three tools, URL scheme rejection, truncation caps, search formatting, policy-guard mismatch cases, and beforeToolCall allow/block/not-applies decisions.
- Runtime source-guard test extended to assert the new wiring (`worker-routes.test.ts`).
- Full suite: `bun test` 211 pass, `bun run check-types` clean, ultracite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)