### PR TITLE
Render turn tool activity in product language, plus the built-in reads smoke checklist

### DIFF
--- a/.agents/docs/thinkspace-agent-runtime-smoke-checks.md
+++ b/.agents/docs/thinkspace-agent-runtime-smoke-checks.md
@@ -429,6 +429,111 @@ branches above have a passing row against the target deployment.
 | 2026-06-11 | Not executed in this agent session            | `6f993f80a3bfc658c57ba86ba2df57158dda144d` | pi agent    | Not run      | Not run        | Not run       | Not run                 | Documentation checklist added; live execution still requires a deployed/local stage plus owner BYOK model credential.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | 2026-06-11 | Local `alchemy dev` (workerd, localhost:3000) | `e802de7b2b98c981c81b7cf590acf883228187eb` | fable agent | PASS         | PASS           | PASS          | PASS                    | First run at `48b41a5` failed every turn before any model call: turn RPCs hit the Durable Object without PartyServer initialization, so Project Think's session was never created. Fixed in `e802de7` (runtime `setName()` before turn RPCs) and re-run. 9.1: turn completed citing Cloudflare Docs; DO message log shows a `tool-tool_cloudflaredocs_search_cloudflare_documentation` call. 9.2/9.3: turns completed model-only with zero MCP connections and no tool parts; revision id/version unchanged after revocation. The model sometimes _claims_ it used the external source while inert — policy held (no MCP activity), but the wording is a model-quality wrinkle. 9.4: `aws-knowledge` temporarily pointed at `https://mcp-smoke-unreachable.invalid/mcp`; potency read `potent`, turn completed model-only with product-safe "external information source is temporarily unavailable" wording, no transport detail leaked; patch reverted and `url-policy` + `mcp-runtime-tools` tests re-ran green. `model_provider_credential` rows were developer-inserted in local D1 (no product grant flow yet). |
 
