### PR TITLE
governed_tools_v3 runtime policy supersedes safe_reads_v2 (#93)

### DIFF
--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -1317,7 +1317,7 @@ const RouteComponent = () => {
 						<div className="flex items-center justify-between gap-4">
 							<p className="text-sm font-medium">Runtime safety policy</p>
 							<Badge variant="outline">
-								{runtimePolicy.mode === "read_only" ? "read-only" : runtimePolicy.mode}
+								{runtimePolicy.mode === "governed_writes" ? "governed writes" : runtimePolicy.mode}
 							</Badge>
 						</div>
 						<p className="text-muted-foreground text-sm">{runtimePolicy.message}</p>

--- a/packages/api/src/thinkspaces/runtime-policy.test.ts
+++ b/packages/api/src/thinkspaces/runtime-policy.test.ts
@@ -10,6 +10,8 @@ import {
 	isThinkspaceRuntimeCapabilityEnabled,
 	THINKSPACE_RUNTIME_CAPABILITY_IDS,
 	THINKSPACE_RUNTIME_DISABLED_CAPABILITY_IDS,
+	THINKSPACE_RUNTIME_ENABLED_CAPABILITY_IDS,
+	THINKSPACE_RUNTIME_HELD_WRITE_CAPABILITY_ID,
 	THINKSPACE_RUNTIME_POLICY,
 } from "./runtime-policy";
 
@@ -21,7 +23,7 @@ test("disables workspace Bash against the runtime default", () => {
 	);
 });
 
-test("enables only built-in read tools and disables every mutation-shaped capability", () => {
+test("enables built-in read tools plus held internal writes and disables every other mutation-shaped capability", () => {
 	const expectedCapabilityIds = [
 		"builtin_read_tools",
 		"workspace_bash",
@@ -32,21 +34,22 @@ test("enables only built-in read tools and disables every mutation-shaped capabi
 		"memory_writes",
 		"artifact_publishing",
 	];
+	const expectedEnabledCapabilityIds = ["builtin_read_tools", "memory_writes"];
 	const expectedDisabledCapabilityIds = expectedCapabilityIds.filter(
-		(id) => id !== "builtin_read_tools",
+		(id) => !expectedEnabledCapabilityIds.includes(id),
 	);
 
 	assert.deepEqual([...THINKSPACE_RUNTIME_CAPABILITY_IDS], expectedCapabilityIds);
+	assert.deepEqual([...THINKSPACE_RUNTIME_ENABLED_CAPABILITY_IDS], expectedEnabledCapabilityIds);
 	assert.deepEqual([...THINKSPACE_RUNTIME_DISABLED_CAPABILITY_IDS], expectedDisabledCapabilityIds);
 	assert.equal(THINKSPACE_RUNTIME_POLICY.capabilities.length, expectedCapabilityIds.length);
 
-	assert.equal(
-		isThinkspaceRuntimeCapabilityEnabled(THINKSPACE_RUNTIME_POLICY, "builtin_read_tools"),
-		true,
-	);
+	// The held internal write is the only mutation-shaped capability newly
+	// enabled over the read-only policy (PRD #92, #93).
+	assert.equal(THINKSPACE_RUNTIME_HELD_WRITE_CAPABILITY_ID, "memory_writes");
 
 	for (const capability of THINKSPACE_RUNTIME_POLICY.capabilities) {
-		const expectedEnabled = capability.id === "builtin_read_tools";
+		const expectedEnabled = expectedEnabledCapabilityIds.includes(capability.id);
 
 		assert.equal(
 			capability.enabled,
@@ -60,9 +63,10 @@ test("enables only built-in read tools and disables every mutation-shaped capabi
 	}
 });
 
-test("declares a read-only runtime mode with bounded step counts", () => {
-	assert.equal(THINKSPACE_RUNTIME_POLICY.mode, "read_only");
-	assert.equal(THINKSPACE_RUNTIME_POLICY.policyId, "safe_reads_v2");
+test("declares the governed-writes runtime mode with bounded step counts", () => {
+	assert.equal(THINKSPACE_RUNTIME_POLICY.mode, "governed_writes");
+	assert.equal(THINKSPACE_RUNTIME_POLICY.policyId, "governed_tools_v3");
+	assert.equal(THINKSPACE_RUNTIME_POLICY.workspaceBash, false);
 	assert.equal(THINKSPACE_RUNTIME_POLICY.maxSteps, 1);
 });
 
@@ -116,7 +120,7 @@ test("reports the runtime policy only after Thinkspace ownership is confirmed", 
 	});
 
 	assert.equal(ownerPolicy?.thinkspaceId, "thinkspace_owned");
-	assert.equal(ownerPolicy?.policyId, "safe_reads_v2");
+	assert.equal(ownerPolicy?.policyId, "governed_tools_v3");
 	assert.equal(ownerPolicy?.workspaceBash, false);
 	assert.equal(nonOwnerPolicy, null);
 	assert.deepEqual(requestedOwnershipChecks, [

--- a/packages/api/src/thinkspaces/runtime-policy.ts
+++ b/packages/api/src/thinkspaces/runtime-policy.ts
@@ -3,8 +3,8 @@ import type { Thinkspace } from "@better-agent/db/schema/thinkspaces";
 
 import { getThinkspace } from "./repository";
 
-export const THINKSPACE_RUNTIME_POLICY_ID = "safe_reads_v2" as const;
-export const THINKSPACE_RUNTIME_POLICY_MODE = "read_only" as const;
+export const THINKSPACE_RUNTIME_POLICY_ID = "governed_tools_v3" as const;
+export const THINKSPACE_RUNTIME_POLICY_MODE = "governed_writes" as const;
 export const THINKSPACE_RUNTIME_MAX_STEPS = 1 as const;
 export const THINKSPACE_RUNTIME_TOOL_MAX_STEPS = 8 as const;
 
@@ -21,9 +21,35 @@ export const THINKSPACE_RUNTIME_CAPABILITY_IDS = [
 
 export type ThinkspaceRuntimeCapabilityId = (typeof THINKSPACE_RUNTIME_CAPABILITY_IDS)[number];
 
-/** Every capability except built-in read-only tools stays disabled (PRD #73). */
+/**
+ * The held-internal-write capability class — the single mutation-shaped
+ * capability `governed_tools_v3` newly enables over `safe_reads_v2` (PRD #92,
+ * #93). The agent may propose a durable Product Memory, but the proposal is
+ * held for the owner's Approval before it takes effect; the capability being
+ * enabled never lets a write execute on its own.
+ */
+export const THINKSPACE_RUNTIME_HELD_WRITE_CAPABILITY_ID = "memory_writes" as const;
+
+/**
+ * `governed_tools_v3` keeps built-in read tools enabled and adds exactly one
+ * capability class — held internal writes — over the read-only `safe_reads_v2`.
+ * Every other mutation-shaped capability stays disabled (PRD #92, #93).
+ */
+export const THINKSPACE_RUNTIME_ENABLED_CAPABILITY_IDS = [
+	"builtin_read_tools",
+	THINKSPACE_RUNTIME_HELD_WRITE_CAPABILITY_ID,
+] as const;
+
+const ENABLED_CAPABILITY_ID_SET: ReadonlySet<ThinkspaceRuntimeCapabilityId> = new Set(
+	THINKSPACE_RUNTIME_ENABLED_CAPABILITY_IDS,
+);
+
+const isCapabilityEnabledByPolicy = (id: ThinkspaceRuntimeCapabilityId): boolean =>
+	ENABLED_CAPABILITY_ID_SET.has(id);
+
+/** Every capability outside the enabled set stays disabled (PRD #92, #93). */
 export const THINKSPACE_RUNTIME_DISABLED_CAPABILITY_IDS = THINKSPACE_RUNTIME_CAPABILITY_IDS.filter(
-	(id) => id !== "builtin_read_tools",
+	(id) => !isCapabilityEnabledByPolicy(id),
 );
 
 export interface ThinkspaceRuntimeCapability {
@@ -75,13 +101,13 @@ const CAPABILITY_LABELS: Record<ThinkspaceRuntimeCapabilityId, string> = {
 
 export const THINKSPACE_RUNTIME_POLICY: ThinkspaceRuntimePolicy = {
 	capabilities: THINKSPACE_RUNTIME_CAPABILITY_IDS.map((id) => ({
-		enabled: id === "builtin_read_tools",
+		enabled: isCapabilityEnabledByPolicy(id),
 		id,
 		label: CAPABILITY_LABELS[id],
 	})),
 	maxSteps: THINKSPACE_RUNTIME_MAX_STEPS,
 	message:
-		"This Thinkspace Agent can read but never mutate: built-in read-only tools are the only enabled capability, and each tool still requires enablement on the active Agent Profile revision plus a potent Permission verdict.",
+		"This Thinkspace Agent can read freely and may propose a durable Product Memory, but every write is held for your Approval before it takes effect: built-in read-only tools and held Memory writes are the only enabled capabilities, and each still requires enablement on the active Agent Profile revision plus a potent Permission verdict.",
 	mode: THINKSPACE_RUNTIME_POLICY_MODE,
 	policyId: THINKSPACE_RUNTIME_POLICY_ID,
 	workspaceBash: false,


### PR DESCRIPTION
Closes #93. First unblocked slice of PRD #92 (`governed_tools_v3` — the Approval holdpoint and Review Queue).

## What this does

Replaces `safe_reads_v2` with **`governed_tools_v3`** as the single runtime policy applied to every Thinkspace Agent turn. The policy keeps built-in read tools enabled and declares exactly one new capability class — **held internal writes** — without constructing or running any held tool yet. The gate opens; nothing walks through it.

## Changes

- **`packages/api/src/thinkspaces/runtime-policy.ts`**: policy id `safe_reads_v2` → `governed_tools_v3`, mode `read_only` → `governed_writes`. Adds `THINKSPACE_RUNTIME_HELD_WRITE_CAPABILITY_ID` (`memory_writes`) and `THINKSPACE_RUNTIME_ENABLED_CAPABILITY_IDS`; enabled/disabled sets derive from one source. Workspace bash stays explicitly `false`; toolset stays empty and `maxSteps` stays `1`. Updated product-language message.
- **`apps/web/src/routes/thinkspaces.$thinkspaceId.tsx`**: renders the new mode as "governed writes"; the per-capability list shows Product Memory writes as enabled.
- **`packages/api/src/thinkspaces/runtime-policy.test.ts`**: policy-constant assertions updated to the new id/mode/enabled-set, following the existing `safe_reads_v2` suite.

## Acceptance criteria (#93)

- [x] Runtime policy reports id `governed_tools_v3` and its mode
- [x] Held-internal-write capability class exists and is the only newly enabled capability; built-in reads stay enabled; all other mutation-shaped capabilities disabled
- [x] Workspace bash remains explicitly forced off and asserted in tests
- [x] Runtime toolset and turn-assembly output unchanged for revisions with no potent held tool
- [x] Thinkspace detail surface renders the new mode in product language
- [x] Policy tests assert the new constants
- [x] Type checks, Ultracite checks, and package test suites pass

## Verification

- `bun test packages/api` → 221 pass, 0 fail
- `@better-agent/api` type-check → clean
- Ultracite check on changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)