### PR TITLE
Add the Memory Approval holdpoint to the Thinkspace runtime (#95)

### DIFF
--- a/apps/server/src/agents/thinkspace-agent.ts
+++ b/apps/server/src/agents/thinkspace-agent.ts
@@ -22,6 +22,25 @@ import {
 	THINKSPACE_BUILT_IN_TOOL_BLOCKED_REASON,
 } from "@better-agent/api/thinkspaces/built-in-runtime-tools";
 import { createFetchWebReader } from "@better-agent/api/thinkspaces/web-reader";
+import {
+	extractPendingMemoryApprovals,
+	extractResolvedMemoryApprovals,
+	flipMemoryApprovalInTranscript,
+	summarizeMemoryProposal,
+} from "@better-agent/api/thinkspaces/approvals";
+import {
+	getThinkspaceApproval,
+	listPendingThinkspaceApprovals,
+	resolveThinkspaceApproval,
+	upsertPendingThinkspaceApproval,
+} from "@better-agent/api/thinkspaces/approvals-repository";
+import { validateThinkspaceApprovalId } from "@better-agent/api/thinkspaces/approval-decisions";
+import type {
+	ThinkspaceMemoryApprovalDecisionRequest,
+	ThinkspaceMemoryApprovalDecisionResult,
+} from "@better-agent/api/thinkspaces/approval-decisions";
+import { createThinkspaceMemoryWriter } from "@better-agent/api/thinkspaces/memory-writer";
+import { THINKSPACE_APPROVAL_ACTION_KIND } from "@better-agent/db/schema/approvals";
 import { createThinkspaceSourceReader } from "@better-agent/api/sources/reader";
 import {
 	createThinkspaceMcpDegradationNotice,
@@ -48,6 +67,7 @@ import {
 	SITTING_FORWARD_CONTEXT_HEADER,
 	SITTING_TURN_ATTRIBUTION_STORAGE_KEY,
 } from "@better-agent/api/thinkspaces/sittings";
+import type { ThinkspaceTurnAttribution } from "@better-agent/api/thinkspaces/sittings";
 import {
 	bindThinkspaceTurnRuntimeContext,
 	matchesThinkspaceTurnRuntimeContext,
@@ -218,6 +238,97 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 		});
 	}
 
+	/**
+	 * Decides one pending Memory Approval out-of-band: the same apply-and-continue
+	 * path an inline Sitting approval drives, invoked from the control plane. The
+	 * decision flips the parked tool part to `approval-responded` in place and
+	 * resumes the turn — on approval the held tool's `execute` finally runs and
+	 * writes the Memory; on rejection it never runs and nothing persists. The
+	 * runtime is authoritative: a forged or mismatched context, an Approval that
+	 * is unknown, already decided, or no longer parked, all resolve to
+	 * `not_found` so the control plane can render the sealed 404.
+	 */
+	async decideMemoryApproval(
+		request: ThinkspaceMemoryApprovalDecisionRequest,
+	): Promise<ThinkspaceMemoryApprovalDecisionResult> {
+		const approvalId = validateThinkspaceApprovalId(request.approvalId);
+		const notFound: ThinkspaceMemoryApprovalDecisionResult = {
+			approvalId,
+			decision: request.decision,
+			status: "not_found",
+			thinkspaceId: request.thinkspaceId,
+		};
+
+		const turnContext =
+			await this.ctx.storage.get<ThinkspaceTurnRuntimeContext>(TURN_CONTEXT_STORAGE_KEY);
+
+		if (
+			!turnContext ||
+			turnContext.thinkspaceId !== request.thinkspaceId ||
+			turnContext.ownerUserId !== request.ownerUserId
+		) {
+			return notFound;
+		}
+
+		const db = createDb(this.env.DB);
+		const approval = await getThinkspaceApproval(db, {
+			approvalId,
+			thinkspaceId: request.thinkspaceId,
+		});
+
+		if (
+			!approval ||
+			approval.status !== "pending" ||
+			approval.actionKind !== THINKSPACE_APPROVAL_ACTION_KIND.MEMORY_WRITE
+		) {
+			return notFound;
+		}
+
+		const messages = await this.getMessages();
+		const flip = flipMemoryApprovalInTranscript({
+			decision: request.decision,
+			messages,
+			reason: request.reason,
+			toolCallId: approval.toolCallId,
+		});
+
+		if (!flip.flipped) {
+			return notFound;
+		}
+
+		// Persist the single flipped message in place (never append — that would
+		// duplicate the transcript), then resolve the index row before resuming.
+		// The decision is final once the transcript records it; resuming only
+		// fires its consequence, which the held tool's idempotent write absorbs.
+		for (const [index, message] of messages.entries()) {
+			const flippedMessage = flip.messages[index];
+
+			if (flippedMessage && message !== flippedMessage) {
+				await this.updateMessageInHistory(flippedMessage);
+			}
+		}
+
+		const resolved = await resolveThinkspaceApproval(db, {
+			approvalId,
+			resolvedAt: new Date(),
+			status: request.decision,
+			thinkspaceId: request.thinkspaceId,
+		});
+
+		if (!resolved) {
+			return notFound;
+		}
+
+		await this.continueLastTurn();
+
+		return {
+			approvalId,
+			decision: request.decision,
+			status: "applied",
+			thinkspaceId: request.thinkspaceId,
+		};
+	}
+
 	override getModel(): LanguageModel {
 		return this.turnModelPlaceholder;
 	}
@@ -246,11 +357,11 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 		// Submitted turns also carry it in their submission metadata; Sitting turns
 		// do not pass through the ledger, so this preserves the activation-history
 		// guarantee (every turn is attributable to the revision it ran under)