+## 10. Built-in reads round-trip: Sources, web, and inspection
+
+Expectation: the built-in read tools (`web_search`, `web_fetch`, `source_read`)
+become potent only when the active Agent Profile revision enables them **and**
+the Thinkspace owns a grant of the governing Permission kind
+(`built_in_web_read` for the web pair, `built_in_source_read` for Source
+reading) — enablement alone confers nothing. A granted turn can read the
+Thinkspace's uploaded Sources (sealed to the bound Thinkspace) and the public
+web (credential-free, GET-only), the Source manifest is injected so the agent
+discovers material unprompted, and the Turn status panel's tool activity lists
+the reads in product language — Sources by name, searches by query, fetches by
+URL — never raw runtime payloads. Revocation makes the next turn inert without
+changing the Agent Profile revision.
+
+Reuse the environment setup, model-readiness workaround
+(`model_provider_credential` row developer-inserted into local D1, section 9),
+and DO-storage observability notes from section 9. Built-in tool calls appear
+in the runtime's message log as `tool-web_search`, `tool-web_fetch`, and
+`tool-source_read` parts; record only product-safe summaries.
+
+### 10.1 Upload, enable, grant: the tool loop reads a Source and the web
+
+- [ ] Create **TS-READS-GRANTED** and confirm model readiness is ready, as in
+      section 3.
+- [ ] Upload a small text Source with distinctive content (UI: Sources →
+      Upload, or curl):
+
+      ```sh
+      curl -s -b /tmp/ba-owner.txt "$SERVER/api/openapi/sources/upload" \
+        -H 'content-type: application/json' \
+        -d '{"thinkspaceId":"<TS-READS-GRANTED>","name":"Q2 pricing notes","contentType":"text/markdown","content":"# Q2 pricing notes\nThe internal launch codename is BLUE-HERON."}'
+      ```
+
+- [ ] Enable all three built-in tools on the draft Agent Profile (UI: Tools →
+      Built-in tools, or curl):
+
+      ```sh
+      curl -s -b /tmp/ba-owner.txt "$SERVER/api/openapi/thinkspaces/updateToolSelections" \
+        -H 'content-type: application/json' \
+        -d '{"thinkspaceId":"<TS-READS-GRANTED>","selections":[],"builtInToolIds":["web_search","web_fetch","source_read"]}'
+      ```
+
+- [ ] Activate the draft granting every requested Permission (UI: Activate
+      Thinkspace, or curl with all requested indexes).
+- [ ] `thinkspaces/get` shows: - `grantedPermissions[]` contains a `built_in_web_read` row
+      (`providerId: "web"`) and a `built_in_source_read` row
+      (`providerId: "sources"`). - `enabledToolPotencies[]` reports all three built-in tools as
+      `potency: "potent"`.
+- [ ] Submit a turn that needs both reads, for example:
+
+      > Read my uploaded pricing notes Source and tell me the launch codename
+      > it contains, then search the web for one public fact about Cloudflare
+      > Durable Objects and cite the page you fetched.
+
+- [ ] Inspect progresses to `completed`; the result reflects the Source
+      content (the codename) and the web read.
+- [ ] The Turn status panel's **Tool activity** lists the reads in product
+      language — the Source by its name (`Read the Source "Q2 pricing
+notes".`), the search by its query, the fetch by its URL — with no raw
+      tool payloads, bucket names, or transport detail.
+- [ ] DO-storage observability shows the corresponding `tool-source_read` /
+      `tool-web_search` / `tool-web_fetch` message parts. Record only a
+      product-safe summary.
+
+### 10.2 Enablement without grant: the built-ins stay inert
+
+- [ ] Create **TS-READS-INERT**, upload a Source, and enable the three
+      built-in tools as above.
+- [ ] Activate while declining the requested Permissions
+      (`"grantedPermissionIndexes":[]`).
+- [ ] `thinkspaces/get` shows no `built_in_web_read` or
+      `built_in_source_read` grant and reports the built-in tools as
+      `potency: "inert"`.
+- [ ] Submit the same reads-requiring turn. Inspect reaches a terminal state;
+      the result is model-only or explains the limitation, the Tool activity
+      list shows no Source or web reads, and DO-storage observability shows
+      no built-in tool parts.
+
+### 10.3 Revocation: the next turn is inert with no Profile change
+
+- [ ] On TS-READS-GRANTED, record the active Agent Profile revision
+      id/version, then revoke the `built_in_source_read` grant (UI:
+      Permissions → Revoke, or `thinkspaces/revokePermission` with the grant
+      id).
+- [ ] The next `thinkspaces/get` shows the grant removed, `source_read` as
+      `potency: "inert"`, the web pair still `potent`, and the revision
+      id/version unchanged.
+- [ ] Submit a Source-requiring turn. The result does not contain the Source
+      content, Tool activity shows no Source read (web reads may still
+      appear), and DO-storage observability shows no `tool-source_read` part
+      with Source content.
+- [ ] Cross-Thinkspace seal: from TS-READS-INERT (or any other Thinkspace
+      with `source_read` granted), submit a turn asking it to read the
+      TS-READS-GRANTED Source by its id. The read resolves as not found
+      inside the turn; no content crosses Thinkspaces.
+
+### 10.4 Result record
+
+Add one row per smoke execution. The issue is not complete until all required
+branches above have a passing row against the target deployment.
+
+| Date       | Stage / URL                        | Commit SHA | Operator    | Granted reads + inspection | No-grant inert | Revoked inert | Cross-Thinkspace seal | Notes                                                                                                                |
+| ---------- | ---------------------------------- | ---------- | ----------- | -------------------------- | -------------- | ------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-12 | Not executed in this agent session | (issue #89 branch) | fable agent | Not run | Not run | Not run | Not run | Documentation checklist added with the inspection-rendering slice; live execution still requires a deployed/local stage plus owner BYOK model credential. |
+
 ## Appendix: temporary local DO probe (optional deep checks)
 
 The two optional deep checks exercise the DO boundary directly, which no

--- a/apps/server/src/agents/thinkspace-agent.ts
+++ b/apps/server/src/agents/thinkspace-agent.ts
@@ -4,6 +4,7 @@ import {
 } from "@better-agent/api/models/readiness";
 import {
 	extractThinkspaceTurnResultText,
+	extractThinkspaceTurnToolActivity,
 	mapThinkspaceTurnInspection,
 	markThinkspaceTurnProductSafeError,
 	validateThinkspaceTurnSubmissionId,
@@ -170,16 +171,14 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 		}
 
 		const snapshot = await this.inspectSubmission(submissionId);
-		const resultText =
-			snapshot?.status === "completed"
-				? extractThinkspaceTurnResultText(await this.getMessages())
-				: null;
+		const messages = snapshot?.status === "completed" ? await this.getMessages() : null;
 
 		return mapThinkspaceTurnInspection({
-			resultText,
+			resultText: messages ? extractThinkspaceTurnResultText(messages) : null,
 			snapshot,
 			submissionId,
 			thinkspaceId: request.thinkspaceId,
+			toolActivity: messages ? extractThinkspaceTurnToolActivity(messages) : [],
 		});
 	}
 

--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -354,6 +354,16 @@ const TurnInspectionPanel = ({
 							{inspection.resultText}
 						</p>
 					) : null}
+					{inspection.toolActivity.length > 0 ? (
+						<div className="grid gap-1">
+							<p className="font-medium text-sm">Tool activity</p>
+							<ul className="grid list-disc gap-1 pl-5 text-muted-foreground text-sm">
+								{inspection.toolActivity.map((entry, position) => (
+									<li key={`${position}-${entry}`}>{entry}</li>
+								))}
+							</ul>
+						</div>
+					) : null}
 					<div className="flex flex-wrap gap-4 text-muted-foreground text-xs">
 						<span>Accepted {formatDateTime(inspection.acceptedAt)}</span>
 						<span>Started {formatDateTime(inspection.startedAt)}</span>

--- a/packages/api/src/thinkspaces/built-in-runtime-tools.ts
+++ b/packages/api/src/thinkspaces/built-in-runtime-tools.ts
@@ -15,7 +15,7 @@ import { z } from "zod";
 import { SourceContentStorageError } from "../sources/content-store";
 import type { ThinkspaceSourceManifestEntry, ThinkspaceSourceReader } from "../sources/reader";
 import type { ActiveAgentProfileRevision } from "./agent-profile";
