### PR TITLE
Memory writing becomes an enable-and-grantable Thinkspace capability (#94)

### DIFF
--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -34,7 +34,7 @@ interface EnabledToolSelection {
 
 type McpToolAccessScopeView = { type: "server" } | { toolName: string; type: "tool" };
 
-type BuiltInToolId = "web_search" | "web_fetch" | "source_read";
+type BuiltInToolId = "web_search" | "web_fetch" | "source_read" | "memory_write";
 
 interface BuiltInToolView {
 	description: string;
@@ -59,6 +59,12 @@ const BUILT_IN_TOOLS: readonly BuiltInToolView[] = [
 		id: "source_read",
 		name: "Source reading",
 	},
+	{
+		description:
+			"Propose a durable Product Memory, held for your Approval before it takes effect. Potent only with the Memory writing Permission.",
+		id: "memory_write",
+		name: "Memory writing",
+	},
 ];
 
 const isBuiltInToolId = (value: string): value is BuiltInToolId =>
@@ -68,6 +74,7 @@ interface PermissionRequestView {
 	actions?: string[];
 	approvalRequired?: boolean;
 	kind?:
+		| "built_in_memory_write"
 		| "built_in_source_read"
 		| "built_in_web_read"
 		| "mcp_tool_access"
@@ -199,6 +206,10 @@ const getPermissionRequestTitle = (permission: PermissionRequestView, index: num
 		return "Source reading (built-in)";
 	}
 
+	if (permission.kind === "built_in_memory_write") {
+		return "Memory writing (built-in)";
+	}
+
 	if (permission.kind === "model_provider_credential") {
 		return `Model credential: ${permission.providerId}`;
 	}
@@ -230,6 +241,10 @@ const getGrantedPermissionTitle = (permission: GrantedPermissionView): string =>
 
 	if (permission.kind === "built_in_source_read") {
 		return "Source reading (built-in)";
+	}
+
+	if (permission.kind === "built_in_memory_write") {
+		return "Memory writing (built-in)";
 	}
 
 	if (permission.kind === "mcp_tool_access") {

--- a/packages/api/src/thinkspaces/agent-profile.ts
+++ b/packages/api/src/thinkspaces/agent-profile.ts
@@ -128,14 +128,16 @@ export interface McpToolAccessPermissionRequest {
 export const BUILT_IN_TOOL_PERMISSION_REQUEST_KINDS = [
 	"built_in_source_read",
 	"built_in_web_read",
+	"built_in_memory_write",
 ] as const;
 export type BuiltInToolPermissionRequestKind =
 	(typeof BUILT_IN_TOOL_PERMISSION_REQUEST_KINDS)[number];
 
 /**
- * A request for one of the built-in read tool Permission kinds: web reading
- * (search and fetch together) or Source reading. The kind itself names the
- * governed resource, so no extra scope payload is carried.
+ * A request for one of the built-in tool Permission kinds: web reading
+ * (search and fetch together), Source reading, or held Memory writing. The
+ * kind itself names the governed resource, so no extra scope payload is
+ * carried.
  */
 export interface BuiltInToolAccessPermissionRequest {
 	kind: BuiltInToolPermissionRequestKind;

--- a/packages/api/src/thinkspaces/built-in-tools.ts
+++ b/packages/api/src/thinkspaces/built-in-tools.ts
@@ -1,5 +1,5 @@
 /**
- * The built-in read tool catalog.
+ * The built-in tool catalog.
  *
  * Built-ins are a first-class tool source in the existing enablement scheme:
  * an Agent Profile revision makes one present with a stable tool id, and a
@@ -7,12 +7,22 @@
  * search and web fetch share one Permission kind (web reading); Source
  * reading has its own, so the user can let the agent read their material
  * without letting it touch the public web, and vice versa (PRD #73).
+ *
+ * `memory_write` is the first non-read built-in: a held tool that proposes a
+ * durable Product Memory for the owner's Approval, governed by its own
+ * Permission kind (PRD #92). It rides the identical enable → request → grant →
+ * potency path; the held execution itself arrives in a later slice.
  */
 import { THINKSPACE_PERMISSION_KINDS } from "@better-agent/db/schema/permissions";
 
 import type { BuiltInToolAccessPermissionRequest } from "./agent-profile";
 
-export const BUILT_IN_TOOL_IDS = ["web_search", "web_fetch", "source_read"] as const;
+export const BUILT_IN_TOOL_IDS = [
+	"web_search",
+	"web_fetch",
+	"source_read",
+	"memory_write",
+] as const;
 
 export type BuiltInToolId = (typeof BUILT_IN_TOOL_IDS)[number];
 
@@ -39,6 +49,7 @@ export const parseBuiltInSourceReadResultName = (output: string): string | null 
 };
 
 export type BuiltInToolPermissionKind =
+	| typeof THINKSPACE_PERMISSION_KINDS.BUILT_IN_MEMORY_WRITE
 	| typeof THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ
 	| typeof THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ;
 
@@ -55,10 +66,16 @@ export const builtInToolPermissionKind = (toolId: string): BuiltInToolPermission
 		return THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ;
 	}
 
+	if (toolId === "memory_write") {
+		return THINKSPACE_PERMISSION_KINDS.BUILT_IN_MEMORY_WRITE;
+	}
+
 	return null;
 };
 
 const BUILT_IN_PERMISSION_REASONS: Record<BuiltInToolPermissionKind, string> = {
+	[THINKSPACE_PERMISSION_KINDS.BUILT_IN_MEMORY_WRITE]:
+		"Allow this Thinkspace Agent to propose durable Product Memory, held for your Approval.",
 	[THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ]:
 		"Allow this Thinkspace Agent to read this Thinkspace's Sources.",
 	[THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ]:

--- a/packages/api/src/thinkspaces/permission-policy.test.ts
+++ b/packages/api/src/thinkspaces/permission-policy.test.ts
@@ -64,18 +64,24 @@ test("MCP toolIds resolve to their server id at both server and tool scope", () 
 	assert.equal(mcpServerIdFromToolId("cloudflare-docs:search_docs"), "cloudflare-docs");
 });
 
+const BUILT_IN_GRANT_PROVIDER_ID = {
+	[THINKSPACE_PERMISSION_KINDS.BUILT_IN_MEMORY_WRITE]: "memory",
+	[THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ]: "sources",
+	[THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ]: "web",
+} as const;
+
+type BuiltInGrantKind = keyof typeof BUILT_IN_GRANT_PROVIDER_ID;
+
 const grantBuiltInPermission = async (
 	db: ProductDb,
-	kind:
-		| typeof THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ
-		| typeof THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ,
+	kind: BuiltInGrantKind,
 	thinkspaceId = THINKSPACE_ID,
 ) => {
 	await db.insert(thinkspacePermissions).values({
 		grantedByUserId: OWNER_USER_ID,
 		id: `thinkspace_permission_${kind}_${thinkspaceId}`,
 		kind,
-		providerId: kind === THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ ? "web" : "sources",
+		providerId: BUILT_IN_GRANT_PROVIDER_ID[kind],
 		thinkspaceId,
 	});
 };
@@ -128,16 +134,60 @@ test("unknown built-in tool ids stay inert even with every built-in grant presen
 	const db = await createSeededDb();
 	await grantBuiltInPermission(db, THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ);
 	await grantBuiltInPermission(db, THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ);
+	await grantBuiltInPermission(db, THINKSPACE_PERMISSION_KINDS.BUILT_IN_MEMORY_WRITE);
 
 	const verdicts = await evaluate(db, [
 		{ source: "built_in", toolId: "workspace_bash" },
-		{ source: "built_in", toolId: "memory_write" },
+		{ source: "built_in", toolId: "workspace_mutate" },
 	]);
 
 	assert.deepEqual(verdicts, [
 		{ potency: "inert", toolId: "workspace_bash" },
-		{ potency: "inert", toolId: "memory_write" },
+		{ potency: "inert", toolId: "workspace_mutate" },
 	]);
+});
+
+test("memory_write is inert with no stored grant: enabling the held tool alone confers nothing", async () => {
+	const db = await createSeededDb();
+
+	const verdicts = await evaluate(db, [{ source: "built_in", toolId: "memory_write" }]);
+
+	assert.deepEqual(verdicts, [{ potency: "inert", toolId: "memory_write" }]);
+});
+
+test("a granted Memory writing Permission makes memory_write potent but never the read tools", async () => {
+	const db = await createSeededDb();
+	await grantBuiltInPermission(db, THINKSPACE_PERMISSION_KINDS.BUILT_IN_MEMORY_WRITE);
+
+	const verdicts = await evaluate(db, [
+		{ source: "built_in", toolId: "memory_write" },
+		...ALL_BUILT_IN_ENABLEMENTS,
+	]);
+
+	assert.deepEqual(verdicts, [
+		{ potency: "potent", toolId: "memory_write" },
+		{ potency: "inert", toolId: "web_search" },
+		{ potency: "inert", toolId: "web_fetch" },
+		{ potency: "inert", toolId: "source_read" },
+	]);
+});
+
+test("a revoked Memory writing grant makes the still-enabled memory_write inert on the next evaluation", async () => {
+	const db = await createSeededDb();
+	await grantBuiltInPermission(db, THINKSPACE_PERMISSION_KINDS.BUILT_IN_MEMORY_WRITE);
+
+	const enablements: ToolEnablement[] = [{ source: "built_in", toolId: "memory_write" }];
+	const granted = await evaluate(db, enablements);
+	assert.deepEqual(granted, [{ potency: "potent", toolId: "memory_write" }]);
+
+	const revokedGrant = await revokeThinkspacePermission(db, {
+		permissionId: `thinkspace_permission_${THINKSPACE_PERMISSION_KINDS.BUILT_IN_MEMORY_WRITE}_${THINKSPACE_ID}`,
+		thinkspaceId: THINKSPACE_ID,
+	});
+	assert.ok(revokedGrant);
+
+	const revoked = await evaluate(db, enablements);
+	assert.deepEqual(revoked, [{ potency: "inert", toolId: "memory_write" }]);
 });
 
 test("built-in grants are Thinkspace-scoped: another Thinkspace's grant never leaks", async () => {

--- a/packages/api/src/thinkspaces/permission-policy.ts
+++ b/packages/api/src/thinkspaces/permission-policy.ts
@@ -10,11 +10,12 @@
  *
  * Decision rule (fails closed): built-in enablements are potent only with a
  * granted Permission of their governing kind — web reading for web search
- * and fetch, Source reading for the Source read tool (PRD #73 superseded the
- * earlier enablement-alone rule for built-ins). MCP-source enablements are
- * potent only with a matching granted MCP tool access Permission. Connected
- * Account and Local Node sources, and built-in tool ids the catalog does not
- * know, are unconditionally inert.
+ * and fetch, Source reading for the Source read tool, Memory writing for the
+ * held Memory-proposing tool (PRD #73 superseded the earlier enablement-alone
+ * rule for built-ins; PRD #92 added the held Memory write). MCP-source
+ * enablements are potent only with a matching granted MCP tool access
+ * Permission. Connected Account and Local Node sources, and built-in tool ids
+ * the catalog does not know, are unconditionally inert.
  */
 import type { ProductDb } from "@better-agent/db";
 import {
@@ -115,6 +116,7 @@ export const createMemoryPermissionPolicy = (
 });
 
 const BUILT_IN_GRANT_KINDS: readonly BuiltInToolPermissionKind[] = [
+	THINKSPACE_PERMISSION_KINDS.BUILT_IN_MEMORY_WRITE,
 	THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ,
 	THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ,
 ];

--- a/packages/api/src/thinkspaces/permissions.test.ts
+++ b/packages/api/src/thinkspaces/permissions.test.ts
@@ -76,6 +76,22 @@ test("model-provider credential requests still convert into credential grants", 
 	assert.equal(grant?.resourceScope, JSON.stringify({ type: "model_provider" }));
 });
 
+test("held Memory writing requests convert into a Memory writing grant with a stable scope", () => {
+	const grant = toThinkspacePermissionGrant({
+		grantedByUserId: OWNER_USER_ID,
+		permission: {
+			kind: THINKSPACE_PERMISSION_KINDS.BUILT_IN_MEMORY_WRITE,
+			reason:
+				"Allow this Thinkspace Agent to propose durable Product Memory, held for your Approval.",
+		},
+		thinkspaceId: THINKSPACE_ID,
+	});
+
+	assert.equal(grant?.kind, THINKSPACE_PERMISSION_KINDS.BUILT_IN_MEMORY_WRITE);
+	assert.equal(grant?.providerId, "memory");
+	assert.equal(grant?.resourceScope, JSON.stringify({ type: "memory_write" }));
+});
+
 test("grantable MCP requests convert into MCP tool access grants with explicit scope", () => {
 	const grant = toThinkspacePermissionGrant(grantInput(), {
 		builtInMcpServers: [readOnlyAuthFreeServer],

--- a/packages/api/src/thinkspaces/permissions.ts
+++ b/packages/api/src/thinkspaces/permissions.ts
@@ -48,14 +48,17 @@ const MODEL_PROVIDER_SCOPE = JSON.stringify({ type: "model_provider" });
 /**
  * Grant rows live on the (thinkspaceId, kind, providerId) unique index, so
  * each built-in kind gets a stable resource identity: the web for web
- * reading, this Thinkspace's Sources for Source reading.
+ * reading, this Thinkspace's Sources for Source reading, this Thinkspace's
+ * Memory for held Memory writing.
  */
 const BUILT_IN_GRANT_PROVIDER_IDS = {
+	built_in_memory_write: "memory",
 	built_in_source_read: "sources",
 	built_in_web_read: "web",
 } as const satisfies Record<BuiltInToolAccessPermissionRequest["kind"], string>;
 
 const BUILT_IN_GRANT_SCOPES = {
+	built_in_memory_write: JSON.stringify({ type: "memory_write" }),
 	built_in_source_read: JSON.stringify({ type: "source_read" }),
 	built_in_web_read: JSON.stringify({ type: "web_read" }),
 } as const satisfies Record<BuiltInToolAccessPermissionRequest["kind"], string>;
@@ -63,6 +66,7 @@ const BUILT_IN_GRANT_SCOPES = {
 const isBuiltInToolPermissionRequest = (
 	permission: RequestedPermission,
 ): permission is BuiltInToolAccessPermissionRequest =>
+	permission.kind === THINKSPACE_PERMISSION_KINDS.BUILT_IN_MEMORY_WRITE ||
 	permission.kind === THINKSPACE_PERMISSION_KINDS.BUILT_IN_SOURCE_READ ||
 	permission.kind === THINKSPACE_PERMISSION_KINDS.BUILT_IN_WEB_READ;
 

--- a/packages/api/src/thinkspaces/router.test.ts
+++ b/packages/api/src/thinkspaces/router.test.ts
@@ -621,6 +621,96 @@ test("revoking a built-in Permission flips the tool inert on the next read witho
 	assert.deepEqual(revisionsAfter, revisionsBefore);
 });
 
+test("enabling the held Memory writing tool writes a built_in enablement and its Permission request", async () => {
+	const { db, saved } = createDbForAgentProfileDraftUpdate(
+		ownedThinkspaceRow({ ...ownedAgentProfileColumns("draft"), status: "draft" }),
+	);
+	const context = createCallContext({ db });
+
+	const updated = await call(
+		thinkspacesRouter.updateToolSelections,
+		{
+			builtInToolIds: ["memory_write"],
+			selections: [],
+			thinkspaceId: OWNED_THINKSPACE_ID,
+		},
+		{ context },
+	);
+
+	assert.ok(updated);
+	assert.deepEqual(JSON.parse(String(saved[0]?.toolEnablements)), [
+		{ source: "built_in", toolId: "memory_write" },
+	]);
+
+	const requests = JSON.parse(String(saved[0]?.requestedPermissions)) as { kind: string }[];
+	assert.deepEqual(
+		requests.map((request) => request.kind).toSorted((left, right) => left.localeCompare(right)),
+		["built_in_memory_write", "model_provider_credential"],
+	);
+});
+
+test("granting then revoking Memory writing flips memory_write potent then inert without touching revisions", async () => {
+	const db = createTestProductDb();
+	await seedRealThinkspaceWithProfile({
+		db,
+		requestedPermissions: [
+			{
+				kind: "built_in_memory_write",
+				reason: "Propose durable Product Memory, held for Approval.",
+			},
+		],
+		toolEnablements: [{ source: "built_in", toolId: "memory_write" }],
+	});
+
+	const activation = await call(
+		thinkspacesRouter.activateAgentProfile,
+		{ grantedPermissionIndexes: [0], thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+
+	assert.ok(activation);
+	assert.equal(activation.grantedPermissions.length, 1);
+	const [memoryGrant] = activation.grantedPermissions;
+	assert.equal(memoryGrant?.kind, "built_in_memory_write");
+	assert.equal(memoryGrant?.providerId, "memory");
+	assert.equal(memoryGrant?.resourceScope, JSON.stringify({ type: "memory_write" }));
+
+	const granted = await call(
+		thinkspacesRouter.get,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+	assert.deepEqual(granted.enabledToolPotencies, [
+		{ potency: "potent", source: "built_in", toolId: "memory_write" },
+	]);
+
+	const revisionsBefore = await db
+		.select()
+		.from(thinkspaceAgentProfiles)
+		.where(eq(thinkspaceAgentProfiles.thinkspaceId, OWNED_THINKSPACE_ID));
+
+	await call(
+		thinkspacesRouter.revokePermission,
+		{ permissionId: String(memoryGrant?.id), thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+
+	const revoked = await call(
+		thinkspacesRouter.get,
+		{ thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+	const revisionsAfter = await db
+		.select()
+		.from(thinkspaceAgentProfiles)
+		.where(eq(thinkspaceAgentProfiles.thinkspaceId, OWNED_THINKSPACE_ID));
+
+	assert.deepEqual(revoked.enabledToolPotencies, [
+		{ potency: "inert", source: "built_in", toolId: "memory_write" },
+	]);
+	assert.deepEqual(revisionsAfter, revisionsBefore);
+});
+
 test("Agent Profile activation rejects archived Thinkspaces before writes", async () => {
 	const { db, patches } = createDbForAgentProfileActivation(
 		ownedThinkspaceRow({ status: "archived" }),

--- a/packages/db/src/schema/permissions.ts
+++ b/packages/db/src/schema/permissions.ts
@@ -5,6 +5,13 @@ import { timestampMsNow } from "./common";
 import { thinkspaces } from "./thinkspaces";
 
 export const THINKSPACE_PERMISSION_KINDS = {
+	/**
+	 * Governs the held built-in Memory-proposing tool for one Thinkspace.
+	 * Distinct from the read kinds: it allows the agent to *propose* a durable
+	 * Product Memory, which is held for the owner's Approval before it takes
+	 * effect (PRD #92).
+	 */
+	BUILT_IN_MEMORY_WRITE: "built_in_memory_write",
 	/** Governs the built-in Source reading tool for one Thinkspace. */
 	BUILT_IN_SOURCE_READ: "built_in_source_read",
 	/** Governs built-in web reading — search and fetch together. */


### PR DESCRIPTION
Closes #94. Second slice of PRD #92 (`governed_tools_v3` — the Approval holdpoint and Review Queue). Blocked-by #93 (merged).

## What this does

Makes Memory writing an **enable-and-grantable capability**, mirroring how built-in read tools and MCP tools became grantable. The held Memory-proposing tool rides the identical `enable → request → grant → potency` path. **No held tool executes in this slice** — enablement plus grant only establishes potency; the held execution arrives in #95.

## Changes

- **`packages/db/src/schema/permissions.ts`**: new Permission kind `BUILT_IN_MEMORY_WRITE` (`built_in_memory_write`), distinct from the built-in read and MCP kinds. (No migration: `kind` is a plain `text` column with no CHECK constraint.)
- **`packages/api/src/thinkspaces/built-in-tools.ts`**: `memory_write` added to the built-in catalog; `builtInToolPermissionKind` maps it to the new kind; reason added.
- **`packages/api/src/thinkspaces/agent-profile.ts`**: `built_in_memory_write` added to the built-in Permission request kinds.
- **`packages/api/src/thinkspaces/permissions.ts`**: grant conversion gains the new kind — resource identity `memory`, scope `{type:"memory_write"}`.
- **`packages/api/src/thinkspaces/permission-policy.ts`**: the store-backed potency policy recognizes the new grant kind (enabled ∩ granted = potent).
- **`apps/web/src/routes/thinkspaces.$thinkspaceId.tsx`**: the Memory writing capability appears in the built-in tool list and the permission request/grant titles; its potency renders alongside existing tools.

The router (`updateToolSelections`, `activateAgentProfile`, `revokePermission`, `get`) needed no changes — it is catalog-driven, so the new tool id flows through automatically.

## Acceptance criteria (#94)

- [x] New Permission kind governs Memory writing, distinct from built-in read and MCP kinds
- [x] Enabling on a draft records a pending Permission request; activation grants it explicitly
- [x] Enable without a matching grant leaves the capability inert
- [x] Revoking at the Thinkspace level makes it inert on the next turn with no Profile change
- [x] Detail / inspect surfaces show the Memory capability's potency
- [x] Potency-intersection tests mirror the existing MCP / built-in suite
- [x] Type checks, Ultracite checks, and package test suites pass

## Verification

- `bun test packages/api` → 227 pass, 0 fail (+6 new)
- `turbo check-types` (api, ui, server) → clean
- Ultracite check on changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)