-		// regardless of entry path, for the future Audit Trail.
-		await this.ctx.storage.put(
-			SITTING_TURN_ATTRIBUTION_STORAGE_KEY,
-			createThinkspaceTurnAttribution(resolved.activeRevision),
-		);
+		// regardless of entry path, for the future Audit Trail. The same
+		// attribution is stamped onto any Memory a held proposal writes and onto
+		// the pending Approval a held proposal raises.
+		const attribution = createThinkspaceTurnAttribution(resolved.activeRevision);
+		await this.ctx.storage.put(SITTING_TURN_ATTRIBUTION_STORAGE_KEY, attribution);
 
 		const toolPotencies = await ThinkspaceAgent.evaluateToolPotencies(
 			permissionPolicy,
@@ -268,6 +379,11 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 
 		const builtInPreparation = await prepareThinkspaceBuiltInRuntimeTools({
 			activeProductToolIds: assembly.activeTools,
+			memoryWriter: createThinkspaceMemoryWriter({
+				attribution,
+				db,
+				thinkspaceId: turnContext.thinkspaceId,
+			}),
 			sourceReader: createThinkspaceSourceReader({
 				db,
 				env: this.env,
@@ -377,6 +493,7 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 	override async onChatResponse(result: ChatResponseResult): Promise<void> {
 		try {
 			await this.cleanupTurnMcpServers();
+			await this.reconcilePendingApprovals();
 		} finally {
 			await super.onChatResponse(result);
 		}
@@ -401,6 +518,77 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 		this.turnMcpServerIds.add(result.id);
 
 		return this.mcp.getAITools({ serverId: result.id, state: "ready" });
+	}
+
+	/**
+	 * Mirrors the parked-turn transcript into the D1 Approval index after every
+	 * turn: a held proposal still awaiting a decision is upserted as a pending
+	 * Approval (idempotent on its tool call id), and any held proposal the
+	 * transcript already shows as decided is resolved out of the queue (covering
+	 * a decision applied through another surface). Best-effort: the transcript in
+	 * the Durable Object stays authoritative, so an indexing failure never breaks
+	 * the turn.
+	 */
+	private async reconcilePendingApprovals(): Promise<void> {
+		try {
+			const turnContext =
+				await this.ctx.storage.get<ThinkspaceTurnRuntimeContext>(TURN_CONTEXT_STORAGE_KEY);
+
+			if (!turnContext) {
+				return;
+			}
+
+			const attribution = await this.ctx.storage.get<ThinkspaceTurnAttribution>(
+				SITTING_TURN_ATTRIBUTION_STORAGE_KEY,
+			);
+			const messages = await this.getMessages();
+			const db = createDb(this.env.DB);
+
+			for (const pending of extractPendingMemoryApprovals(messages)) {
+				await upsertPendingThinkspaceApproval(db, {
+					record: {
+						actionKind: THINKSPACE_APPROVAL_ACTION_KIND.MEMORY_WRITE,
+						approvalRequestId: pending.approvalRequestId,
+						id: `approval_${crypto.randomUUID()}`,
+						ownerUserId: turnContext.ownerUserId,
+						profileRevisionId: attribution?.profileRevisionId ?? null,
+						profileVersion: attribution?.profileVersion ?? null,
+						proposedContent: pending.content,
+						proposedSummary: summarizeMemoryProposal(pending.content),
+						submissionId: null,
+						thinkspaceId: turnContext.thinkspaceId,
+						toolCallId: pending.toolCallId,
+					},
+				});
+			}
+
+			const resolvedProposals = extractResolvedMemoryApprovals(messages);
+
+			if (resolvedProposals.length === 0) {
+				return;
+			}
+
+			const pendingRows = await listPendingThinkspaceApprovals(db, {
+				thinkspaceId: turnContext.thinkspaceId,
+			});
+			const rowByToolCall = new Map(pendingRows.map((row) => [row.toolCallId, row]));
+			const resolvedAt = new Date();
+
+			for (const resolution of resolvedProposals) {
+				const row = rowByToolCall.get(resolution.toolCallId);
+
+				if (row) {
+					await resolveThinkspaceApproval(db, {
+						approvalId: row.id,
+						resolvedAt,
+						status: resolution.status,
+						thinkspaceId: turnContext.thinkspaceId,
+					});
+				}
+			}
+		} catch {
+			// Best-effort index reconciliation; the transcript stays authoritative.
+		}
 	}
 
 	private async cleanupTurnMcpServers(): Promise<void> {

--- a/packages/api/src/approvals/router.test.ts
+++ b/packages/api/src/approvals/router.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+import { user } from "@better-agent/db/schema/auth";
+import { thinkspaceApprovals } from "@better-agent/db/schema/approvals";
+import { thinkspaces } from "@better-agent/db/schema/thinkspaces";
+import { call } from "@orpc/server";
+
+import type { Context } from "../context";
+import { createTestProductDb } from "../testing/product-db";
+import type { ThinkspaceMemoryApprovalDecisionResult } from "../thinkspaces/approval-decisions";
+import { approvalsRouter } from "./router";
+
+const OWNED_THINKSPACE_ID = "thinkspace_owned";
+
+const authenticatedSession = { session: { id: "session_1" }, user: { id: "owner_user" } };
+const nonOwnerSession = { session: { id: "session_2" }, user: { id: "other_user" } };
+
+const untouchableDb = new Proxy({} as Record<string, unknown>, {
+	get(_target, property) {
+		throw new Error(`Product storage must not be touched (accessed ${String(property)}).`);
+	},
+}) as unknown as ProductDb;
+
+/**
+ * A fake Thinkspace Agent namespace that resolves the decide RPC to a fixed
+ * result, standing in for the Durable Object so the router's owner-gating and
+ * result mapping are testable without a live runtime.
+ */
+const createAgentNamespace = (
+	decide: () => Promise<ThinkspaceMemoryApprovalDecisionResult>,
+	calls: { count: number },
+) => ({
+	get: () => ({
+		decideMemoryApproval: () => {
+			calls.count += 1;
+
+			return decide();
+		},
+		setName: () => Promise.resolve(),
+	}),
+	idFromName: (name: string) => ({ toString: () => name }),
+});
+
+const createCallContext = ({
+	agentNamespace,
+	db,
+	session = authenticatedSession,
+}: {
+	agentNamespace?: ReturnType<typeof createAgentNamespace>;
+	db: ProductDb;
+	session?: typeof authenticatedSession | null;
+}): Context =>
+	({
+		db,
+		env: agentNamespace ? { THINKSPACE_AGENT: agentNamespace } : {},
+		executionCtx: undefined,
+		headers: new Headers(),
+		modelCatalog: undefined,
+		session,
+	}) as unknown as Context;
+
+const seedOwnedThinkspace = async (db: ProductDb) => {
+	await db.insert(user).values({
+		email: "owner@example.com",
+		id: authenticatedSession.user.id,
+		name: "Owner",
+	});
+	await db.insert(thinkspaces).values({
+		goal: "Decide between vendors",
+		id: OWNED_THINKSPACE_ID,
+		ownerUserId: authenticatedSession.user.id,
+		status: "active",
+	});
+};
+
+const decideInput = (overrides: Record<string, unknown> = {}) => ({
+	approvalId: "approval_1",
+	decision: "approved" as const,
+	thinkspaceId: OWNED_THINKSPACE_ID,
+	...overrides,
+});
+
+const expectCode = (code: string) => (error: unknown) =>
+	error instanceof Error && (error as { code?: string }).code === code;
+
+test("an approved decision is applied through the runtime and returned to the owner", async () => {
+	const db = createTestProductDb();
+	await seedOwnedThinkspace(db);
+	const calls = { count: 0 };
+	const agentNamespace = createAgentNamespace(
+		() =>
+			Promise.resolve({
+				approvalId: "approval_1",
+				decision: "approved",
+				status: "applied",
+				thinkspaceId: OWNED_THINKSPACE_ID,
+			}),
+		calls,
+	);
+
+	const result = await call(approvalsRouter.decide, decideInput(), {
+		context: createCallContext({ agentNamespace, db }),
+	});
+
+	assert.deepEqual(result, {
+		approvalId: "approval_1",
+		decision: "approved",
+		status: "applied",
+		thinkspaceId: OWNED_THINKSPACE_ID,
+	});
+	assert.equal(calls.count, 1);
+});
+
+test("a runtime not_found (unknown or already-decided Approval) maps to NOT_FOUND", async () => {
+	const db = createTestProductDb();
+	await seedOwnedThinkspace(db);
+	const calls = { count: 0 };
+	const agentNamespace = createAgentNamespace(
+		() =>
+			Promise.resolve({
+				approvalId: "approval_1",
+				decision: "approved",
+				status: "not_found",
+				thinkspaceId: OWNED_THINKSPACE_ID,
+			}),
+		calls,
+	);
+
+	await assert.rejects(
+		call(approvalsRouter.decide, decideInput(), {
+			context: createCallContext({ agentNamespace, db }),
+		}),
+		expectCode("NOT_FOUND"),
+	);
+});
+
+test("unauthenticated decisions are rejected before any storage or runtime access", async () => {
+	await assert.rejects(
+		call(approvalsRouter.decide, decideInput(), {
+			context: createCallContext({ db: untouchableDb, session: null }),
+		}),
+		expectCode("UNAUTHORIZED"),
+	);
+});
+
+test("a non-owner deciding another user's Approval gets NOT_FOUND, and never reaches the runtime", async () => {
+	const db = createTestProductDb();
+	await seedOwnedThinkspace(db);
+	const calls = { count: 0 };
+	const agentNamespace = createAgentNamespace(
+		() => Promise.reject(new Error("runtime must not be reached for a non-owner")),
+		calls,
+	);
+
+	await assert.rejects(
+		call(approvalsRouter.decide, decideInput(), {
+			context: createCallContext({ agentNamespace, db, session: nonOwnerSession }),
+		}),
+		expectCode("NOT_FOUND"),
+	);
+	assert.equal(calls.count, 0);
+});
+
+test("a guessed Thinkspace id cannot resolve another user's runtime", async () => {
+	const db = createTestProductDb();
+	await seedOwnedThinkspace(db);
+	const calls = { count: 0 };
+	const agentNamespace = createAgentNamespace(
+		() => Promise.reject(new Error("runtime must not be reached for a guessed id")),
+		calls,
+	);
+
+	await assert.rejects(
+		call(approvalsRouter.decide, decideInput({ thinkspaceId: "thinkspace_guessed" }), {
+			context: createCallContext({ agentNamespace, db }),
+		}),
+		expectCode("NOT_FOUND"),
+	);
+	assert.equal(calls.count, 0);
+});
+
+test("a resolved Approval row is invisible to a non-owner's queue read", async () => {
+	const db = createTestProductDb();
+	await seedOwnedThinkspace(db);
+	await db.insert(thinkspaceApprovals).values({
+		actionKind: "memory_write",
+		approvalRequestId: "approval_req_1",
+		id: "approval_1",
+		ownerUserId: authenticatedSession.user.id,
+		proposedContent: "The user prefers Vendor A.",
+		proposedSummary: "Proposed a durable Product Memory.",
+		thinkspaceId: OWNED_THINKSPACE_ID,
+		toolCallId: "tool_call_1",
+	});
+
+	// Sanity: the row exists and is owned by the seeded owner, confirming the
+	// NOT_FOUND a non-owner receives is an ownership seal, not an empty table.
+	const stored = await db.select().from(thinkspaceApprovals);
+	assert.equal(stored.length, 1);
+	assert.equal(stored[0]?.ownerUserId, authenticatedSession.user.id);
+});

--- a/packages/api/src/approvals/router.ts
+++ b/packages/api/src/approvals/router.ts
@@ -1,0 +1,62 @@
+import { ORPCError } from "@orpc/server";
+import { z } from "zod";
+
+import { protectedProcedure } from "../procedures";
+import {
+	decideOwnedThinkspaceMemoryApproval,
+	ThinkspaceApprovalValidationError,
+} from "../thinkspaces/approval-decisions";
+
+export const THINKSPACE_APPROVAL_DECISION_REASON_MAX_LENGTH = 1000;
+
+const decideInput = z.object({
+	approvalId: z.string().min(1),
+	decision: z.enum(["approved", "rejected"]),
+	reason: z.string().max(THINKSPACE_APPROVAL_DECISION_REASON_MAX_LENGTH).optional(),
+	thinkspaceId: z.string().min(1),
+});
+
+const toNotFound = (): ORPCError<"NOT_FOUND", undefined> =>
+	new ORPCError("NOT_FOUND", { message: "Approval was not found." });
+
+/**
+ * The Review Queue is the cross-Thinkspace control-plane surface for pending
+ * Approvals: it reads the D1 index, and deciding drives the Durable Object that
+ * owns the parked turn. This slice exposes only the decide half (the batched
+ * list arrives with the Review Queue page); the listing of pending Approvals
+ * across all of a user's Thinkspaces follows the same owner-indexed pattern.
+ */
+export const approvalsRouter = {
+	decide: protectedProcedure.input(decideInput).handler(async ({ context, input }) => {
+		let result: Awaited<ReturnType<typeof decideOwnedThinkspaceMemoryApproval>>;
+
+		try {
+			result = await decideOwnedThinkspaceMemoryApproval({
+				approvalId: input.approvalId,
+				db: context.db,
+				decision: input.decision,
+				env: context.env,
+				ownerUserId: context.session.user.id,
+				reason: input.reason,
+				thinkspaceId: input.thinkspaceId,
+			});
+		} catch (error) {
+			if (error instanceof ThinkspaceApprovalValidationError) {
+				throw new ORPCError("BAD_REQUEST", { message: error.message });
+			}
+
+			throw error;
+		}
+
+		if (!result || result.status === "not_found") {
+			throw toNotFound();
+		}
+
+		return {
+			approvalId: result.approvalId,
+			decision: result.decision,
+			status: result.status,
+			thinkspaceId: result.thinkspaceId,
+		};
+	}),
+};

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -1,5 +1,6 @@
 import type { InferRouterInputs, InferRouterOutputs, RouterClient } from "@orpc/server";
 
+import { approvalsRouter } from "../approvals/router";
 import { mcpRouter } from "../mcp/router";
 import { modelsRouter } from "../models/router";
 import { profileRouter } from "../profile/router";
@@ -8,6 +9,7 @@ import { sourcesRouter } from "../sources/router";
 import { thinkspacesRouter } from "../thinkspaces/router";
 
 export const appRouter = {
+	approvals: approvalsRouter,
 	healthCheck: publicProcedure.handler(() => "OK"),
 	mcp: mcpRouter,
 	models: modelsRouter,

--- a/packages/api/src/thinkspaces/approval-decisions.test.ts
+++ b/packages/api/src/thinkspaces/approval-decisions.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+
+import {
+	decideOwnedThinkspaceMemoryApproval,
+	ThinkspaceApprovalValidationError,
+} from "./approval-decisions";
+import type { ThinkspaceMemoryApprovalDecisionRequest } from "./approval-decisions";
+
+const env = {
+	THINKSPACE_AGENT: {
+		idFromName: (name: string) => ({ toString: () => name }),
+	},
+} as never;
+
+const ownerFound = () => Promise.resolve({ id: "thinkspace_1" });
+
+test("deciding forwards the bound Thinkspace, owner, decision, and reason to the runtime", async () => {
+	const seen: ThinkspaceMemoryApprovalDecisionRequest[] = [];
+
+	const result = await decideOwnedThinkspaceMemoryApproval({
+		approvalId: "  approval_1  ",
+		db: {} as ProductDb,
+		decideApproval: ({ request }) => {
+			seen.push(request);
+
+			return Promise.resolve({
+				approvalId: request.approvalId,
+				decision: request.decision,
+				status: "applied",
+				thinkspaceId: request.thinkspaceId,
+			});
+		},
+		decision: "approved",
+		env,
+		getThinkspaceByOwner: ownerFound,
+		ownerUserId: "owner_user",
+		reason: "Looks durable.",
+		thinkspaceId: "thinkspace_1",
+	});
+
+	assert.deepEqual(seen, [
+		{
+			approvalId: "approval_1",
+			decision: "approved",
+			ownerUserId: "owner_user",
+			reason: "Looks durable.",
+			thinkspaceId: "thinkspace_1",
+		},
+	]);
+	assert.equal(result?.status, "applied");
+});
+
+test("a non-owner's decide resolves to null without ever reaching the runtime", async () => {
+	let reachedRuntime = false;
+
+	const result = await decideOwnedThinkspaceMemoryApproval({
+		approvalId: "approval_1",
+		db: {} as ProductDb,
+		decideApproval: () => {
+			reachedRuntime = true;
+
+			return Promise.resolve({
+				approvalId: "approval_1",
+				decision: "approved",
+				status: "applied",
+				thinkspaceId: "thinkspace_1",
+			});
+		},
+		decision: "approved",
+		env,
+		getThinkspaceByOwner: () => Promise.resolve(null),
+		ownerUserId: "other_user",
+		thinkspaceId: "thinkspace_1",
+	});
+
+	assert.equal(result, null);
+	assert.equal(reachedRuntime, false);
+});
+
+test("an empty Approval handle is rejected before any ownership or runtime work", async () => {
+	await assert.rejects(
+		decideOwnedThinkspaceMemoryApproval({
+			approvalId: "   ",
+			db: {} as ProductDb,
+			decideApproval: () => Promise.reject(new Error("must not run")),
+			decision: "approved",
+			env,
+			getThinkspaceByOwner: () => Promise.reject(new Error("must not run")),
+			ownerUserId: "owner_user",
+			thinkspaceId: "thinkspace_1",
+		}),
+		ThinkspaceApprovalValidationError,
+	);
+});

--- a/packages/api/src/thinkspaces/approval-decisions.ts
+++ b/packages/api/src/thinkspaces/approval-decisions.ts
@@ -1,0 +1,144 @@
+import type { ProductDb } from "@better-agent/db";
+import type { Thinkspace } from "@better-agent/db/schema/thinkspaces";
+import type { CloudflareEnv } from "@better-agent/env/types";
+
+import type { ThinkspaceApprovalDecision } from "./approvals";
+import { getThinkspace } from "./repository";
+import { resolveThinkspaceAgentRuntime, THINKSPACE_AGENT_BINDING_NAME } from "./runtime";
+
+export const THINKSPACE_APPROVAL_ID_MAX_LENGTH = 128;
+
+/**
+ * The worker→runtime contract for deciding one pending Approval out-of-band.
+ * Deciding drives the Durable Object (which owns the parked-turn state); the
+ * Review Queue reads the D1 index. Mirrors the submit/inspect runtime contracts
+ * in turns.ts and inspect.ts.
+ */
+export interface ThinkspaceMemoryApprovalDecisionRequest {
+	approvalId: string;
+	decision: ThinkspaceApprovalDecision;
+	ownerUserId: string;
+	reason?: string;
+	thinkspaceId: string;
+}
+
+export type ThinkspaceMemoryApprovalDecisionStatus = "applied" | "not_found";
+
+export interface ThinkspaceMemoryApprovalDecisionResult {
+	approvalId: string;
+	decision: ThinkspaceApprovalDecision;
+	status: ThinkspaceMemoryApprovalDecisionStatus;
+	thinkspaceId: string;
+}
+
+export class ThinkspaceApprovalValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ThinkspaceApprovalValidationError";
+	}
+}
+
+export const validateThinkspaceApprovalId = (approvalId: string): string => {
+	const bounded = approvalId.trim();
+
+	if (!bounded) {
+		throw new ThinkspaceApprovalValidationError("Deciding an Approval needs a non-empty handle.");
+	}
+
+	if (bounded.length > THINKSPACE_APPROVAL_ID_MAX_LENGTH) {
+		throw new ThinkspaceApprovalValidationError(
+			`An Approval handle is limited to ${THINKSPACE_APPROVAL_ID_MAX_LENGTH} characters.`,
+		);
+	}
+
+	return bounded;
+};
+
+type ThinkspaceApprovalDecisionEnv = Pick<CloudflareEnv, typeof THINKSPACE_AGENT_BINDING_NAME>;
+
+type GetThinkspaceByOwner = (
+	db: ProductDb,
+	input: { ownerUserId: string; thinkspaceId: string },
+) => Promise<Pick<Thinkspace, "id"> | null>;
+
+type DecideApproval = (input: {
+	env: ThinkspaceApprovalDecisionEnv;
+	request: ThinkspaceMemoryApprovalDecisionRequest;
+	runtimeName: string;
+}) => Promise<ThinkspaceMemoryApprovalDecisionResult>;
+
+interface ThinkspaceAgentApprovalStub {
+	decideMemoryApproval: (
+		request: ThinkspaceMemoryApprovalDecisionRequest,
+	) => Promise<ThinkspaceMemoryApprovalDecisionResult>;
+	/**
+	 * PartyServer's initialization RPC. User-defined RPC methods do not pass
+	 * through the runtime's fetch/alarm entry points where `onStart()` would run,
+	 * so the runtime must be initialized explicitly before the decision RPC.
+	 */
+	setName: (name: string) => Promise<void>;
+}
+
+const decideViaThinkspaceAgentRuntime: DecideApproval = async ({ env, request, runtimeName }) => {
+	const namespace = env[THINKSPACE_AGENT_BINDING_NAME];
+	const stub = namespace.get(
+		namespace.idFromName(runtimeName),
+	) as unknown as ThinkspaceAgentApprovalStub;
+
+	await stub.setName(runtimeName);
+
+	return await stub.decideMemoryApproval(request);
+};
+
+export interface DecideOwnedThinkspaceMemoryApprovalInput {
+	approvalId: string;
+	db: ProductDb;
+	decideApproval?: DecideApproval;
+	decision: ThinkspaceApprovalDecision;
+	env: ThinkspaceApprovalDecisionEnv;
+	getThinkspaceByOwner?: GetThinkspaceByOwner;
+	ownerUserId: string;
+	reason?: string;
+	thinkspaceId: string;
+}
+
+/**
+ * Owner-gated decide: hides another user's Thinkspace (and therefore its
+ * Approvals) behind the same null-return the rest of the control plane maps to
+ * 404. Returns null when the Thinkspace is not the caller's; otherwise drives
+ * the runtime, which is authoritative over whether the specific Approval is
+ * still pending.
+ */
+export const decideOwnedThinkspaceMemoryApproval = async ({
+	approvalId,
+	db,
+	decideApproval = decideViaThinkspaceAgentRuntime,
+	decision,
+	env,
+	getThinkspaceByOwner = getThinkspace,
+	ownerUserId,
+	reason,
+	thinkspaceId,
+}: DecideOwnedThinkspaceMemoryApprovalInput): Promise<ThinkspaceMemoryApprovalDecisionResult | null> => {
+	const boundedApprovalId = validateThinkspaceApprovalId(approvalId);
+
+	const thinkspace = await getThinkspaceByOwner(db, { ownerUserId, thinkspaceId });
+
+	if (!thinkspace) {
+		return null;
+	}
+
+	const runtime = resolveThinkspaceAgentRuntime({ env, thinkspaceId: thinkspace.id });
+
+	return await decideApproval({
+		env,
+		request: {
+			approvalId: boundedApprovalId,
+			decision,
+			ownerUserId,
+			reason,
+			thinkspaceId: thinkspace.id,
+		},
+		runtimeName: runtime.runtimeName,
+	});
+};

--- a/packages/api/src/thinkspaces/approvals-repository.test.ts
+++ b/packages/api/src/thinkspaces/approvals-repository.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+import { user } from "@better-agent/db/schema/auth";
+import { thinkspaces } from "@better-agent/db/schema/thinkspaces";
+
+import { createTestProductDb } from "../testing/product-db";
+import {
+	getThinkspaceApproval,
+	listPendingThinkspaceApprovals,
+	resolveThinkspaceApproval,
+	upsertPendingThinkspaceApproval,
+} from "./approvals-repository";
+import { createThinkspaceMemory, listThinkspaceMemories } from "./memories-repository";
+
+const OWNER_ID = "owner_user";
+const THINKSPACE_ID = "thinkspace_approvals";
+const OTHER_THINKSPACE_ID = "thinkspace_approvals_other";
+
+const seed = async (db: ProductDb) => {
+	await db.insert(user).values({ email: "owner@example.com", id: OWNER_ID, name: "Owner" });
+	await db.insert(thinkspaces).values([
+		{ goal: "Decide vendors", id: THINKSPACE_ID, ownerUserId: OWNER_ID, status: "active" },
+		{ goal: "Other", id: OTHER_THINKSPACE_ID, ownerUserId: OWNER_ID, status: "active" },
+	]);
+};
+
+const pendingRecord = (overrides: Record<string, unknown> = {}) => ({
+	actionKind: "memory_write",
+	approvalRequestId: "approval_req_1",
+	id: "approval_1",
+	ownerUserId: OWNER_ID,
+	profileRevisionId: "rev_1",
+	profileVersion: 1,
+	proposedContent: "The user prefers Vendor A.",
+	proposedSummary: 'Proposed a durable Product Memory: "The user prefers Vendor A."',
+	submissionId: null,
+	thinkspaceId: THINKSPACE_ID,
+	toolCallId: "tool_call_1",
+	...overrides,
+});
+
+test("a pending Approval is recorded once and reconciling the same parked hold returns the same row", async () => {
+	const db = createTestProductDb();
+	await seed(db);
+
+	const first = await upsertPendingThinkspaceApproval(db, { record: pendingRecord() });
+	assert.equal(first.status, "pending");
+	assert.equal(first.proposedContent, "The user prefers Vendor A.");
+
+	// A second reconcile of the same (thinkspaceId, toolCallId) — note a fresh
+	// generated id — must resolve to the existing row, never a duplicate.
+	const second = await upsertPendingThinkspaceApproval(db, {
+		record: pendingRecord({ id: "approval_regenerated" }),
+	});
+	assert.equal(second.id, first.id);
+
+	const pending = await listPendingThinkspaceApprovals(db, { thinkspaceId: THINKSPACE_ID });
+	assert.equal(pending.length, 1);
+});
+
+test("an Approval is sealed to its Thinkspace: a forged id from elsewhere never resolves", async () => {
+	const db = createTestProductDb();
+	await seed(db);
+	await upsertPendingThinkspaceApproval(db, { record: pendingRecord() });
+
+	const found = await getThinkspaceApproval(db, {
+		approvalId: "approval_1",
+		thinkspaceId: THINKSPACE_ID,
+	});
+	assert.ok(found);
+
+	const fromOtherThinkspace = await getThinkspaceApproval(db, {
+		approvalId: "approval_1",
+		thinkspaceId: OTHER_THINKSPACE_ID,
+	});
+	assert.equal(fromOtherThinkspace, null);
+});
+
+test("resolving moves an Approval out of the queue and is a no-op the second time", async () => {
+	const db = createTestProductDb();
+	await seed(db);
+	await upsertPendingThinkspaceApproval(db, { record: pendingRecord() });
+
+	const resolvedAt = new Date();
+	const resolved = await resolveThinkspaceApproval(db, {
+		approvalId: "approval_1",
+		resolvedAt,
+		status: "approved",
+		thinkspaceId: THINKSPACE_ID,
+	});
+	assert.equal(resolved?.status, "approved");
+	assert.ok(resolved?.resolvedAt);
+
+	// A resolved Approval leaves the queue.
+	assert.deepEqual(await listPendingThinkspaceApprovals(db, { thinkspaceId: THINKSPACE_ID }), []);
+
+	// A late or duplicate decision cannot overwrite the earlier one.
+	const again = await resolveThinkspaceApproval(db, {
+		approvalId: "approval_1",
+		resolvedAt: new Date(),
+		status: "rejected",
+		thinkspaceId: THINKSPACE_ID,
+	});
+	assert.equal(again, null);
+
+	const stored = await getThinkspaceApproval(db, {
+		approvalId: "approval_1",
+		thinkspaceId: THINKSPACE_ID,
+	});
+	assert.equal(stored?.status, "approved");
+});
+
+test("an approved Memory is written once and is visible; the same held call never double-writes", async () => {
+	const db = createTestProductDb();
+	await seed(db);
+
+	const first = await createThinkspaceMemory(db, {
+		record: {
+			content: "The user prefers Vendor A.",
+			id: "memory_1",
+			profileRevisionId: "rev_1",
+			profileVersion: 1,
+			thinkspaceId: THINKSPACE_ID,
+			toolCallId: "tool_call_1",
+		},
+	});
+	assert.equal(first.content, "The user prefers Vendor A.");
+
+	// A resumed/retried continuation of the same held call resolves to the
+	// already-stored Memory rather than inserting a duplicate.
+	const again = await createThinkspaceMemory(db, {
+		record: {
+			content: "The user prefers Vendor A.",
+			id: "memory_regenerated",
+			profileRevisionId: "rev_1",
+			profileVersion: 1,
+			thinkspaceId: THINKSPACE_ID,
+			toolCallId: "tool_call_1",
+		},
+	});
+	assert.equal(again.id, first.id);
+
+	const memories = await listThinkspaceMemories(db, { thinkspaceId: THINKSPACE_ID });
+	assert.equal(memories.length, 1);
+	assert.deepEqual(await listThinkspaceMemories(db, { thinkspaceId: OTHER_THINKSPACE_ID }), []);
+});

--- a/packages/api/src/thinkspaces/approvals-repository.ts
+++ b/packages/api/src/thinkspaces/approvals-repository.ts
@@ -1,0 +1,149 @@
+import type { ProductDb } from "@better-agent/db";
+import { THINKSPACE_APPROVAL_STATUS, thinkspaceApprovals } from "@better-agent/db/schema/approvals";
+import type {
+	ThinkspaceApproval,
+	ThinkspaceApprovalStatus,
+} from "@better-agent/db/schema/approvals";
+import { and, desc, eq } from "drizzle-orm";
+
+export interface UpsertPendingThinkspaceApprovalInput {
+	record: {
+		actionKind: string;
+		approvalRequestId: string;
+		id: string;
+		ownerUserId: string;
+		profileRevisionId: string | null;
+		profileVersion: number | null;
+		proposedContent: string;
+		proposedSummary: string;
+		submissionId: string | null;
+		thinkspaceId: string;
+		toolCallId: string;
+	};
+}
+
+export interface GetThinkspaceApprovalInput {
+	approvalId: string;
+	thinkspaceId: string;
+}
+
+export interface ResolveThinkspaceApprovalInput {
+	approvalId: string;
+	resolvedAt: Date;
+	status: Extract<ThinkspaceApprovalStatus, "approved" | "rejected">;
+	thinkspaceId: string;
+}
+
+const getThinkspaceApprovalByToolCall = async (
+	db: ProductDb,
+	{ thinkspaceId, toolCallId }: { thinkspaceId: string; toolCallId: string },
+): Promise<ThinkspaceApproval | null> => {
+	const [approval] = await db
+		.select()
+		.from(thinkspaceApprovals)
+		.where(
+			and(
+				eq(thinkspaceApprovals.thinkspaceId, thinkspaceId),
+				eq(thinkspaceApprovals.toolCallId, toolCallId),
+			),
+		)
+		.limit(1);
+
+	return approval ?? null;
+};
+
+/**
+ * Records a pending Approval the moment the hold is raised. Idempotent on
+ * (thinkspaceId, toolCallId): reconciling the same parked turn again resolves
+ * to the existing row instead of inserting a duplicate, and never disturbs an
+ * Approval that has since been decided. Always returns the authoritative row.
+ */
+export const upsertPendingThinkspaceApproval = async (
+	db: ProductDb,
+	{ record }: UpsertPendingThinkspaceApprovalInput,
+): Promise<ThinkspaceApproval> => {
+	const [created] = await db
+		.insert(thinkspaceApprovals)
+		.values({ ...record, status: THINKSPACE_APPROVAL_STATUS.PENDING })
+		.onConflictDoNothing({
+			target: [thinkspaceApprovals.thinkspaceId, thinkspaceApprovals.toolCallId],
+		})
+		.returning();
+
+	if (created) {
+		return created;
+	}
+
+	const existing = await getThinkspaceApprovalByToolCall(db, {
+		thinkspaceId: record.thinkspaceId,
+		toolCallId: record.toolCallId,
+	});
+
+	if (!existing) {
+		throw new Error("Approval was not persisted.");
+	}
+
+	return existing;
+};
+
+/**
+ * Reads one Approval keyed by (thinkspaceId, approvalId) together, so an
+ * Approval id forged from another Thinkspace can never resolve here.
+ */
+export const getThinkspaceApproval = async (
+	db: ProductDb,
+	{ approvalId, thinkspaceId }: GetThinkspaceApprovalInput,
+): Promise<ThinkspaceApproval | null> => {
+	const [approval] = await db
+		.select()
+		.from(thinkspaceApprovals)
+		.where(
+			and(
+				eq(thinkspaceApprovals.id, approvalId),
+				eq(thinkspaceApprovals.thinkspaceId, thinkspaceId),
+			),
+		)
+		.limit(1);
+
+	return approval ?? null;
+};
+
+export const listPendingThinkspaceApprovals = async (
+	db: ProductDb,
+	{ thinkspaceId }: { thinkspaceId: string },
+): Promise<ThinkspaceApproval[]> =>
+	await db
+		.select()
+		.from(thinkspaceApprovals)
+		.where(
+			and(
+				eq(thinkspaceApprovals.thinkspaceId, thinkspaceId),
+				eq(thinkspaceApprovals.status, THINKSPACE_APPROVAL_STATUS.PENDING),
+			),
+		)
+		.orderBy(desc(thinkspaceApprovals.createdAt));
+
+/**
+ * Moves a pending Approval to its decided status. The `status = pending` guard
+ * makes resolution a no-op once the Approval has already left the queue, so a
+ * late or duplicate decision can never overwrite an earlier one. Returns the
+ * updated row, or null when nothing pending matched.
+ */
+export const resolveThinkspaceApproval = async (
+	db: ProductDb,
+	{ approvalId, resolvedAt, status, thinkspaceId }: ResolveThinkspaceApprovalInput,
+): Promise<ThinkspaceApproval | null> => {
+	const [resolved] = await db
+		.update(thinkspaceApprovals)
+		.set({ resolvedAt, status })
+		.where(
+			and(
+				eq(thinkspaceApprovals.id, approvalId),
+				eq(thinkspaceApprovals.thinkspaceId, thinkspaceId),
+				eq(thinkspaceApprovals.status, THINKSPACE_APPROVAL_STATUS.PENDING),
+			),
+		)
+		.returning();
+
+	return resolved ?? null;
+};

--- a/packages/api/src/thinkspaces/approvals.test.ts
+++ b/packages/api/src/thinkspaces/approvals.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	extractPendingMemoryApprovals,
+	extractResolvedMemoryApprovals,
+	flipMemoryApprovalInTranscript,
+	summarizeMemoryProposal,
+} from "./approvals";
+
+const memoryPart = (overrides: Record<string, unknown> = {}) => ({
+	approval: { id: "approval_req_1" },
+	input: { content: "The user prefers Vendor A." },
+	state: "approval-requested",
+	toolCallId: "tool_call_1",
+	type: "tool-memory_write",
+	...overrides,
+});
+
+const assistant = (parts: Record<string, unknown>[]) => ({ parts, role: "assistant" });
+
+test("a parked Memory proposal is extracted with the durable handles a decision needs", () => {
+	const pending = extractPendingMemoryApprovals([
+		assistant([{ text: "Working on it.", type: "text" }, memoryPart()]),
+	]);
+
+	assert.deepEqual(pending, [
+		{
+			approvalRequestId: "approval_req_1",
+			content: "The user prefers Vendor A.",
+			toolCallId: "tool_call_1",
+		},
+	]);
+});
+
+test("malformed or non-Memory holds never surface as decidable Approvals", () => {
+	const pending = extractPendingMemoryApprovals([
+		assistant([
+			// A different tool awaiting approval is not this index's concern.
+			{
+				approval: { id: "a" },
+				state: "approval-requested",
+				toolCallId: "t",
+				type: "tool-web_search",
+			},
+			// A Memory hold missing its approval id cannot be decided, so it is skipped.
+			memoryPart({ approval: {} }),
+			// A Memory hold missing content is skipped.
+			memoryPart({ input: {}, toolCallId: "tool_call_2" }),
+			// Not in the requested state.
+			memoryPart({ state: "output-available", toolCallId: "tool_call_3" }),
+		]),
+	]);
+
+	assert.deepEqual(pending, []);
+});
+
+test("decided Memory holds are read back with their outcome for index reconciliation", () => {
+	const resolved = extractResolvedMemoryApprovals([
+		assistant([
+			memoryPart({
+				approval: { approved: true, id: "a" },
+				state: "output-available",
+				toolCallId: "approved_executed",
+			}),
+			memoryPart({
+				approval: { approved: false, id: "b" },
+				state: "output-denied",
+				toolCallId: "rejected",
+			}),
+			memoryPart({
+				approval: { approved: true, id: "c" },
+				state: "approval-responded",
+				toolCallId: "approved_pending",
+			}),
+			// Still parked: not yet resolved.
+			memoryPart({ toolCallId: "still_pending" }),
+		]),
+	]);
+
+	assert.deepEqual(resolved, [
+		{ status: "approved", toolCallId: "approved_executed" },
+		{ status: "rejected", toolCallId: "rejected" },
+		{ status: "approved", toolCallId: "approved_pending" },
+	]);
+});
+
+test("approving flips exactly the matching parked hold to approval-responded, preserving the approval id", () => {
+	const messages = [assistant([{ text: "Note.", type: "text" }, memoryPart()])];
+
+	const result = flipMemoryApprovalInTranscript({
+		decision: "approved",
+		messages,
+		toolCallId: "tool_call_1",
+	});
+
+	assert.equal(result.flipped, true);
+
+	const flippedPart = result.messages[0]?.parts?.[1] as Record<string, unknown>;
+	assert.equal(flippedPart.state, "approval-responded");
+	assert.deepEqual(flippedPart.approval, { approved: true, id: "approval_req_1" });
+	// The sibling text part is untouched.
+	assert.deepEqual(result.messages[0]?.parts?.[0], { text: "Note.", type: "text" });
+	// Purity: the input transcript is never mutated.
+	const [inputMessage] = messages;
+	assert.ok(inputMessage);
+	assert.equal((inputMessage.parts[1] as Record<string, unknown>).state, "approval-requested");
+});
+
+test("rejecting flips the hold to a denial and carries an optional reason", () => {
+	const messages = [assistant([memoryPart()])];
+
+	const result = flipMemoryApprovalInTranscript({
+		decision: "rejected",
+		messages,
+		reason: "Not durable enough.",
+		toolCallId: "tool_call_1",
+	});
+
+	assert.equal(result.flipped, true);
+	const flippedPart = result.messages[0]?.parts?.[0] as Record<string, unknown>;
+	assert.deepEqual(flippedPart.approval, {
+		approved: false,
+		id: "approval_req_1",
+		reason: "Not durable enough.",
+	});
+});
+
+test("a decision for a hold that is no longer parked reports no flip so the caller fails closed", () => {
+	const messages = [assistant([memoryPart({ state: "output-available" })])];
+
+	const result = flipMemoryApprovalInTranscript({
+		decision: "approved",
+		messages,
+		toolCallId: "tool_call_1",
+	});
+
+	assert.equal(result.flipped, false);
+	assert.deepEqual(result.messages, messages);
+});
+
+test("a Memory proposal summary collapses whitespace and bounds length for the queue", () => {
+	const summary = summarizeMemoryProposal("  Vendor A\n\n   is preferred   ");
+	assert.equal(summary, 'Proposed a durable Product Memory: "Vendor A is preferred"');
+
+	const long = summarizeMemoryProposal("x".repeat(500));
+	assert.ok(long.length < 500);
+	assert.match(long, /…"$/u);
+});

--- a/packages/api/src/thinkspaces/approvals.ts
+++ b/packages/api/src/thinkspaces/approvals.ts
@@ -1,0 +1,230 @@
+/**
+ * The Approval holdpoint, expressed as pure transcript logic.
+ *
+ * A held tool (the Memory-proposing tool) is defined to the runtime with
+ * Project Think's `needsApproval` mechanism. When the agent calls it, the
+ * AI SDK does not execute it; it records a tool part in the `approval-requested`
+ * state and parks the turn. Better Agent maps that transport-level pause onto a
+ * product-level **Approval**: the owner decides, and the decision flips the part
+ * to `approval-responded`, which resumes the parked turn — on approval the
+ * tool's `execute` finally runs and writes the Memory; on rejection it never
+ * runs and nothing persists (ADR-0006: Think's tool approval is the transport,
+ * the product Approval is the authority).
+ *
+ * This module owns the seam in pure functions so it is testable without a live
+ * model or the runtime: reading which holds a transcript is carrying, and
+ * flipping one hold to its decided state. It imports neither `ai` nor
+ * `@cloudflare/think`; it works on the structural shape of a UI message part.
+ */
+
+/** The runtime tool-part type the held Memory-proposing tool produces. */
+export const MEMORY_WRITE_TOOL_PART_TYPE = "tool-memory_write" as const;
+
+const APPROVAL_REQUESTED_STATE = "approval-requested";
+const APPROVAL_RESPONDED_STATE = "approval-responded";
+const OUTPUT_AVAILABLE_STATE = "output-available";
+const OUTPUT_DENIED_STATE = "output-denied";
+
+export const MEMORY_PROPOSAL_SUMMARY_MAX_LENGTH = 200;
+
+export type ThinkspaceApprovalDecision = "approved" | "rejected";
+
+/** A held Memory proposal awaiting the owner's decision. */
+export interface PendingMemoryApproval {
+	approvalRequestId: string;
+	content: string;
+	toolCallId: string;
+}
+
+/** A held Memory proposal the transcript already shows as decided. */
+export interface ResolvedMemoryApproval {
+	status: ThinkspaceApprovalDecision;
+	toolCallId: string;
+}
+
+interface ApprovalShape {
+	approved?: boolean;
+	id?: unknown;
+	reason?: unknown;
+}
+
+interface TranscriptToolPart {
+	approval?: ApprovalShape;
+	input?: unknown;
+	state?: string;
+	toolCallId?: unknown;
+	type?: string;
+}
+
+interface TranscriptMessage {
+	parts?: readonly TranscriptToolPart[];
+	role?: string;
+}
+
+const isMemoryWritePart = (part: TranscriptToolPart): boolean =>
+	part.type === MEMORY_WRITE_TOOL_PART_TYPE;
+
+const toNonEmptyString = (value: unknown): string | null =>
+	typeof value === "string" && value.length > 0 ? value : null;
+
+const proposedContent = (input: unknown): string | null => {
+	if (typeof input !== "object" || input === null) {
+		return null;
+	}
+
+	const { content } = input as Record<string, unknown>;
+
+	return toNonEmptyString(content);
+};
+
+/** A short product-language summary of a proposed Memory for the Review Queue. */
+export const summarizeMemoryProposal = (content: string): string => {
+	const collapsed = content.replaceAll(/\s+/gu, " ").trim();
+	const bounded =
+		collapsed.length > MEMORY_PROPOSAL_SUMMARY_MAX_LENGTH
+			? `${collapsed.slice(0, MEMORY_PROPOSAL_SUMMARY_MAX_LENGTH - 1)}…`
+			: collapsed;
+
+	return `Proposed a durable Product Memory: "${bounded}"`;
+};
+
+/**
+ * Every held Memory proposal a transcript is currently parked on. A part counts
+ * as pending only when it is a Memory-write part in the `approval-requested`
+ * state with the durable handles a decision needs (tool call id, approval
+ * request id) and a non-empty proposed content; anything malformed is skipped
+ * and stays held, never surfacing as a decidable Approval.
+ */
+export const extractPendingMemoryApprovals = (
+	messages: readonly TranscriptMessage[],
+): PendingMemoryApproval[] => {
+	const pending: PendingMemoryApproval[] = [];
+
+	for (const message of messages) {
+		for (const part of message.parts ?? []) {
+			if (!(isMemoryWritePart(part) && part.state === APPROVAL_REQUESTED_STATE)) {
+				continue;
+			}
+
+			const toolCallId = toNonEmptyString(part.toolCallId);
+			const approvalRequestId = toNonEmptyString(part.approval?.id);
+			const content = proposedContent(part.input);
+
+			if (!(toolCallId && approvalRequestId && content)) {
+				continue;
+			}
+
+			pending.push({ approvalRequestId, content, toolCallId });
+		}
+	}
+
+	return pending;
+};
+
+const resolvedStatus = (part: TranscriptToolPart): ThinkspaceApprovalDecision | null => {
+	if (part.approval?.approved === true || part.state === OUTPUT_AVAILABLE_STATE) {
+		return "approved";
+	}
+
+	if (part.approval?.approved === false || part.state === OUTPUT_DENIED_STATE) {
+		return "rejected";
+	}
+
+	return null;
+};
+
+/**
+ * Every held Memory proposal the transcript already shows as decided. Lets the
+ * index reconcile rows the owner decided through another surface (a later
+ * inline Sitting decision) back out of the Review Queue.
+ */
+export const extractResolvedMemoryApprovals = (
+	messages: readonly TranscriptMessage[],
+): ResolvedMemoryApproval[] => {
+	const resolved: ResolvedMemoryApproval[] = [];
+
+	for (const message of messages) {
+		for (const part of message.parts ?? []) {
+			if (!isMemoryWritePart(part) || part.state === APPROVAL_REQUESTED_STATE) {
+				continue;
+			}
+
+			const toolCallId = toNonEmptyString(part.toolCallId);
+			const status = resolvedStatus(part);
+
+			if (toolCallId && status) {
+				resolved.push({ status, toolCallId });
+			}
+		}
+	}
+
+	return resolved;
+};
+
+export interface FlipMemoryApprovalInput {
+	decision: ThinkspaceApprovalDecision;
+	messages: readonly TranscriptMessage[];
+	reason?: string;
+	toolCallId: string;
+}
+
+export interface FlipMemoryApprovalResult<TMessage> {
+	flipped: boolean;
+	messages: TMessage[];
+}
+
+/**
+ * Records the owner's decision on one parked Memory proposal by flipping its
+ * `approval-requested` part to `approval-responded`, preserving the part's
+ * approval id (the AI SDK keys its continuation on it). Pure: it never mutates
+ * the input, only flips the single part whose tool call id matches and that is
+ * still awaiting a decision, and reports whether a flip happened so the caller
+ * can fail closed when the hold is already gone.
+ */
+export const flipMemoryApprovalInTranscript = <TMessage extends TranscriptMessage>({
+	decision,
+	messages,
+	reason,
+	toolCallId,
+}: {
+	decision: ThinkspaceApprovalDecision;
+	messages: readonly TMessage[];
+	reason?: string;
+	toolCallId: string;
+}): FlipMemoryApprovalResult<TMessage> => {
+	let flipped = false;
+
+	const next = messages.map((message) => ({
+		...message,
+		parts: (message.parts ?? []).map((part) => {
+			if (
+				flipped ||
+				!isMemoryWritePart(part) ||
+				part.state !== APPROVAL_REQUESTED_STATE ||
+				part.toolCallId !== toolCallId
+			) {
+				return part;
+			}
+
+			const approvalId = toNonEmptyString(part.approval?.id);
+
+			if (!approvalId) {
+				return part;
+			}
+
+			flipped = true;
+
+			return {
+				...part,
+				approval: {
+					approved: decision === "approved",
+					id: approvalId,
+					...(reason ? { reason } : {}),
+				},
+				state: APPROVAL_RESPONDED_STATE,
+			};
+		}),
+	}));
+
+	return { flipped, messages: next as TMessage[] };
+};

--- a/packages/api/src/thinkspaces/built-in-runtime-tools.test.ts
+++ b/packages/api/src/thinkspaces/built-in-runtime-tools.test.ts
@@ -12,6 +12,7 @@ import {
 	evaluateBuiltInRuntimeToolCallPermission,
 	prepareThinkspaceBuiltInRuntimeTools,
 } from "./built-in-runtime-tools";
+import type { ThinkspaceMemoryWriteInput, ThinkspaceMemoryWriter } from "./memory-writer";
 import { createMemoryPermissionPolicy } from "./permission-policy";
 import { THINKSPACE_RUNTIME_POLICY } from "./runtime-policy";
 import { ThinkspaceWebReadError } from "./web-reader";
@@ -39,9 +40,35 @@ const stubSourceReader = (
 	...overrides,
 });
 
+const stubMemoryWriter = (
+	overrides: Partial<ThinkspaceMemoryWriter> = {},
+): ThinkspaceMemoryWriter => ({
+	write: () => Promise.resolve(),
+	...overrides,
+});
+
+const recordingMemoryWriter = (): {
+	writer: ThinkspaceMemoryWriter;
+	writes: ThinkspaceMemoryWriteInput[];
+} => {
+	const writes: ThinkspaceMemoryWriteInput[] = [];
+
+	return {
+		writer: {
+			write: (input) => {
+				writes.push(input);
+
+				return Promise.resolve();
+			},
+		},
+		writes,
+	};
+};
+
 test("only active built-in tools are constructed; unknown and MCP ids construct nothing", async () => {
 	const preparation = await prepareThinkspaceBuiltInRuntimeTools({
 		activeProductToolIds: ["web_search", "cloudflare-docs:search_docs", "workspace_bash"],
+		memoryWriter: stubMemoryWriter(),
 		sourceReader: stubSourceReader(),
 		webReader: stubWebReader(),
 	});
@@ -54,6 +81,7 @@ test("only active built-in tools are constructed; unknown and MCP ids construct 
 test("an empty active set keeps the toolset empty with no manifest", async () => {
 	const preparation = await prepareThinkspaceBuiltInRuntimeTools({
 		activeProductToolIds: [],
+		memoryWriter: stubMemoryWriter(),
 		sourceReader: stubSourceReader(),
 		webReader: stubWebReader(),
 	});
@@ -66,6 +94,7 @@ test("an empty active set keeps the toolset empty with no manifest", async () =>
 test("source_read returns the Source content and a product-safe not-found for forged ids", async () => {
 	const preparation = await prepareThinkspaceBuiltInRuntimeTools({
 		activeProductToolIds: ["source_read"],
+		memoryWriter: stubMemoryWriter(),
 		sourceReader: stubSourceReader({
 			listManifest: () =>
 				Promise.resolve([
@@ -102,6 +131,7 @@ test("source_read returns the Source content and a product-safe not-found for fo
 test("the Source manifest is injected when source_read is active and reflects the Thinkspace's Sources", async () => {
 	const preparation = await prepareThinkspaceBuiltInRuntimeTools({
 		activeProductToolIds: ["source_read", "web_search"],
+		memoryWriter: stubMemoryWriter(),
 		sourceReader: stubSourceReader({
 			listManifest: () =>
 				Promise.resolve([
@@ -130,6 +160,7 @@ test("a Thinkspace with no Sources gets an explicit empty manifest", () => {
 test("a manifest listing failure degrades into a product-safe notice instead of failing the turn", async () => {
 	const preparation = await prepareThinkspaceBuiltInRuntimeTools({
 		activeProductToolIds: ["source_read"],
+		memoryWriter: stubMemoryWriter(),
 		sourceReader: stubSourceReader({
 			listManifest: () => Promise.reject(new Error("D1_ERROR: no such table")),
 		}),
@@ -145,6 +176,7 @@ test("a manifest listing failure degrades into a product-safe notice instead of 
 test("web and Source tool failures resolve to product-safe messages without transport detail", async () => {
 	const preparation = await prepareThinkspaceBuiltInRuntimeTools({
 		activeProductToolIds: ["web_search", "web_fetch", "source_read"],
+		memoryWriter: stubMemoryWriter(),
 		sourceReader: stubSourceReader({
 			read: () => Promise.reject(new SourceContentStorageError()),
 		}),
@@ -171,10 +203,77 @@ test("web and Source tool failures resolve to product-safe messages without tran
 	assert.doesNotMatch(sourceFailure, /R2|bucket|binding/iu);
 });
 
+test("memory_write is constructed when active, declares its hold, and writes only through the writer on an approved execute", async () => {
+	const { writer, writes } = recordingMemoryWriter();
+	const preparation = await prepareThinkspaceBuiltInRuntimeTools({
+		activeProductToolIds: ["memory_write"],
+		memoryWriter: writer,
+		sourceReader: stubSourceReader(),
+		webReader: stubWebReader(),
+	});
+
+	assert.deepEqual(preparation.activeToolNames, ["memory_write"]);
+	// The hold is constant so it can never be ambiguous: the runtime always
+	// parks this tool for the owner rather than executing it inline.
+	assert.equal((preparation.tools.memory_write as Tool).needsApproval, true);
+
+	// execute only ever runs on an approved continuation; when it does, the
+	// proposed Memory flows through the writer keyed by the held tool call.
+	const result = await executeTool(preparation.tools.memory_write, {
+		content: "The user prefers Vendor A for its pricing.",
+	});
+	assert.match(result, /Recorded a durable Product Memory/u);
+	assert.deepEqual(writes, [
+		{ content: "The user prefers Vendor A for its pricing.", toolCallId: "tool_call_1" },
+	]);
+});
+
+test("a memory_write storage failure resolves to a product-safe message without transport detail", async () => {
+	const preparation = await prepareThinkspaceBuiltInRuntimeTools({
+		activeProductToolIds: ["memory_write"],
+		memoryWriter: stubMemoryWriter({
+			write: () => Promise.reject(new Error("D1_ERROR: database is locked")),
+		}),
+		sourceReader: stubSourceReader(),
+		webReader: stubWebReader(),
+	});
+
+	const failure = await executeTool(preparation.tools.memory_write, { content: "Anything." });
+	assert.match(failure, /failed unexpectedly/u);
+	assert.doesNotMatch(failure, /D1_ERROR/u);
+});
+
 test("the policy guard passes for the shipped policy and active built-ins", () => {
 	assert.doesNotThrow(() =>
 		assertThinkspaceRuntimePolicySupportsBuiltInTools({
-			activeProductToolIds: ["web_search", "source_read"],
+			activeProductToolIds: ["web_search", "source_read", "memory_write"],
+		}),
+	);
+});
+
+test("the policy guard gates memory_write on the held-write capability, not the read capability", () => {
+	// A policy with held internal writes disabled but reads enabled must reject
+	// an assembled memory_write while still admitting the read tools.
+	const noHeldWritesPolicy = {
+		...THINKSPACE_RUNTIME_POLICY,
+		capabilities: THINKSPACE_RUNTIME_POLICY.capabilities.map((capability) =>
+			capability.id === "memory_writes" ? { ...capability, enabled: false } : capability,
+		),
+	};
+
+	assert.throws(
+		() =>
+			assertThinkspaceRuntimePolicySupportsBuiltInTools({
+				activeProductToolIds: ["memory_write"],
+				policy: noHeldWritesPolicy,
+			}),
+		/thinkspace-turn-product-safe:.*runtime safety policy/u,
+	);
+
+	assert.doesNotThrow(() =>
+		assertThinkspaceRuntimePolicySupportsBuiltInTools({
+			activeProductToolIds: ["web_search"],
+			policy: noHeldWritesPolicy,
 		}),
 	);
 });

--- a/packages/api/src/thinkspaces/built-in-runtime-tools.ts
+++ b/packages/api/src/thinkspaces/built-in-runtime-tools.ts
@@ -18,11 +18,17 @@ import type { ActiveAgentProfileRevision } from "./agent-profile";
 import { formatBuiltInSourceReadResult, isBuiltInToolId } from "./built-in-tools";
 import type { BuiltInToolId } from "./built-in-tools";
 import { markThinkspaceTurnProductSafeError } from "./inspect";
+import type { ThinkspaceMemoryWriter } from "./memory-writer";
 import type { ThinkspacePermissionPolicy } from "./permission-policy";
 import { isThinkspaceRuntimeCapabilityEnabled, THINKSPACE_RUNTIME_POLICY } from "./runtime-policy";
-import type { ThinkspaceRuntimePolicy } from "./runtime-policy";
+import type { ThinkspaceRuntimeCapabilityId, ThinkspaceRuntimePolicy } from "./runtime-policy";
 import { ThinkspaceWebReadError } from "./web-reader";
 import type { ThinkspaceWebReader } from "./web-reader";
+
+export const THINKSPACE_MEMORY_CONTENT_MAX_LENGTH = 4000;
+
+const MEMORY_WRITE_ACCEPTED_MESSAGE =
+	"Recorded a durable Product Memory for this Thinkspace. It is now part of what this Thinkspace remembers.";
 
 export const THINKSPACE_BUILT_IN_TOOL_BLOCKED_REASON =
 	"This built-in tool is not currently available for this Thinkspace Agent turn.";
@@ -51,6 +57,7 @@ const toProductSafeToolFailure = (error: unknown): string => {
 
 export interface PrepareThinkspaceBuiltInRuntimeToolsInput {
 	activeProductToolIds: readonly string[];
+	memoryWriter: ThinkspaceMemoryWriter;
 	sourceReader: ThinkspaceSourceReader;
 	webReader: ThinkspaceWebReader;
 }
@@ -135,8 +142,48 @@ const createSourceReadTool = (sourceReader: ThinkspaceSourceReader) =>
 		}),
 	});
 
+/**
+ * The held Memory-proposing tool. `needsApproval` is constant so the hold can
+ * never be ambiguous (fail closed: undeterminable held status is treated as
+ * held). The AI SDK does not run `execute` until the owner approves, so the
+ * write below happens only on an approved continuation; a rejection never
+ * reaches it and nothing persists.
+ */
+const createMemoryWriteTool = (memoryWriter: ThinkspaceMemoryWriter) =>
+	tool({
+		description:
+			"Propose a durable Product Memory for this Thinkspace — a fact about the user's Goal or context worth remembering across turns. Held for the owner's Approval: calling it records nothing until the owner approves the proposal.",
+		execute: async ({ content }, { toolCallId }) => {
+			try {
+				await memoryWriter.write({ content, toolCallId });
+
+				return MEMORY_WRITE_ACCEPTED_MESSAGE;
+			} catch (error) {
+				return toProductSafeToolFailure(error);
+			}
+		},
+		inputSchema: z.object({
+			content: z
+				.string()
+				.min(1)
+				.max(THINKSPACE_MEMORY_CONTENT_MAX_LENGTH)
+				.describe("The Product Memory to remember, written as a concise standalone statement."),
+		}),
+		needsApproval: true,
+	});
+
 const activeBuiltInToolIds = (activeProductToolIds: readonly string[]): BuiltInToolId[] =>
 	activeProductToolIds.filter(isBuiltInToolId);
+
+/**
+ * Which runtime capability class governs each built-in tool: the read tools
+ * ride `builtin_read_tools`; the held Memory-proposing tool rides the
+ * `memory_writes` held-internal-write class. The fail-closed assembly check
+ * uses this so a tool can never go active under a policy that has its governing
+ * capability disabled.
+ */
+const builtInToolRuntimeCapabilityId = (toolId: BuiltInToolId): ThinkspaceRuntimeCapabilityId =>
+	toolId === "memory_write" ? "memory_writes" : "builtin_read_tools";
 
 /**
  * Builds the built-in half of the turn's toolset from the active set. The
@@ -146,6 +193,7 @@ const activeBuiltInToolIds = (activeProductToolIds: readonly string[]): BuiltInT
  */
 export const prepareThinkspaceBuiltInRuntimeTools = async ({
 	activeProductToolIds,
+	memoryWriter,
 	sourceReader,
 	webReader,
 }: PrepareThinkspaceBuiltInRuntimeToolsInput): Promise<ThinkspaceBuiltInRuntimePreparation> => {
@@ -160,6 +208,10 @@ export const prepareThinkspaceBuiltInRuntimeTools = async ({
 
 		if (toolId === "web_fetch") {
 			tools.web_fetch = createWebFetchTool(webReader);
+		}
+
+		if (toolId === "memory_write") {
+			tools.memory_write = createMemoryWriteTool(memoryWriter);
 		}
 
 		if (toolId === "source_read") {
@@ -181,10 +233,12 @@ export const prepareThinkspaceBuiltInRuntimeTools = async ({
 };
 
 /**
- * The zero-blast-radius guarantee must survive bugs (PRD #73): if assembly
- * produced an active built-in tool while the runtime policy has the
- * capability disabled, or workspace bash is not forced off, the turn fails
- * product-safely before any inference happens.
+ * The zero-blast-radius guarantee must survive bugs (PRD #73, #92): if assembly
+ * produced an active built-in tool while the runtime policy has that tool's
+ * governing capability disabled, or workspace bash is not forced off, the turn
+ * fails product-safely before any inference happens. Each active built-in is
+ * checked against its own capability class, so the held Memory-proposing tool
+ * can never assemble under a policy that has held internal writes disabled.
  */
 export const assertThinkspaceRuntimePolicySupportsBuiltInTools = ({
 	activeProductToolIds,
@@ -197,11 +251,10 @@ export const assertThinkspaceRuntimePolicySupportsBuiltInTools = ({
 		throw new Error(markThinkspaceTurnProductSafeError(POLICY_ASSEMBLY_MISMATCH_MESSAGE));
 	}
 
-	if (
-		activeBuiltInToolIds(activeProductToolIds).length > 0 &&
-		!isThinkspaceRuntimeCapabilityEnabled(policy, "builtin_read_tools")
-	) {
-		throw new Error(markThinkspaceTurnProductSafeError(POLICY_ASSEMBLY_MISMATCH_MESSAGE));
+	for (const toolId of activeBuiltInToolIds(activeProductToolIds)) {
+		if (!isThinkspaceRuntimeCapabilityEnabled(policy, builtInToolRuntimeCapabilityId(toolId))) {
+			throw new Error(markThinkspaceTurnProductSafeError(POLICY_ASSEMBLY_MISMATCH_MESSAGE));
+		}
 	}
 };
 

--- a/packages/api/src/thinkspaces/memories-repository.ts
+++ b/packages/api/src/thinkspaces/memories-repository.ts
@@ -1,0 +1,81 @@
+import type { ProductDb } from "@better-agent/db";
+import { thinkspaceMemories } from "@better-agent/db/schema/memories";
+import type { ThinkspaceMemory } from "@better-agent/db/schema/memories";
+import { and, desc, eq } from "drizzle-orm";
+
+export interface CreateThinkspaceMemoryInput {
+	record: {
+		content: string;
+		id: string;
+		profileRevisionId: string | null;
+		profileVersion: number | null;
+		thinkspaceId: string;
+		toolCallId: string;
+	};
+}
+
+export interface ListThinkspaceMemoriesInput {
+	thinkspaceId: string;
+}
+
+const getThinkspaceMemoryByToolCall = async (
+	db: ProductDb,
+	{ thinkspaceId, toolCallId }: { thinkspaceId: string; toolCallId: string },
+): Promise<ThinkspaceMemory | null> => {
+	const [memory] = await db
+		.select()
+		.from(thinkspaceMemories)
+		.where(
+			and(
+				eq(thinkspaceMemories.thinkspaceId, thinkspaceId),
+				eq(thinkspaceMemories.toolCallId, toolCallId),
+			),
+		)
+		.limit(1);
+
+	return memory ?? null;
+};
+
+/**
+ * Writes an approved Memory into the per-Thinkspace store. The write is
+ * idempotent on (thinkspaceId, toolCallId): a resumed or retried continuation
+ * of the held tool call resolves to the already-stored Memory instead of
+ * inserting a duplicate, so approving once can only ever produce one Memory.
+ */
+export const createThinkspaceMemory = async (
+	db: ProductDb,
+	{ record }: CreateThinkspaceMemoryInput,
+): Promise<ThinkspaceMemory> => {
+	const [created] = await db
+		.insert(thinkspaceMemories)
+		.values(record)
+		.onConflictDoNothing({
+			target: [thinkspaceMemories.thinkspaceId, thinkspaceMemories.toolCallId],
+		})
+		.returning();
+
+	if (created) {
+		return created;
+	}
+
+	const existing = await getThinkspaceMemoryByToolCall(db, {
+		thinkspaceId: record.thinkspaceId,
+		toolCallId: record.toolCallId,
+	});
+
+	if (!existing) {
+		throw new Error("Memory was not persisted.");
+	}
+
+	return existing;
+};
+
+export const listThinkspaceMemories = async (
+	db: ProductDb,
+	{ thinkspaceId }: ListThinkspaceMemoriesInput,
+): Promise<ThinkspaceMemory[]> =>
+	await db
+		.select()
+		.from(thinkspaceMemories)
+		.where(eq(thinkspaceMemories.thinkspaceId, thinkspaceId))
+		.orderBy(desc(thinkspaceMemories.createdAt));

--- a/packages/api/src/thinkspaces/memory-writer.ts
+++ b/packages/api/src/thinkspaces/memory-writer.ts
@@ -1,0 +1,51 @@
+import type { ProductDb } from "@better-agent/db";
+
+import { createThinkspaceMemory } from "./memories-repository";
+
+export interface ThinkspaceMemoryWriteInput {
+	content: string;
+	toolCallId: string;
+}
+
+/**
+ * The seam the held Memory-proposing tool writes through once an Approval is
+ * granted. Defined as an interface so the runtime tool stays unaware of storage
+ * and tests can substitute a recorder.
+ */
+export interface ThinkspaceMemoryWriter {
+	write: (input: ThinkspaceMemoryWriteInput) => Promise<void>;
+}
+
+export interface CreateThinkspaceMemoryWriterInput {
+	attribution: { profileRevisionId: string; profileVersion: number } | null;
+	db: ProductDb;
+	generateId?: () => string;
+	thinkspaceId: string;
+}
+
+const defaultGenerateMemoryId = (): string => `memory_${crypto.randomUUID()}`;
+
+/**
+ * Store-backed Memory writer. Carries the turn's revision attribution so an
+ * accepted Memory records which Agent Profile revision proposed it, regardless
+ * of how much later the Approval was decided.
+ */
+export const createThinkspaceMemoryWriter = ({
+	attribution,
+	db,
+	generateId = defaultGenerateMemoryId,
+	thinkspaceId,
+}: CreateThinkspaceMemoryWriterInput): ThinkspaceMemoryWriter => ({
+	write: async ({ content, toolCallId }) => {
+		await createThinkspaceMemory(db, {
+			record: {
+				content,
+				id: generateId(),
+				profileRevisionId: attribution?.profileRevisionId ?? null,
+				profileVersion: attribution?.profileVersion ?? null,
+				thinkspaceId,
+				toolCallId,
+			},
+		});
+	},
+});

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -35,6 +35,7 @@ import {
 	saveAgentProfileDraft,
 } from "./agent-profile-repository";
 import { inspectOwnedThinkspaceTurn, THINKSPACE_TURN_SUBMISSION_ID_MAX_LENGTH } from "./inspect";
+import { listThinkspaceMemories } from "./memories-repository";
 import {
 	listThinkspacePermissions,
 	prepareThinkspacePermissionGrants,
@@ -469,6 +470,27 @@ export const thinkspacesRouter = {
 		async ({ context }) =>
 			await listThinkspaces(context.db, { ownerUserId: context.session.user.id }),
 	),
+	listMemories: protectedProcedure.input(thinkspaceIdInput).handler(async ({ context, input }) => {
+		const thinkspace = await getThinkspace(context.db, {
+			ownerUserId: context.session.user.id,
+			thinkspaceId: input.thinkspaceId,
+		});
+
+		if (!thinkspace) {
+			throw toNotFound();
+		}
+
+		const memories = await listThinkspaceMemories(context.db, { thinkspaceId: thinkspace.id });
+
+		return memories.map((memory) => ({
+			content: memory.content,
+			createdAt: memory.createdAt,
+			id: memory.id,
+			profileRevisionId: memory.profileRevisionId,
+			profileVersion: memory.profileVersion,
+			thinkspaceId: memory.thinkspaceId,
+		}));
+	}),
 	modelReadiness: protectedProcedure
 		.input(thinkspaceIdInput)
 		.handler(async ({ context, input }) => {

--- a/packages/db/src/migrations/0009_green_triton.sql
+++ b/packages/db/src/migrations/0009_green_triton.sql
@@ -1,0 +1,36 @@
+CREATE TABLE `thinkspace_approvals` (
+	`action_kind` text NOT NULL,
+	`approval_request_id` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`id` text PRIMARY KEY NOT NULL,
+	`owner_user_id` text NOT NULL,
+	`profile_revision_id` text,
+	`profile_version` integer,
+	`proposed_content` text NOT NULL,
+	`proposed_summary` text NOT NULL,
+	`resolved_at` integer,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`submission_id` text,
+	`thinkspace_id` text NOT NULL,
+	`tool_call_id` text NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`owner_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`thinkspace_id`) REFERENCES `thinkspaces`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_thinkspace_approvals_owner_status_created` ON `thinkspace_approvals` (`owner_user_id`,`status`,`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_thinkspace_approvals_thinkspace_status` ON `thinkspace_approvals` (`thinkspace_id`,`status`);--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_thinkspace_approvals_thinkspace_tool_call` ON `thinkspace_approvals` (`thinkspace_id`,`tool_call_id`);--> statement-breakpoint
+CREATE TABLE `thinkspace_memories` (
+	`content` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`id` text PRIMARY KEY NOT NULL,
+	`profile_revision_id` text,
+	`profile_version` integer,
+	`thinkspace_id` text NOT NULL,
+	`tool_call_id` text NOT NULL,
+	FOREIGN KEY (`thinkspace_id`) REFERENCES `thinkspaces`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_thinkspace_memories_thinkspace_created` ON `thinkspace_memories` (`thinkspace_id`,`created_at`);--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_thinkspace_memories_thinkspace_tool_call` ON `thinkspace_memories` (`thinkspace_id`,`tool_call_id`);

--- a/packages/db/src/migrations/meta/0009_snapshot.json
+++ b/packages/db/src/migrations/meta/0009_snapshot.json
@@ -1,0 +1,1525 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a7475183-db1f-457a-a13d-d823c94f740c",
+  "prevId": "0a46a7a6-d0ed-46e9-b702-2773fd9fdc3e",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_account_provider_account": {
+          "name": "idx_account_provider_account",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_server_catalog": {
+      "name": "mcp_server_catalog",
+      "columns": {
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'streamable_http'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_agent_profiles": {
+      "name": "thinkspace_agent_profiles",
+      "columns": {
+        "activated_at": {
+          "name": "activated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_permissions": {
+          "name": "requested_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "routines": {
+          "name": "routines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "skill_references": {
+          "name": "skill_references",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_enablements": {
+          "name": "tool_enablements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_agent_profiles_thinkspace_version": {
+          "name": "uq_agent_profiles_thinkspace_version",
+          "columns": [
+            "thinkspace_id",
+            "version"
+          ],
+          "isUnique": true
+        },
+        "uq_agent_profiles_thinkspace_active": {
+          "name": "uq_agent_profiles_thinkspace_active",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'active'"
+        },
+        "uq_agent_profiles_thinkspace_draft": {
+          "name": "uq_agent_profiles_thinkspace_draft",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'draft'"
+        },
+        "idx_agent_profiles_thinkspace_status": {
+          "name": "idx_agent_profiles_thinkspace_status",
+          "columns": [
+            "thinkspace_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_agent_profiles_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_agent_profiles_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_agent_profiles",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_approvals": {
+      "name": "thinkspace_approvals",
+      "columns": {
+        "action_kind": {
+          "name": "action_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_request_id": {
+          "name": "approval_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_revision_id": {
+          "name": "profile_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_version": {
+          "name": "profile_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposed_content": {
+          "name": "proposed_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposed_summary": {
+          "name": "proposed_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_thinkspace_approvals_owner_status_created": {
+          "name": "idx_thinkspace_approvals_owner_status_created",
+          "columns": [
+            "owner_user_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_thinkspace_approvals_thinkspace_status": {
+          "name": "idx_thinkspace_approvals_thinkspace_status",
+          "columns": [
+            "thinkspace_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "uq_thinkspace_approvals_thinkspace_tool_call": {
+          "name": "uq_thinkspace_approvals_thinkspace_tool_call",
+          "columns": [
+            "thinkspace_id",
+            "tool_call_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_approvals_owner_user_id_user_id_fk": {
+          "name": "thinkspace_approvals_owner_user_id_user_id_fk",
+          "tableFrom": "thinkspace_approvals",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thinkspace_approvals_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_approvals_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_approvals",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_memories": {
+      "name": "thinkspace_memories",
+      "columns": {
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_revision_id": {
+          "name": "profile_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_version": {
+          "name": "profile_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_thinkspace_memories_thinkspace_created": {
+          "name": "idx_thinkspace_memories_thinkspace_created",
+          "columns": [
+            "thinkspace_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "uq_thinkspace_memories_thinkspace_tool_call": {
+          "name": "uq_thinkspace_memories_thinkspace_tool_call",
+          "columns": [
+            "thinkspace_id",
+            "tool_call_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_memories_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_memories_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_memories",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_permissions": {
+      "name": "thinkspace_permissions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "resource_scope": {
+          "name": "resource_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_thinkspace_permissions_thinkspace": {
+          "name": "idx_thinkspace_permissions_thinkspace",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": false
+        },
+        "uidx_thinkspace_permissions_model_provider": {
+          "name": "uidx_thinkspace_permissions_model_provider",
+          "columns": [
+            "thinkspace_id",
+            "kind",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_permissions_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_permissions_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_permissions",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_sources": {
+      "name": "thinkspace_sources",
+      "columns": {
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_thinkspace_sources_thinkspace_created": {
+          "name": "idx_thinkspace_sources_thinkspace_created",
+          "columns": [
+            "thinkspace_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_sources_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_sources_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_sources",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspaces": {
+      "name": "thinkspaces",
+      "columns": {
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration_summary": {
+          "name": "configuration_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memory_governance": {
+          "name": "memory_governance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_thinkspaces_owner_status_updated": {
+          "name": "idx_thinkspaces_owner_status_updated",
+          "columns": [
+            "owner_user_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "idx_thinkspaces_owner_created": {
+          "name": "idx_thinkspaces_owner_created",
+          "columns": [
+            "owner_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_thinkspaces_owner_archived": {
+          "name": "idx_thinkspaces_owner_archived",
+          "columns": [
+            "owner_user_id",
+            "archived_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thinkspaces_owner_user_id_user_id_fk": {
+          "name": "thinkspaces_owner_user_id_user_id_fk",
+          "tableFrom": "thinkspaces",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_mcp_connections": {
+      "name": "user_mcp_connections",
+      "columns": {
+        "catalog_visible": {
+          "name": "catalog_visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_headers": {
+          "name": "encrypted_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'streamable_http'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_mcp_connections_user": {
+          "name": "idx_user_mcp_connections_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_mcp_connections_server": {
+          "name": "idx_user_mcp_connections_server",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_mcp_connections_server_id_mcp_server_catalog_id_fk": {
+          "name": "user_mcp_connections_server_id_mcp_server_catalog_id_fk",
+          "tableFrom": "user_mcp_connections",
+          "tableTo": "mcp_server_catalog",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_mcp_connections_user_id_user_id_fk": {
+          "name": "user_mcp_connections_user_id_user_id_fk",
+          "tableFrom": "user_mcp_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_product_settings": {
+      "name": "user_product_settings",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_product_settings_user_id_user_id_fk": {
+          "name": "user_product_settings_user_id_user_id_fk",
+          "tableFrom": "user_product_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_provider_credentials": {
+      "name": "user_provider_credentials",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_provider_credentials_user": {
+          "name": "idx_user_provider_credentials_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_provider_credentials_user_provider": {
+          "name": "idx_user_provider_credentials_user_provider",
+          "columns": [
+            "user_id",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_provider_credentials_user_id_user_id_fk": {
+          "name": "user_provider_credentials_user_id_user_id_fk",
+          "tableFrom": "user_provider_credentials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        },
+        "idx_verification_expires_at": {
+          "name": "idx_verification_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1781285043540,
       "tag": "0008_aspiring_spacker_dave",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1781747165847,
+      "tag": "0009_green_triton",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/approvals.ts
+++ b/packages/db/src/schema/approvals.ts
@@ -1,0 +1,101 @@
+import { relations } from "drizzle-orm";
+import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+
+import { user } from "./auth";
+import { timestampMsNow } from "./common";
+import { thinkspaces } from "./thinkspaces";
+
+/**
+ * The status of a pending Approval. An Approval is the owner's consent to one
+ * specific proposed action within a Permission's allowance; it stays `pending`
+ * until the owner decides it, then leaves the Review Queue as `approved` or
+ * `rejected`.
+ */
+export const THINKSPACE_APPROVAL_STATUS = {
+	APPROVED: "approved",
+	PENDING: "pending",
+	REJECTED: "rejected",
+} as const;
+
+export type ThinkspaceApprovalStatus =
+	(typeof THINKSPACE_APPROVAL_STATUS)[keyof typeof THINKSPACE_APPROVAL_STATUS];
+
+/**
+ * The class of action a pending Approval holds. The first (and only) held
+ * action in this slice is the agent proposing a durable Product Memory.
+ */
+export const THINKSPACE_APPROVAL_ACTION_KIND = {
+	MEMORY_WRITE: "memory_write",
+} as const;
+
+export type ThinkspaceApprovalActionKind =
+	(typeof THINKSPACE_APPROVAL_ACTION_KIND)[keyof typeof THINKSPACE_APPROVAL_ACTION_KIND];
+
+/**
+ * The D1 index half of a pending Approval (ADR-0002): the authoritative
+ * paused-turn state lives in the Thinkspace Agent's Durable Object, where
+ * Project Think persists it; this table mirrors one row per pending Approval so
+ * the cross-Thinkspace Review Queue can be a simple owner-indexed query and a
+ * decision can be applied long after the turn parked. The row is written when
+ * the hold is raised and updated when the Approval is resolved.
+ *
+ * `owner_user_id` is denormalized from the Thinkspace so the Review Queue lists
+ * every pending Approval across all of a user's Thinkspaces without a join.
+ * `tool_call_id` is the durable, entry-path-agnostic handle into the parked
+ * turn's transcript; the unique index on (thinkspace_id, tool_call_id) makes
+ * the hold-time upsert idempotent so reconciling the same parked turn twice
+ * never duplicates the Approval.
+ */
+export const thinkspaceApprovals = sqliteTable(
+	"thinkspace_approvals",
+	{
+		actionKind: text("action_kind").notNull(),
+		approvalRequestId: text("approval_request_id").notNull(),
+		createdAt: integer("created_at", { mode: "timestamp_ms" }).default(timestampMsNow).notNull(),
+		id: text("id").primaryKey(),
+		ownerUserId: text("owner_user_id")
+			.notNull()
+			.references(() => user.id, { onDelete: "cascade" }),
+		profileRevisionId: text("profile_revision_id"),
+		profileVersion: integer("profile_version"),
+		proposedContent: text("proposed_content").notNull(),
+		proposedSummary: text("proposed_summary").notNull(),
+		resolvedAt: integer("resolved_at", { mode: "timestamp_ms" }),
+		status: text("status").default(THINKSPACE_APPROVAL_STATUS.PENDING).notNull(),
+		submissionId: text("submission_id"),
+		thinkspaceId: text("thinkspace_id")
+			.notNull()
+			.references(() => thinkspaces.id, { onDelete: "cascade" }),
+		toolCallId: text("tool_call_id").notNull(),
+		updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+			.default(timestampMsNow)
+			.$onUpdate(() => new Date())
+			.notNull(),
+	},
+	(table) => [
+		index("idx_thinkspace_approvals_owner_status_created").on(
+			table.ownerUserId,
+			table.status,
+			table.createdAt,
+		),
+		index("idx_thinkspace_approvals_thinkspace_status").on(table.thinkspaceId, table.status),
+		uniqueIndex("uq_thinkspace_approvals_thinkspace_tool_call").on(
+			table.thinkspaceId,
+			table.toolCallId,
+		),
+	],
+);
+
+export const thinkspaceApprovalRelations = relations(thinkspaceApprovals, ({ one }) => ({
+	owner: one(user, {
+		fields: [thinkspaceApprovals.ownerUserId],
+		references: [user.id],
+	}),
+	thinkspace: one(thinkspaces, {
+		fields: [thinkspaceApprovals.thinkspaceId],
+		references: [thinkspaces.id],
+	}),
+}));
+
+export type ThinkspaceApproval = typeof thinkspaceApprovals.$inferSelect;
+export type NewThinkspaceApproval = typeof thinkspaceApprovals.$inferInsert;

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -15,7 +15,23 @@ export {
 	thinkspaceAgentProfileRelations,
 	thinkspaceAgentProfiles,
 } from "./agent-profiles";
+export {
+	THINKSPACE_APPROVAL_ACTION_KIND,
+	THINKSPACE_APPROVAL_STATUS,
+	type ThinkspaceApproval,
+	type ThinkspaceApprovalActionKind,
+	thinkspaceApprovalRelations,
+	thinkspaceApprovals,
+	type ThinkspaceApprovalStatus,
+	type NewThinkspaceApproval,
+} from "./approvals";
 export { timestampMsNow } from "./common";
+export {
+	type NewThinkspaceMemory,
+	thinkspaceMemoryRelations,
+	type ThinkspaceMemory,
+	thinkspaceMemories,
+} from "./memories";
 export {
 	type NewThinkspacePermission,
 	THINKSPACE_PERMISSION_KINDS,

--- a/packages/db/src/schema/memories.ts
+++ b/packages/db/src/schema/memories.ts
@@ -1,0 +1,50 @@
+import { relations } from "drizzle-orm";
+import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+
+import { timestampMsNow } from "./common";
+import { thinkspaces } from "./thinkspaces";
+
+/**
+ * A Product Memory is something a Thinkspace Agent learned and the owner
+ * consented to keep — durable understanding that persists across turns instead
+ * of evaporating when a turn ends. This is the minimal store the held
+ * Memory-proposing tool writes into once an Approval is granted (PRD #92): the
+ * agent proposes a Memory, the owner approves it, and the approved content
+ * lands here, scoped to exactly one Thinkspace.
+ *
+ * `tool_call_id` is the held tool call that produced this Memory; the unique
+ * index on (thinkspace_id, tool_call_id) makes the post-approval write
+ * idempotent, so a resumed or retried continuation can never double-write the
+ * same proposed Memory.
+ */
+export const thinkspaceMemories = sqliteTable(
+	"thinkspace_memories",
+	{
+		content: text("content").notNull(),
+		createdAt: integer("created_at", { mode: "timestamp_ms" }).default(timestampMsNow).notNull(),
+		id: text("id").primaryKey(),
+		profileRevisionId: text("profile_revision_id"),
+		profileVersion: integer("profile_version"),
+		thinkspaceId: text("thinkspace_id")
+			.notNull()
+			.references(() => thinkspaces.id, { onDelete: "cascade" }),
+		toolCallId: text("tool_call_id").notNull(),
+	},
+	(table) => [
+		index("idx_thinkspace_memories_thinkspace_created").on(table.thinkspaceId, table.createdAt),
+		uniqueIndex("uq_thinkspace_memories_thinkspace_tool_call").on(
+			table.thinkspaceId,
+			table.toolCallId,
+		),
+	],
+);
+
+export const thinkspaceMemoryRelations = relations(thinkspaceMemories, ({ one }) => ({
+	thinkspace: one(thinkspaces, {
+		fields: [thinkspaceMemories.thinkspaceId],
+		references: [thinkspaces.id],
+	}),
+}));
+
+export type ThinkspaceMemory = typeof thinkspaceMemories.$inferSelect;
+export type NewThinkspaceMemory = typeof thinkspaceMemories.$inferInsert;


### PR DESCRIPTION
Closes #95. Third slice of PRD #92 (`governed_tools_v3` — the Approval holdpoint and Review Queue). Blocked-by #93 and #94 (both merged).

## What this does

Gates the built-in `memory_write` tool behind a **durable approval hold**. When the agent calls it, the runtime parks the turn and emits a transport-level approval request instead of writing; Better Agent maps that pause onto a product-level **Approval**. Approving resumes the parked turn and writes a visible Memory; rejecting resumes the turn and persists nothing. A decision applied long after the turn — even after runtime eviction — still resumes the correct parked turn.

The hold rides Project Think 0.8.8's native AI SDK v6 tool approval: `needsApproval` is **constant `true`** so the hold can never be ambiguous, and the tool's `execute` (the actual Memory write) runs **only on an approved continuation** — approve → write, reject → nothing persists is SDK-native.

## How it works

- **Held tool, fail-closed.** `memory_write` is routed through its own runtime capability class so it can never assemble under a policy with held internal writes disabled. `needsApproval` is a constant, never a predicate.
- **Out-of-band decide.** `decideMemoryApproval` flips the parked tool part in the transcript in place (`updateMessageInHistory`) and resumes via `continueLastTurn()`, which re-runs `beforeTurn` and re-assembles the tool + writer. (`saveMessages` is append-only and `_applyToolApproval` is private — flip-in-place + continue is the only correct route.)
- **State split (ADR-0002).** Authoritative paused-turn state stays in the Thinkspace Agent's Durable Object where Think persists it; a `thinkspace_approvals` D1 row mirrors each pending Approval (written/reconciled in `onChatResponse`, resolved by the decide path, located by `tool_call_id`). Survives eviction.
- **Pure, testable core.** Transcript flip and pending/decided extraction live in `packages/api/src/thinkspaces/approvals.ts`; repositories in `approvals-repository.ts` / `memories-repository.ts`; control-plane wiring in `approval-decisions.ts`; the owner-gated `approvals` router drives the DO **404-first** (non-owner, unauthenticated, and guessed-id callers never reach the runtime). `thinkspaces.listMemories` makes an approved Memory visible.

Introduces the `thinkspace_approvals` and `thinkspace_memories` schema with migration `0009`.

## Acceptance criteria (#95)

- [x] Calling the Memory-proposing tool raises a pending Approval and parks the turn rather than writing
- [x] A pending Approval records proposed content, originating turn/submission handle, and Agent Profile revision
- [x] Authoritative paused state lives in the DO; a D1 index row mirrors the pending Approval
- [x] Owner-gated endpoint approves or rejects a specific Approval; approve resumes + writes a visible Memory, reject resumes + persists nothing
- [x] A decision applied after runtime eviction still resumes the correct parked turn
- [x] The holdpoint fails closed: undeterminable held status is treated as held, a missing potency verdict is inert
- [x] Per-turn governance is identical for Sitting and submitted turns
- [x] Non-owner and unauthenticated calls are rejected 404-first
- [x] Turn-seam tests cover raise → approve → write and raise → reject → no-write
- [x] Type checks, Ultracite checks, and package test suites pass (250/250 api tests, 66 new)

## Known caveat (owned by #98)

No single live end-to-end test (model calls tool → parks → approve resumes → executes); the DO extends `Think` and needs a live runtime. The seam is proven at the component level (pure flip + writer `execute` + repo lifecycle + adversarial router boundaries). The live round-trip is the #98 smoke checklist (`.agents/docs/thinkspace-agent-runtime-smoke-checks.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)