-import { isBuiltInToolId } from "./built-in-tools";
+import { formatBuiltInSourceReadResult, isBuiltInToolId } from "./built-in-tools";
 import type { BuiltInToolId } from "./built-in-tools";
 import { markThinkspaceTurnProductSafeError } from "./inspect";
 import type { ThinkspacePermissionPolicy } from "./permission-policy";
@@ -125,7 +125,7 @@ const createSourceReadTool = (sourceReader: ThinkspaceSourceReader) =>
 					return SOURCE_NOT_FOUND_MESSAGE;
 				}
 
-				return `Source ${document.id}: "${document.name}"\n\n${document.content}`;
+				return formatBuiltInSourceReadResult(document);
 			} catch (error) {
 				return toProductSafeToolFailure(error);
 			}

--- a/packages/api/src/thinkspaces/built-in-tools.ts
+++ b/packages/api/src/thinkspaces/built-in-tools.ts
@@ -19,6 +19,25 @@ export type BuiltInToolId = (typeof BUILT_IN_TOOL_IDS)[number];
 export const isBuiltInToolId = (value: string): value is BuiltInToolId =>
 	BUILT_IN_TOOL_IDS.includes(value as BuiltInToolId);
 
+/**
+ * The success result format of the source_read built-in tool. The runtime
+ * tool emits it and turn inspection parses the Source name back out of it,
+ * so the format/parse pair lives here to keep the two sides from drifting.
+ */
+export const formatBuiltInSourceReadResult = (document: {
+	content: string;
+	id: string;
+	name: string;
+}): string => `Source ${document.id}: "${document.name}"\n\n${document.content}`;
+
+const SOURCE_READ_RESULT_FIRST_LINE = /^Source [^:\n]+: "(?<sourceName>.+)"$/u;
+
+export const parseBuiltInSourceReadResultName = (output: string): string | null => {
+	const firstLine = output.split("\n", 1)[0] ?? "";
+
+	return SOURCE_READ_RESULT_FIRST_LINE.exec(firstLine)?.groups?.sourceName ?? null;
+};
+
 export type BuiltInToolPermissionKind =
 	| typeof THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ
 	| typeof THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ;

--- a/packages/api/src/thinkspaces/inspect.test.ts
+++ b/packages/api/src/thinkspaces/inspect.test.ts
@@ -309,10 +309,18 @@ test("bounds tool activity entry length and entry count for safe rendering", () 
 		},
 	]);
 	const capped = extractThinkspaceTurnToolActivity([{ parts: manyParts, role: "assistant" }]);
+	const truncatedFailure = extractThinkspaceTurnToolActivity([
+		{
+			parts: [{ input: { query: longQuery }, state: "output-error", type: "tool-web_search" }],
+			role: "assistant",
+		},
+	]);
 
 	assert.equal(bounded[0]?.length, THINKSPACE_TURN_TOOL_ACTIVITY_ENTRY_MAX_LENGTH);
 	assert.equal(bounded[0]?.endsWith("…"), true);
 	assert.equal(capped.length, THINKSPACE_TURN_TOOL_ACTIVITY_MAX_ENTRIES);
+	assert.equal(truncatedFailure[0]?.length, THINKSPACE_TURN_TOOL_ACTIVITY_ENTRY_MAX_LENGTH);
+	assert.equal(truncatedFailure[0]?.endsWith("(did not complete)"), true);
 });
 
 test("unknown handles map to a product-safe unknown state", () => {

--- a/packages/api/src/thinkspaces/inspect.test.ts
+++ b/packages/api/src/thinkspaces/inspect.test.ts
@@ -7,11 +7,14 @@ import type { CloudflareEnv } from "@better-agent/env/types";
 import {
 	extractThinkspaceTurnProductSafeFailureMessage,
 	extractThinkspaceTurnResultText,
+	extractThinkspaceTurnToolActivity,
 	inspectOwnedThinkspaceTurn,
 	mapThinkspaceTurnInspection,
 	markThinkspaceTurnProductSafeError,
 	THINKSPACE_TURN_RESULT_TEXT_MAX_LENGTH,
 	THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH,
+	THINKSPACE_TURN_TOOL_ACTIVITY_ENTRY_MAX_LENGTH,
+	THINKSPACE_TURN_TOOL_ACTIVITY_MAX_ENTRIES,
 	validateThinkspaceTurnSubmissionId,
 } from "./inspect";
 import type { ThinkspaceRuntimeSubmissionSnapshot, ThinkspaceTurnInspection } from "./inspect";
@@ -126,6 +129,192 @@ test("bounds completed result text for safe rendering", () => {
 	assert.equal(resultText?.endsWith("…"), true);
 });
 
+test("renders built-in tool calls from the latest assistant message in product language", () => {
+	const activity = extractThinkspaceTurnToolActivity([
+		{
+			parts: [
+				{ text: "Working on it.", type: "text" },
+				{
+					input: { query: "durable objects pricing" },
+					output: "1. https://example.com — Durable Objects pricing",
+					state: "output-available",
+					type: "tool-web_search",
+				},
+				{
+					input: { url: "https://example.com/pricing" },
+					output: "Pricing page content…",
+					state: "output-available",
+					type: "tool-web_fetch",
+				},
+				{
+					input: { sourceId: "source_abc" },
+					output: 'Source source_abc: "Q2 pricing notes"\n\nThe notes content.',
+					state: "output-available",
+					type: "tool-source_read",
+				},
+			],
+			role: "assistant",
+		},
+	]);
+
+	assert.deepEqual(activity, [
+		'Searched the web for "durable objects pricing".',
+		"Fetched the web page https://example.com/pricing.",
+		'Read the Source "Q2 pricing notes".',
+	]);
+});
+
+test("a Source read that did not succeed falls back to the requested id", () => {
+	const activity = extractThinkspaceTurnToolActivity([
+		{
+			parts: [
+				{
+					input: { sourceId: "source_forged" },
+					output:
+						"That Source is not available in this Thinkspace. It may have been deleted. Check the Source manifest for what exists.",
+					state: "output-available",
+					type: "tool-source_read",
+				},
+			],
+			role: "assistant",
+		},
+	]);
+
+	assert.deepEqual(activity, ["Tried to read Source source_forged."]);
+});
+
+test("external information source calls render with the catalog server's product name", () => {
+	const servers = [
+		{
+			authType: "none" as const,
+			description: "Docs.",
+			enabledByDefaultForThinkspaces: false as const,
+			id: "cloudflare-docs",
+			name: "Cloudflare Docs",
+			riskLevel: "read_only" as const,
+			transport: "streamable_http" as const,
+			url: "https://docs.mcp.cloudflare.com/mcp",
+		},
+	];
+	const activity = extractThinkspaceTurnToolActivity(
+		[
+			{
+				parts: [
+					{
+						input: { query: "durable objects" },
+						state: "output-available",
+						type: "tool-tool_cloudflaredocs_search_cloudflare_documentation",
+					},
+					{
+						input: { query: "durable objects" },
+						state: "output-available",
+						toolName: "tool_cloudflaredocs_search_cloudflare_documentation",
+						type: "dynamic-tool",
+					},
+				],
+				role: "assistant",
+			},
+		],
+		servers,
+	);
+
+	assert.deepEqual(activity, [
+		"Used the Cloudflare Docs external information source: search_cloudflare_documentation.",
+		"Used the Cloudflare Docs external information source: search_cloudflare_documentation.",
+	]);
+});
+
+test("unrecognized tools render generically and never leak their payloads", () => {
+	const activity = extractThinkspaceTurnToolActivity([
+		{
+			parts: [
+				{
+					input: { secret: "sk-ant-secret", url: "https://internal.example" },
+					output: "401 Unauthorized: invalid x-api-key sk-ant-secret",
+					state: "output-available",
+					type: "tool-mystery_tool",
+				},
+			],
+			role: "assistant",
+		},
+	]);
+
+	assert.equal(activity.length, 1);
+	assert.equal(activity[0]?.includes("sk-ant-secret"), false);
+	assert.equal(activity[0]?.includes("internal.example"), false);
+	assert.equal(activity[0]?.includes("mystery_tool"), false);
+});
+
+test("tool calls that did not complete are marked without exposing the error", () => {
+	const activity = extractThinkspaceTurnToolActivity([
+		{
+			parts: [
+				{
+					input: { query: "blocked query" },
+					state: "output-error",
+					type: "tool-web_search",
+				},
+			],
+			role: "assistant",
+		},
+	]);
+
+	assert.deepEqual(activity, ['Searched the web for "blocked query". (did not complete)']);
+});
+
+test("only the latest assistant message's tool calls become activity", () => {
+	const activity = extractThinkspaceTurnToolActivity([
+		{
+			parts: [
+				{
+					input: { query: "older turn" },
+					state: "output-available",
+					type: "tool-web_search",
+				},
+			],
+			role: "assistant",
+		},
+		{ parts: [{ text: "Next instruction.", type: "text" }], role: "user" },
+		{
+			parts: [{ text: "Model-only answer.", type: "text" }],
+			role: "assistant",
+		},
+	]);
+
+	assert.deepEqual(activity, []);
+	assert.deepEqual(extractThinkspaceTurnToolActivity([]), []);
+});
+
+test("bounds tool activity entry length and entry count for safe rendering", () => {
+	const longQuery = "q".repeat(THINKSPACE_TURN_TOOL_ACTIVITY_ENTRY_MAX_LENGTH + 100);
+	const manyParts = Array.from(
+		{ length: THINKSPACE_TURN_TOOL_ACTIVITY_MAX_ENTRIES + 10 },
+		(_, index) => ({
+			input: { query: `query ${index}` },
+			state: "output-available",
+			type: "tool-web_search",
+		}),
+	);
+
+	const bounded = extractThinkspaceTurnToolActivity([
+		{
+			parts: [
+				{
+					input: { query: longQuery },
+					state: "output-available",
+					type: "tool-web_search",
+				},
+			],
+			role: "assistant",
+		},
+	]);
+	const capped = extractThinkspaceTurnToolActivity([{ parts: manyParts, role: "assistant" }]);
+
+	assert.equal(bounded[0]?.length, THINKSPACE_TURN_TOOL_ACTIVITY_ENTRY_MAX_LENGTH);
+	assert.equal(bounded[0]?.endsWith("…"), true);
+	assert.equal(capped.length, THINKSPACE_TURN_TOOL_ACTIVITY_MAX_ENTRIES);
+});
+
 test("unknown handles map to a product-safe unknown state", () => {
 	const inspection = mapThinkspaceTurnInspection({
 		snapshot: null,
@@ -229,6 +418,40 @@ test("completed turns carry the bounded model-only result text", () => {
 	assert.equal(completed.status, "completed");
 	assert.equal(completed.resultText, "The Thinkspace goal summary.");
 	assert.equal(completed.completedAt, 1_717_000_001_000);
+});
+
+test("only completed turns carry tool activity; every other state stays empty", () => {
+	const toolActivity = ['Searched the web for "durable objects pricing".'];
+	const completed = mapThinkspaceTurnInspection({
+		resultText: "Answer.",
+		snapshot: createSnapshot({ completedAt: 1_717_000_001_000, status: "completed" }),
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+		toolActivity,
+	});
+	const running = mapThinkspaceTurnInspection({
+		snapshot: createSnapshot({ status: "running" }),
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+		toolActivity,
+	});
+	const failed = mapThinkspaceTurnInspection({
+		snapshot: createSnapshot({ status: "error" }),
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+		toolActivity,
+	});
+	const unknown = mapThinkspaceTurnInspection({
+		snapshot: null,
+		submissionId: "submission_1",
+		thinkspaceId: "thinkspace_inspect",
+		toolActivity,
+	});
+
+	assert.deepEqual(completed.toolActivity, toolActivity);
+	assert.deepEqual(running.toolActivity, []);
+	assert.deepEqual(failed.toolActivity, []);
+	assert.deepEqual(unknown.toolActivity, []);
 });
 
 test("completed tool-using turns remain attributable to their Agent Profile revision", () => {

--- a/packages/api/src/thinkspaces/inspect.ts
+++ b/packages/api/src/thinkspaces/inspect.ts
@@ -2,12 +2,17 @@ import type { ProductDb } from "@better-agent/db";
 import type { Thinkspace } from "@better-agent/db/schema/thinkspaces";
 import type { CloudflareEnv } from "@better-agent/env/types";
 
+import type { BuiltInMcpServer } from "../mcp/catalog";
+import { listBuiltInMcpServers } from "../mcp/catalog";
+import { parseCloudflareAgentsMcpToolName } from "../mcp/tool-identity";
 import { getThinkspace } from "./repository";
 import { resolveThinkspaceAgentRuntime, THINKSPACE_AGENT_BINDING_NAME } from "./runtime";
 import { THINKSPACE_TURN_SOURCE, ThinkspaceTurnValidationError } from "./turns";
 
 export const THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH = 128;
 export const THINKSPACE_TURN_RESULT_TEXT_MAX_LENGTH = 8000;
+export const THINKSPACE_TURN_TOOL_ACTIVITY_MAX_ENTRIES = 32;
+export const THINKSPACE_TURN_TOOL_ACTIVITY_ENTRY_MAX_LENGTH = 300;
 
 /**
  * Marker prefix for failure messages the Thinkspace Agent runtime throws on
@@ -57,7 +62,11 @@ export interface ThinkspaceRuntimeSubmissionSnapshot {
 }
 
 export interface ThinkspaceRuntimeMessagePart {
+	input?: unknown;
+	output?: unknown;
+	state?: string;
 	text?: string;
+	toolName?: string;
 	type: string;
 }
 
@@ -84,6 +93,7 @@ export interface ThinkspaceTurnInspection {
 	status: ThinkspaceTurnInspectionStatus;
 	submissionId: string;
 	thinkspaceId: string;
+	toolActivity: readonly string[];
 }
 
 export interface ThinkspaceTurnInspectionRequest {
@@ -186,6 +196,156 @@ export const extractThinkspaceTurnResultText = (
 	return resultText;
 };
 
+const TOOL_PART_TYPE_PREFIX = "tool-";
+const DYNAMIC_TOOL_PART_TYPE = "dynamic-tool";
+const INCOMPLETE_TOOL_CALL_SUFFIX = " (did not complete)";
+const GENERIC_TOOL_ACTIVITY_MESSAGE = "Used another tool for this turn.";
+
+/** Matches the first line of a successful source_read result: `Source <id>: "<name>"`. */
+const SOURCE_READ_RESULT_FIRST_LINE = /^Source [^:\n]+: "(?<sourceName>.+)"$/u;
+
+const runtimeToolNameFromMessagePart = (part: ThinkspaceRuntimeMessagePart): string | null => {
+	if (part.type === DYNAMIC_TOOL_PART_TYPE) {
+		return typeof part.toolName === "string" && part.toolName ? part.toolName : null;
+	}
+
+	if (part.type.startsWith(TOOL_PART_TYPE_PREFIX)) {
+		const toolName = part.type.slice(TOOL_PART_TYPE_PREFIX.length);
+
+		return toolName || null;
+	}
+
+	return null;
+};
+
+const toolInputField = (input: unknown, field: string): string | null => {
+	if (typeof input !== "object" || input === null) {
+		return null;
+	}
+
+	const value = (input as Record<string, unknown>)[field];
+
+	return typeof value === "string" && value.trim() ? value.trim() : null;
+};
+
+const describeWebSearchActivity = (part: ThinkspaceRuntimeMessagePart): string => {
+	const query = toolInputField(part.input, "query");
+
+	return query ? `Searched the web for "${query}".` : "Searched the web.";
+};
+
+const describeWebFetchActivity = (part: ThinkspaceRuntimeMessagePart): string => {
+	const url = toolInputField(part.input, "url");
+
+	return url ? `Fetched the web page ${url}.` : "Fetched a web page.";
+};
+
+const describeSourceReadActivity = (part: ThinkspaceRuntimeMessagePart): string => {
+	if (typeof part.output === "string") {
+		const firstLine = part.output.split("\n", 1)[0] ?? "";
+		const named = SOURCE_READ_RESULT_FIRST_LINE.exec(firstLine);
+
+		const sourceName = named?.groups?.sourceName;
+
+		if (sourceName) {
+			return `Read the Source "${sourceName}".`;
+		}
+	}
+
+	const sourceId = toolInputField(part.input, "sourceId");
+
+	return sourceId ? `Tried to read Source ${sourceId}.` : "Tried to read a Source.";
+};
+
+const describeMcpToolActivity = (
+	runtimeToolName: string,
+	builtInMcpServers: readonly BuiltInMcpServer[],
+): string | null => {
+	const identity = parseCloudflareAgentsMcpToolName(
+		runtimeToolName,
+		builtInMcpServers.map((server) => server.id),
+	);
+
+	if (!identity) {
+		return null;
+	}
+
+	const server = builtInMcpServers.find((candidate) => candidate.id === identity.serverId);
+	const serverName = server?.name ?? identity.serverId;
+
+	return `Used the ${serverName} external information source: ${identity.toolName}.`;
+};
+
+const describeToolActivity = (
+	part: ThinkspaceRuntimeMessagePart,
+	builtInMcpServers: readonly BuiltInMcpServer[],
+): string | null => {
+	const runtimeToolName = runtimeToolNameFromMessagePart(part);
+
+	if (!runtimeToolName) {
+		return null;
+	}
+
+	if (runtimeToolName === "web_search") {
+		return describeWebSearchActivity(part);
+	}
+
+	if (runtimeToolName === "web_fetch") {
+		return describeWebFetchActivity(part);
+	}
+
+	if (runtimeToolName === "source_read") {
+		return describeSourceReadActivity(part);
+	}
+
+	return (
+		describeMcpToolActivity(runtimeToolName, builtInMcpServers) ?? GENERIC_TOOL_ACTIVITY_MESSAGE
+	);
+};
+
+const boundToolActivityEntry = (entry: string): string =>
+	entry.length > THINKSPACE_TURN_TOOL_ACTIVITY_ENTRY_MAX_LENGTH
+		? `${entry.slice(0, THINKSPACE_TURN_TOOL_ACTIVITY_ENTRY_MAX_LENGTH - 1)}…`
+		: entry;
+
+/**
+ * Renders the latest assistant message's tool calls as a bounded list of
+ * product-language lines — Sources read by name, searches by query, fetches
+ * by URL, external information sources by their catalog name. Raw runtime
+ * payloads and tool outputs never pass through; tools outside the known
+ * catalogs render generically.
+ */
+export const extractThinkspaceTurnToolActivity = (
+	messages: readonly ThinkspaceRuntimeMessage[],
+	builtInMcpServers: readonly BuiltInMcpServer[] = listBuiltInMcpServers(),
+): string[] => {
+	const lastAssistantMessage = messages.findLast((message) => message.role === "assistant");
+
+	if (!lastAssistantMessage) {
+		return [];
+	}
+
+	const activity: string[] = [];
+
+	for (const part of lastAssistantMessage.parts) {
+		if (activity.length >= THINKSPACE_TURN_TOOL_ACTIVITY_MAX_ENTRIES) {
+			break;
+		}
+
+		const description = describeToolActivity(part, builtInMcpServers);
+
+		if (!description) {
+			continue;
+		}
+
+		const suffix = part.state === "output-error" ? INCOMPLETE_TOOL_CALL_SUFFIX : "";
+
+		activity.push(boundToolActivityEntry(`${description}${suffix}`));
+	}
+
+	return activity;
+};
+
 const createUnknownTurnInspection = (
 	submissionId: string,
 	thinkspaceId: string,
@@ -200,6 +360,7 @@ const createUnknownTurnInspection = (
 	status: "unknown",
 	submissionId,
 	thinkspaceId,
+	toolActivity: [],
 });
 
 const createFailureMessage = (snapshot: ThinkspaceRuntimeSubmissionSnapshot): string => {
@@ -219,11 +380,13 @@ export const mapThinkspaceTurnInspection = ({
 	snapshot,
 	submissionId,
 	thinkspaceId,
+	toolActivity = [],
 }: {
 	resultText?: string | null;
 	snapshot: ThinkspaceRuntimeSubmissionSnapshot | null;
 	submissionId: string;
 	thinkspaceId: string;
+	toolActivity?: readonly string[];
 }): ThinkspaceTurnInspection => {
 	if (
 		!snapshot ||
@@ -248,6 +411,7 @@ export const mapThinkspaceTurnInspection = ({
 		startedAt: snapshot.startedAt ?? null,
 		submissionId: snapshot.submissionId,
 		thinkspaceId,
+		toolActivity: [] as readonly string[],
 	};
 
 	if (snapshot.status === "pending") {
@@ -264,6 +428,7 @@ export const mapThinkspaceTurnInspection = ({
 			message: resultText ? COMPLETED_TURN_MESSAGE : COMPLETED_WITHOUT_TEXT_MESSAGE,
 			resultText,
 			status: "completed",
+			toolActivity,
 		};
 	}
 

--- a/packages/api/src/thinkspaces/inspect.ts
+++ b/packages/api/src/thinkspaces/inspect.ts
@@ -5,6 +5,8 @@ import type { CloudflareEnv } from "@better-agent/env/types";
 import type { BuiltInMcpServer } from "../mcp/catalog";
 import { listBuiltInMcpServers } from "../mcp/catalog";
 import { parseCloudflareAgentsMcpToolName } from "../mcp/tool-identity";
+import { isBuiltInToolId, parseBuiltInSourceReadResultName } from "./built-in-tools";
+import type { BuiltInToolId } from "./built-in-tools";
 import { getThinkspace } from "./repository";
 import { resolveThinkspaceAgentRuntime, THINKSPACE_AGENT_BINDING_NAME } from "./runtime";
 import { THINKSPACE_TURN_SOURCE, ThinkspaceTurnValidationError } from "./turns";
@@ -170,6 +172,10 @@ export const extractThinkspaceTurnProductSafeFailureMessage = (error?: string): 
 	return message || GENERIC_FAILED_TURN_MESSAGE;
 };
 
+/** Bounds a product-surface string with a trailing ellipsis when it overflows. */
+const boundForRendering = (text: string, maxLength: number): string =>
+	text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
+
 export const extractThinkspaceTurnResultText = (
 	messages: readonly ThinkspaceRuntimeMessage[],
 ): string | null => {
@@ -189,20 +195,13 @@ export const extractThinkspaceTurnResultText = (
 		return null;
 	}
 
-	if (resultText.length > THINKSPACE_TURN_RESULT_TEXT_MAX_LENGTH) {
-		return `${resultText.slice(0, THINKSPACE_TURN_RESULT_TEXT_MAX_LENGTH - 1)}…`;
-	}
-
-	return resultText;
+	return boundForRendering(resultText, THINKSPACE_TURN_RESULT_TEXT_MAX_LENGTH);
 };
 
 const TOOL_PART_TYPE_PREFIX = "tool-";
 const DYNAMIC_TOOL_PART_TYPE = "dynamic-tool";
 const INCOMPLETE_TOOL_CALL_SUFFIX = " (did not complete)";
 const GENERIC_TOOL_ACTIVITY_MESSAGE = "Used another tool for this turn.";
-
-/** Matches the first line of a successful source_read result: `Source <id>: "<name>"`. */
-const SOURCE_READ_RESULT_FIRST_LINE = /^Source [^:\n]+: "(?<sourceName>.+)"$/u;
 
 const runtimeToolNameFromMessagePart = (part: ThinkspaceRuntimeMessagePart): string | null => {
 	if (part.type === DYNAMIC_TOOL_PART_TYPE) {
@@ -241,15 +240,11 @@ const describeWebFetchActivity = (part: ThinkspaceRuntimeMessagePart): string =>
 };
 
 const describeSourceReadActivity = (part: ThinkspaceRuntimeMessagePart): string => {
-	if (typeof part.output === "string") {
-		const firstLine = part.output.split("\n", 1)[0] ?? "";
-		const named = SOURCE_READ_RESULT_FIRST_LINE.exec(firstLine);
+	const sourceName =
+		typeof part.output === "string" ? parseBuiltInSourceReadResultName(part.output) : null;
 
-		const sourceName = named?.groups?.sourceName;
-
-		if (sourceName) {
-			return `Read the Source "${sourceName}".`;
-		}
+	if (sourceName) {
+		return `Read the Source "${sourceName}".`;
 	}
 
 	const sourceId = toolInputField(part.input, "sourceId");
@@ -276,6 +271,26 @@ const describeMcpToolActivity = (
 	return `Used the ${serverName} external information source: ${identity.toolName}.`;
 };
 
+const describeBuiltInToolActivity = (
+	toolId: BuiltInToolId,
+	part: ThinkspaceRuntimeMessagePart,
+): string => {
+	switch (toolId) {
+		case "web_search": {
+			return describeWebSearchActivity(part);
+		}
+		case "web_fetch": {
+			return describeWebFetchActivity(part);
+		}
+		case "source_read": {
+			return describeSourceReadActivity(part);
+		}
+		default: {
+			return GENERIC_TOOL_ACTIVITY_MESSAGE;
+		}
+	}
+};
+
 const describeToolActivity = (
 	part: ThinkspaceRuntimeMessagePart,
 	builtInMcpServers: readonly BuiltInMcpServer[],
@@ -286,27 +301,14 @@ const describeToolActivity = (
 		return null;
 	}
 
-	if (runtimeToolName === "web_search") {
-		return describeWebSearchActivity(part);
-	}
-
-	if (runtimeToolName === "web_fetch") {
-		return describeWebFetchActivity(part);
-	}
-
-	if (runtimeToolName === "source_read") {
-		return describeSourceReadActivity(part);
+	if (isBuiltInToolId(runtimeToolName)) {
+		return describeBuiltInToolActivity(runtimeToolName, part);
 	}
 
 	return (
 		describeMcpToolActivity(runtimeToolName, builtInMcpServers) ?? GENERIC_TOOL_ACTIVITY_MESSAGE
 	);
 };
-
-const boundToolActivityEntry = (entry: string): string =>
-	entry.length > THINKSPACE_TURN_TOOL_ACTIVITY_ENTRY_MAX_LENGTH
-		? `${entry.slice(0, THINKSPACE_TURN_TOOL_ACTIVITY_ENTRY_MAX_LENGTH - 1)}…`
-		: entry;
 
 /**
  * Renders the latest assistant message's tool calls as a bounded list of
@@ -338,9 +340,15 @@ export const extractThinkspaceTurnToolActivity = (
 			continue;
 		}
 
+		// Bound the description with the suffix's length reserved so a long
+		// entry never silently sheds its did-not-complete marker.
 		const suffix = part.state === "output-error" ? INCOMPLETE_TOOL_CALL_SUFFIX : "";
+		const bounded = boundForRendering(
+			description,
+			THINKSPACE_TURN_TOOL_ACTIVITY_ENTRY_MAX_LENGTH - suffix.length,
+		);
 
-		activity.push(boundToolActivityEntry(`${description}${suffix}`));
+		activity.push(`${bounded}${suffix}`);
 	}
 
 	return activity;

--- a/packages/api/src/thinkspaces/router.test.ts
+++ b/packages/api/src/thinkspaces/router.test.ts
@@ -780,15 +780,16 @@ test("owners can still submit and inspect turns through the router with the Thin
 	};
 	const inspection: ThinkspaceTurnInspection = {
 		acceptedAt: 1_717_000_000_000,
-		completedAt: null,
-		message: "Accepted. This Thinkspace Agent turn is waiting for the runtime to start it.",
+		completedAt: 1_717_000_001_000,
+		message: "Completed. Showing the Thinkspace Agent's latest model-only response.",
 		profileRevisionId: OWNED_THINKSPACE_ID,
 		profileVersion: 1,
-		resultText: null,
-		startedAt: null,
-		status: "accepted",
+		resultText: "The Thinkspace goal summary.",
+		startedAt: 1_717_000_000_500,
+		status: "completed",
 		submissionId: "submission_1",
 		thinkspaceId: OWNED_THINKSPACE_ID,
+		toolActivity: ['Read the Source "Q2 pricing notes".', 'Searched the web for "pricing".'],
 	};
 	const env = {
 		BETTER_AUTH_SECRET: "test-secret",
@@ -837,7 +838,11 @@ test("owners can still submit and inspect turns through the router with the Thin
 
 	assert.equal(submitted.status, "accepted");
 	assert.equal(submitted.submissionId, "submission_1");
-	assert.equal(inspected.status, "accepted");
+	assert.equal(inspected.status, "completed");
+	assert.deepEqual(inspected.toolActivity, [
+		'Read the Source "Q2 pricing notes".',
+		'Searched the web for "pricing".',
+	]);
 	assert.ok(runtimeNames.every((name) => name === OWNED_THINKSPACE_ID));
 });
 


### PR DESCRIPTION
## What

The last `safe_reads_v2` slice (PRD #73, user stories 25–28): the owner-gated turn inspection surface now reports which tools ran during a completed turn, in product language.

- **Tool activity extraction** (`packages/api/src/thinkspaces/inspect.ts`): `extractThinkspaceTurnToolActivity` walks the latest assistant message's tool call parts (the same messages used for the result text) and renders each in product language — `web_search` by query, `web_fetch` by URL, `source_read` by the Source's name from a successful read (requested id otherwise), and external information source (MCP) calls by the catalog server's product name via the existing `parseCloudflareAgentsMcpToolName` identity. Unrecognized tools render generically; tool inputs/outputs and runtime payloads never pass through. Calls that ended in an error state are marked "(did not complete)" without exposing the error.
- **Bounded for safe rendering**: the list is capped at 32 entries and 300 characters per entry, mirroring the result-text cap.
- **Inspection shape**: `ThinkspaceTurnInspection` gains `toolActivity`; only completed turns carry it — pending/running/failed/unknown inspections stay empty. The runtime computes it alongside the result text in `inspectTurnSubmission`.
- **UI**: the Turn status panel lists the activity under the result text.
- **Smoke checklist**: `.agents/docs/thinkspace-agent-runtime-smoke-checks.md` gains section 10 — the live built-in reads round trip (upload → enable → grant → tool loop reads Source + web → inspection shows the reads → revoke → inert, plus the cross-Thinkspace seal), with a result-record table. Live execution is a separate operator activity.

## Access posture

Non-owner and unauthenticated `inspectTurn` keep rejecting 404-first — the existing adversarial router coverage runs unchanged, and the owner round-trip test now proves a completed inspection carries its activity through the router.

## Verification

- `bun test`: 222 pass
- `bun run check-types`: clean
- `bun x ultracite check` on changed files: clean

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)