### PR TITLE
Add the cross-Thinkspace Review Queue (#96)

### DIFF
--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -5,6 +5,7 @@ import UserMenu from "./user-menu";
 export default function Header() {
 	const links = [
 		{ label: "Thinkspaces", to: "/thinkspaces" },
+		{ label: "Review Queue", to: "/review-queue" },
 		{ label: "Settings", to: "/settings" },
 	] as const;
 

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -18,10 +18,17 @@ import { Route as SettingsIndexRouteImport } from './routes/settings.index'
 import { Route as ThinkspacesThinkspaceIdRouteImport } from './routes/thinkspaces.$thinkspaceId'
 import { Route as SettingsProfileRouteImport } from './routes/settings.profile'
 import { Route as SettingsProductRouteImport } from './routes/settings.product'
+import { Route as ReviewQueueRouteImport } from './routes/review-queue'
+import { Route as ReviewQueueIndexRouteImport } from './routes/review-queue.index'
 
 const ThinkspacesRoute = ThinkspacesRouteImport.update({
   id: '/thinkspaces',
   path: '/thinkspaces',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ReviewQueueRoute = ReviewQueueRouteImport.update({
+  id: '/review-queue',
+  path: '/review-queue',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SettingsRoute = SettingsRouteImport.update({
@@ -43,6 +50,11 @@ const ThinkspacesIndexRoute = ThinkspacesIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => ThinkspacesRoute,
+} as any)
+const ReviewQueueIndexRoute = ReviewQueueIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ReviewQueueRoute,
 } as any)
 const SettingsIndexRoute = SettingsIndexRouteImport.update({
   id: '/',
@@ -68,11 +80,13 @@ const SettingsProductRoute = SettingsProductRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/review-queue': typeof ReviewQueueRouteWithChildren
   '/settings': typeof SettingsRouteWithChildren
   '/thinkspaces': typeof ThinkspacesRouteWithChildren
   '/settings/product': typeof SettingsProductRoute
   '/settings/profile': typeof SettingsProfileRoute
   '/thinkspaces/$thinkspaceId': typeof ThinkspacesThinkspaceIdRoute
+  '/review-queue/': typeof ReviewQueueIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/thinkspaces/': typeof ThinkspacesIndexRoute
 }
@@ -82,6 +96,7 @@ export interface FileRoutesByTo {
   '/settings/product': typeof SettingsProductRoute
   '/settings/profile': typeof SettingsProfileRoute
   '/thinkspaces/$thinkspaceId': typeof ThinkspacesThinkspaceIdRoute
+  '/review-queue': typeof ReviewQueueIndexRoute
   '/settings': typeof SettingsIndexRoute
   '/thinkspaces': typeof ThinkspacesIndexRoute
 }
@@ -89,11 +104,13 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/review-queue': typeof ReviewQueueRouteWithChildren
   '/settings': typeof SettingsRouteWithChildren
   '/thinkspaces': typeof ThinkspacesRouteWithChildren
   '/settings/product': typeof SettingsProductRoute
   '/settings/profile': typeof SettingsProfileRoute
   '/thinkspaces/$thinkspaceId': typeof ThinkspacesThinkspaceIdRoute
+  '/review-queue/': typeof ReviewQueueIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/thinkspaces/': typeof ThinkspacesIndexRoute
 }
@@ -102,11 +119,13 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/login'
+    | '/review-queue'
     | '/settings'
     | '/thinkspaces'
     | '/settings/product'
     | '/settings/profile'
     | '/thinkspaces/$thinkspaceId'
+    | '/review-queue/'
     | '/settings/'
     | '/thinkspaces/'
   fileRoutesByTo: FileRoutesByTo
@@ -116,17 +135,20 @@ export interface FileRouteTypes {
     | '/settings/product'
     | '/settings/profile'
     | '/thinkspaces/$thinkspaceId'
+    | '/review-queue'
     | '/settings'
     | '/thinkspaces'
   id:
     | '__root__'
     | '/'
     | '/login'
+    | '/review-queue'
     | '/settings'
     | '/thinkspaces'
     | '/settings/product'
     | '/settings/profile'
     | '/thinkspaces/$thinkspaceId'
+    | '/review-queue/'
     | '/settings/'
     | '/thinkspaces/'
   fileRoutesById: FileRoutesById
@@ -134,6 +156,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LoginRoute: typeof LoginRoute
+  ReviewQueueRoute: typeof ReviewQueueRouteWithChildren
   SettingsRoute: typeof SettingsRouteWithChildren
   ThinkspacesRoute: typeof ThinkspacesRouteWithChildren
 }
@@ -161,6 +184,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/review-queue': {
+      id: '/review-queue'
+      path: '/review-queue'
+      fullPath: '/review-queue'
+      preLoaderRoute: typeof ReviewQueueRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -174,6 +204,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/thinkspaces/'
       preLoaderRoute: typeof ThinkspacesIndexRouteImport
       parentRoute: typeof ThinkspacesRoute
+    }
+    '/review-queue/': {
+      id: '/review-queue/'
+      path: '/'
+      fullPath: '/review-queue/'
+      preLoaderRoute: typeof ReviewQueueIndexRouteImport
+      parentRoute: typeof ReviewQueueRoute
     }
     '/settings/': {
       id: '/settings/'
@@ -236,9 +273,22 @@ const ThinkspacesRouteWithChildren = ThinkspacesRoute._addFileChildren(
   ThinkspacesRouteChildren,
 )
 
+interface ReviewQueueRouteChildren {
+  ReviewQueueIndexRoute: typeof ReviewQueueIndexRoute
+}
+
+const ReviewQueueRouteChildren: ReviewQueueRouteChildren = {
+  ReviewQueueIndexRoute: ReviewQueueIndexRoute,
+}
+
+const ReviewQueueRouteWithChildren = ReviewQueueRoute._addFileChildren(
+  ReviewQueueRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LoginRoute: LoginRoute,
+  ReviewQueueRoute: ReviewQueueRouteWithChildren,
   SettingsRoute: SettingsRouteWithChildren,
   ThinkspacesRoute: ThinkspacesRouteWithChildren,
 }

--- a/apps/web/src/routes/review-queue.index.tsx
+++ b/apps/web/src/routes/review-queue.index.tsx
@@ -1,0 +1,144 @@
+import { Badge } from "@better-agent/ui/components/badge";
+import { Button } from "@better-agent/ui/components/button";
+import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router";
+import { CheckIcon, InboxIcon, XIcon } from "lucide-react";
+
+const routeApi = getRouteApi("/review-queue/");
+
+const dateFormatter = new Intl.DateTimeFormat("en", {
+	dateStyle: "medium",
+	timeStyle: "short",
+});
+
+const formatProposedAt = (value: Date | number | string): string =>
+	dateFormatter.format(new Date(value));
+
+const ACTION_LABELS: Record<string, string> = {
+	memory_write: "Memory proposal",
+};
+
+const actionLabel = (actionKind: string): string => ACTION_LABELS[actionKind] ?? "Held action";
+
+const RouteComponent = () => {
+	const context = routeApi.useRouteContext();
+	const queryClient = useQueryClient();
+	const queueQuery = useSuspenseQuery(context.orpc.approvals.list.queryOptions());
+	const decideMutation = useMutation(
+		context.orpc.approvals.decide.mutationOptions({
+			// A decision either resolves the Approval or reveals it already left the
+			// queue (decided elsewhere, or the parked turn was evicted); either way the
+			// authoritative list is the runtime-backed index, so refetch it both ways.
+			onSettled: async () => {
+				await queryClient.invalidateQueries({
+					queryKey: context.orpc.approvals.list.queryKey(),
+				});
+			},
+		}),
+	);
+
+	const decide = (item: (typeof queueQuery.data)[number], decision: "approved" | "rejected") => {
+		decideMutation.mutate({
+			approvalId: item.approvalId,
+			decision,
+			thinkspaceId: item.thinkspaceId,
+		});
+	};
+
+	const pendingApprovals = queueQuery.data;
+	const hasPending = pendingApprovals.length > 0;
+
+	return (
+		<div className="mx-auto grid w-full max-w-3xl gap-8 px-4 py-8">
+			<div className="grid gap-2">
+				<h1 className="text-2xl font-semibold tracking-tight">Review Queue</h1>
+				<p className="max-w-lg text-muted-foreground text-sm leading-relaxed">
+					Actions your Thinkspace Agents have proposed and are holding for your decision. Approve to
+					let the action run; reject to discard it. Deep work still happens inside each Sitting.
+				</p>
+			</div>
+
+			{decideMutation.isError ? (
+				<p className="text-destructive text-sm" role="alert">
+					{decideMutation.error.message}
+				</p>
+			) : null}
+
+			<section aria-labelledby="review-queue-heading">
+				<h2 className="sr-only" id="review-queue-heading">
+					Pending Approvals
+				</h2>
+
+				{hasPending ? (
+					<ul className="grid gap-3">
+						{pendingApprovals.map((item) => {
+							const isDeciding =
+								decideMutation.isPending &&
+								decideMutation.variables?.approvalId === item.approvalId;
+
+							return (
+								<li
+									className="grid gap-3 rounded-lg border border-border bg-card p-4"
+									key={item.approvalId}
+								>
+									<div className="flex items-start justify-between gap-3">
+										<Link
+											className="font-medium text-sm hover:underline"
+											params={{ thinkspaceId: item.thinkspaceId }}
+											to="/thinkspaces/$thinkspaceId"
+										>
+											{item.thinkspaceGoal}
+										</Link>
+										<Badge variant="secondary">{actionLabel(item.actionKind)}</Badge>
+									</div>
+
+									<p className="text-foreground text-sm leading-relaxed">{item.proposedSummary}</p>
+
+									<div className="flex items-center justify-between gap-3">
+										<p className="text-muted-foreground text-xs">
+											Proposed {formatProposedAt(item.proposedAt)}
+										</p>
+										<div className="flex gap-2">
+											<Button
+												disabled={isDeciding}
+												onClick={() => decide(item, "rejected")}
+												size="sm"
+												variant="outline"
+											>
+												<XIcon />
+												Reject
+											</Button>
+											<Button
+												disabled={isDeciding}
+												onClick={() => decide(item, "approved")}
+												size="sm"
+											>
+												<CheckIcon />
+												Approve
+											</Button>
+										</div>
+									</div>
+								</li>
+							);
+						})}
+					</ul>
+				) : (
+					<div className="grid justify-items-center gap-2 rounded-lg border border-border border-dashed p-10 text-center">
+						<InboxIcon className="size-6 text-muted-foreground" />
+						<p className="font-medium text-sm">Your Review Queue is clear</p>
+						<p className="max-w-sm text-muted-foreground text-sm">
+							When a Thinkspace Agent proposes an action that needs your consent, it will wait for
+							you here.
+						</p>
+					</div>
+				)}
+			</section>
+		</div>
+	);
+};
+
+export const Route = createFileRoute("/review-queue/")({
+	component: RouteComponent,
+	loader: async ({ context }) =>
+		await context.queryClient.ensureQueryData(context.orpc.approvals.list.queryOptions()),
+});

--- a/apps/web/src/routes/review-queue.tsx
+++ b/apps/web/src/routes/review-queue.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+
+import { getUser } from "@/functions/get-user";
+
+export const Route = createFileRoute("/review-queue")({
+	beforeLoad: async ({ location }) => {
+		const session = await getUser();
+		if (!session) {
+			throw redirect({
+				search: { redirect: location.href },
+				to: "/login",
+			});
+		}
+		return { session };
+	},
+	component: Outlet,
+});

--- a/packages/api/src/approvals/router.test.ts
+++ b/packages/api/src/approvals/router.test.ts
@@ -201,3 +201,122 @@ test("a resolved Approval row is invisible to a non-owner's queue read", async (
 	assert.equal(stored.length, 1);
 	assert.equal(stored[0]?.ownerUserId, authenticatedSession.user.id);
 });
+
+test("the Review Queue lists the owner's pending Approvals most-recent first, in product language", async () => {
+	const db = createTestProductDb();
+	await seedOwnedThinkspace(db);
+	await db.insert(thinkspaceApprovals).values([
+		{
+			actionKind: "memory_write",
+			approvalRequestId: "req_old",
+			createdAt: new Date(1000),
+			id: "approval_old",
+			ownerUserId: authenticatedSession.user.id,
+			proposedContent: "The user prefers Vendor A.",
+			proposedSummary: 'Proposed a durable Product Memory: "The user prefers Vendor A."',
+			thinkspaceId: OWNED_THINKSPACE_ID,
+			toolCallId: "tool_old",
+		},
+		{
+			actionKind: "memory_write",
+			approvalRequestId: "req_new",
+			createdAt: new Date(2000),
+			id: "approval_new",
+			ownerUserId: authenticatedSession.user.id,
+			proposedContent: "The user prefers Vendor B.",
+			proposedSummary: 'Proposed a durable Product Memory: "The user prefers Vendor B."',
+			thinkspaceId: OWNED_THINKSPACE_ID,
+			toolCallId: "tool_new",
+		},
+	]);
+
+	const queue = await call(approvalsRouter.list, undefined, {
+		context: createCallContext({ db }),
+	});
+
+	assert.deepEqual(queue, [
+		{
+			actionKind: "memory_write",
+			approvalId: "approval_new",
+			proposedAt: new Date(2000),
+			proposedSummary: 'Proposed a durable Product Memory: "The user prefers Vendor B."',
+			thinkspaceGoal: "Decide between vendors",
+			thinkspaceId: OWNED_THINKSPACE_ID,
+		},
+		{
+			actionKind: "memory_write",
+			approvalId: "approval_old",
+			proposedAt: new Date(1000),
+			proposedSummary: 'Proposed a durable Product Memory: "The user prefers Vendor A."',
+			thinkspaceGoal: "Decide between vendors",
+			thinkspaceId: OWNED_THINKSPACE_ID,
+		},
+	]);
+});
+
+test("a decided Approval has left the Review Queue", async () => {
+	const db = createTestProductDb();
+	await seedOwnedThinkspace(db);
+	await db.insert(thinkspaceApprovals).values([
+		{
+			actionKind: "memory_write",
+			approvalRequestId: "req_pending",
+			id: "approval_pending",
+			ownerUserId: authenticatedSession.user.id,
+			proposedContent: "Still awaiting a decision.",
+			proposedSummary: "Still awaiting a decision.",
+			thinkspaceId: OWNED_THINKSPACE_ID,
+			toolCallId: "tool_pending",
+		},
+		{
+			actionKind: "memory_write",
+			approvalRequestId: "req_done",
+			id: "approval_done",
+			ownerUserId: authenticatedSession.user.id,
+			proposedContent: "Already decided.",
+			proposedSummary: "Already decided.",
+			status: "approved",
+			thinkspaceId: OWNED_THINKSPACE_ID,
+			toolCallId: "tool_done",
+		},
+	]);
+
+	const queue = await call(approvalsRouter.list, undefined, {
+		context: createCallContext({ db }),
+	});
+
+	assert.deepEqual(
+		queue.map((item) => item.approvalId),
+		["approval_pending"],
+	);
+});
+
+test("an Approval is invisible from another owner's Review Queue", async () => {
+	const db = createTestProductDb();
+	await seedOwnedThinkspace(db);
+	await db.insert(thinkspaceApprovals).values({
+		actionKind: "memory_write",
+		approvalRequestId: "req_1",
+		id: "approval_1",
+		ownerUserId: authenticatedSession.user.id,
+		proposedContent: "The user prefers Vendor A.",
+		proposedSummary: "Proposed a durable Product Memory.",
+		thinkspaceId: OWNED_THINKSPACE_ID,
+		toolCallId: "tool_call_1",
+	});
+
+	const queue = await call(approvalsRouter.list, undefined, {
+		context: createCallContext({ db, session: nonOwnerSession }),
+	});
+
+	assert.deepEqual(queue, []);
+});
+
+test("an unauthenticated Review Queue read is rejected before any storage access", async () => {
+	await assert.rejects(
+		call(approvalsRouter.list, undefined, {
+			context: createCallContext({ db: untouchableDb, session: null }),
+		}),
+		expectCode("UNAUTHORIZED"),
+	);
+});

--- a/packages/api/src/approvals/router.ts
+++ b/packages/api/src/approvals/router.ts
@@ -6,6 +6,7 @@ import {
 	decideOwnedThinkspaceMemoryApproval,
 	ThinkspaceApprovalValidationError,
 } from "../thinkspaces/approval-decisions";
+import { listPendingThinkspaceApprovalsByOwner } from "../thinkspaces/approvals-repository";
 
 export const THINKSPACE_APPROVAL_DECISION_REASON_MAX_LENGTH = 1000;
 
@@ -21,10 +22,10 @@ const toNotFound = (): ORPCError<"NOT_FOUND", undefined> =>
 
 /**
  * The Review Queue is the cross-Thinkspace control-plane surface for pending
- * Approvals: it reads the D1 index, and deciding drives the Durable Object that
- * owns the parked turn. This slice exposes only the decide half (the batched
- * list arrives with the Review Queue page); the listing of pending Approvals
- * across all of a user's Thinkspaces follows the same owner-indexed pattern.
+ * Approvals: `list` reads the owner-indexed D1 index (every pending Approval
+ * across all of a user's Thinkspaces), and `decide` drives the Durable Object
+ * that owns the parked turn. Both are owner-scoped — an Approval is invisible
+ * and undecidable from any other owner's queue.
  */
 export const approvalsRouter = {
 	decide: protectedProcedure.input(decideInput).handler(async ({ context, input }) => {
@@ -58,5 +59,19 @@ export const approvalsRouter = {
 			status: result.status,
 			thinkspaceId: result.thinkspaceId,
 		};
+	}),
+	list: protectedProcedure.handler(async ({ context }) => {
+		const pending = await listPendingThinkspaceApprovalsByOwner(context.db, {
+			ownerUserId: context.session.user.id,
+		});
+
+		return pending.map(({ approval, thinkspaceGoal }) => ({
+			actionKind: approval.actionKind,
+			approvalId: approval.id,
+			proposedAt: approval.createdAt,
+			proposedSummary: approval.proposedSummary,
+			thinkspaceGoal,
+			thinkspaceId: approval.thinkspaceId,
+		}));
 	}),
 };

--- a/packages/api/src/thinkspaces/approvals-repository.test.ts
+++ b/packages/api/src/thinkspaces/approvals-repository.test.ts
@@ -3,12 +3,14 @@ import test from "node:test";
 
 import type { ProductDb } from "@better-agent/db";
 import { user } from "@better-agent/db/schema/auth";
+import { thinkspaceApprovals } from "@better-agent/db/schema/approvals";
 import { thinkspaces } from "@better-agent/db/schema/thinkspaces";
 
 import { createTestProductDb } from "../testing/product-db";
 import {
 	getThinkspaceApproval,
 	listPendingThinkspaceApprovals,
+	listPendingThinkspaceApprovalsByOwner,
 	resolveThinkspaceApproval,
 	upsertPendingThinkspaceApproval,
 } from "./approvals-repository";
@@ -110,6 +112,105 @@ test("resolving moves an Approval out of the queue and is a no-op the second tim
 		thinkspaceId: THINKSPACE_ID,
 	});
 	assert.equal(stored?.status, "approved");
+});
+
+test("the owner's Review Queue lists every pending Approval across their Thinkspaces, most-recent first, each named by its Thinkspace", async () => {
+	const db = createTestProductDb();
+	await seed(db);
+
+	await db.insert(thinkspaceApprovals).values([
+		{
+			actionKind: "memory_write",
+			approvalRequestId: "req_old",
+			createdAt: new Date(1000),
+			id: "approval_old",
+			ownerUserId: OWNER_ID,
+			proposedContent: "Older proposal.",
+			proposedSummary: "Older proposal.",
+			thinkspaceId: THINKSPACE_ID,
+			toolCallId: "tool_old",
+		},
+		{
+			actionKind: "memory_write",
+			approvalRequestId: "req_new",
+			createdAt: new Date(2000),
+			id: "approval_new",
+			ownerUserId: OWNER_ID,
+			proposedContent: "Newer proposal.",
+			proposedSummary: "Newer proposal.",
+			thinkspaceId: OTHER_THINKSPACE_ID,
+			toolCallId: "tool_new",
+		},
+	]);
+
+	const queue = await listPendingThinkspaceApprovalsByOwner(db, { ownerUserId: OWNER_ID });
+
+	assert.deepEqual(
+		queue.map((item) => item.approval.id),
+		["approval_new", "approval_old"],
+	);
+	assert.equal(queue[0]?.thinkspaceGoal, "Other");
+	assert.equal(queue[1]?.thinkspaceGoal, "Decide vendors");
+});
+
+test("a resolved Approval and another owner's pending Approval never appear in the queue", async () => {
+	const db = createTestProductDb();
+	await seed(db);
+	await db.insert(user).values({ email: "other@example.com", id: "other_owner", name: "Other" });
+	await db.insert(thinkspaces).values({
+		goal: "Someone else's",
+		id: "thinkspace_other_owner",
+		ownerUserId: "other_owner",
+		status: "active",
+	});
+	await db.insert(thinkspaceApprovals).values([
+		{
+			actionKind: "memory_write",
+			approvalRequestId: "req_pending",
+			id: "approval_pending",
+			ownerUserId: OWNER_ID,
+			proposedContent: "Still pending.",
+			proposedSummary: "Still pending.",
+			thinkspaceId: THINKSPACE_ID,
+			toolCallId: "tool_pending",
+		},
+		{
+			actionKind: "memory_write",
+			approvalRequestId: "req_resolved",
+			id: "approval_resolved",
+			ownerUserId: OWNER_ID,
+			proposedContent: "Already decided.",
+			proposedSummary: "Already decided.",
+			status: "approved",
+			thinkspaceId: THINKSPACE_ID,
+			toolCallId: "tool_resolved",
+		},
+		{
+			actionKind: "memory_write",
+			approvalRequestId: "req_foreign",
+			id: "approval_foreign",
+			ownerUserId: "other_owner",
+			proposedContent: "Not yours.",
+			proposedSummary: "Not yours.",
+			thinkspaceId: "thinkspace_other_owner",
+			toolCallId: "tool_foreign",
+		},
+	]);
+
+	const queue = await listPendingThinkspaceApprovalsByOwner(db, { ownerUserId: OWNER_ID });
+	assert.deepEqual(
+		queue.map((item) => item.approval.id),
+		["approval_pending"],
+	);
+
+	// Owner-scoping is mutual: the other owner sees only their own pending Approval.
+	const foreignQueue = await listPendingThinkspaceApprovalsByOwner(db, {
+		ownerUserId: "other_owner",
+	});
+	assert.deepEqual(
+		foreignQueue.map((item) => item.approval.id),
+		["approval_foreign"],
+	);
 });
 
 test("an approved Memory is written once and is visible; the same held call never double-writes", async () => {

--- a/packages/api/src/thinkspaces/approvals-repository.ts
+++ b/packages/api/src/thinkspaces/approvals-repository.ts
@@ -4,6 +4,7 @@ import type {
 	ThinkspaceApproval,
 	ThinkspaceApprovalStatus,
 } from "@better-agent/db/schema/approvals";
+import { thinkspaces } from "@better-agent/db/schema/thinkspaces";
 import { and, desc, eq } from "drizzle-orm";
 
 export interface UpsertPendingThinkspaceApprovalInput {
@@ -118,6 +119,36 @@ export const listPendingThinkspaceApprovals = async (
 		.where(
 			and(
 				eq(thinkspaceApprovals.thinkspaceId, thinkspaceId),
+				eq(thinkspaceApprovals.status, THINKSPACE_APPROVAL_STATUS.PENDING),
+			),
+		)
+		.orderBy(desc(thinkspaceApprovals.createdAt));
+
+/** One Review Queue entry: the pending Approval row and the Goal of the Thinkspace it arose in. */
+export interface PendingThinkspaceApprovalListItem {
+	approval: ThinkspaceApproval;
+	thinkspaceGoal: string;
+}
+
+/**
+ * The cross-Thinkspace Review Queue read: every pending Approval the owner is
+ * holding, across all of their Thinkspaces, most-recent first. `owner_user_id`
+ * is denormalized onto the row so ownership filters without a join; the inner
+ * join carries only the Thinkspace's Goal, so each queue item can name where it
+ * arose. Owner-scoped by construction: an Approval is never visible to anyone
+ * but its owner.
+ */
+export const listPendingThinkspaceApprovalsByOwner = async (
+	db: ProductDb,
+	{ ownerUserId }: { ownerUserId: string },
+): Promise<PendingThinkspaceApprovalListItem[]> =>
+	await db
+		.select({ approval: thinkspaceApprovals, thinkspaceGoal: thinkspaces.goal })
+		.from(thinkspaceApprovals)
+		.innerJoin(thinkspaces, eq(thinkspaceApprovals.thinkspaceId, thinkspaces.id))
+		.where(
+			and(
+				eq(thinkspaceApprovals.ownerUserId, ownerUserId),
 				eq(thinkspaceApprovals.status, THINKSPACE_APPROVAL_STATUS.PENDING),
 			),
 		)


### PR DESCRIPTION
Closes #96. Fourth slice of PRD #92 (`governed_tools_v3` — the Approval holdpoint and Review Queue). Blocked-by #95 (merged, PR #101).

## What this does

Adds the **cross-Thinkspace Review Queue**: one owner-scoped surface listing every pending Approval across all of a user's Thinkspaces, with inline approve/reject so the owner can clear held actions without opening a Sitting. The Review Queue is the doorbell; deep work still happens inside each Sitting.

## Backend

- **`packages/api/src/thinkspaces/approvals-repository.ts`** — `listPendingThinkspaceApprovalsByOwner`: owner-scoped, `status = pending`, most-recent-first. `owner_user_id` is denormalized onto the row so ownership needs no join; the inner join carries only each Thinkspace's Goal, so a queue item can name where it arose.
- **`packages/api/src/approvals/router.ts`** — a new `list` protected procedure maps the index rows to product-shaped items (Thinkspace Goal, proposed action kind, proposed summary, proposed-at). `approve`/`reject` reuse the existing `decide` path from #95, so a resolved Approval leaves the queue and its parked turn resumes.

Both surfaces are owner-scoped by construction: an Approval is **invisible and undecidable from any other owner's queue**, and an unauthenticated read is rejected (UNAUTHORIZED) before any storage access. (`decide` remains 404-first from #95.)

## Web page

- **`apps/web/src/routes/review-queue.tsx`** (auth-gated parent) + **`review-queue.index.tsx`** (the page) — renders each pending Approval in product language with inline **Approve / Reject** that invalidate the queue on settle, plus a teaching empty state. Built in the DESIGN.md "Workbench" style with the existing `@better-agent/ui` components.
- **`apps/web/src/components/header.tsx`** — a "Review Queue" nav link.
- **`routeTree.gen.ts`** — registers the new route (regenerates idempotently on the next `dev`/`build`).

## Acceptance criteria (#96)

- [x] An owner-gated router lists a user's pending Approvals across all their Thinkspaces, recency-ordered, mirroring the existing owner-indexed Thinkspace listing
- [x] Each item names its Thinkspace, the proposed action in product language, and when it was proposed
- [x] Approve / reject from the Review Queue resolve the Approval and resume the parked turn (reusing the holdpoint decide path)
- [x] A resolved Approval leaves the queue
- [x] A web page renders the Review Queue and lets the owner approve / reject from it
- [x] Non-owner and unauthenticated calls are rejected; an Approval is invisible and undecidable from any other owner's queue
- [x] Router tests run against the in-memory SQLite test database following the thinkspaces / sources router suites
- [x] Type checks (api/server/ui), Ultracite checks, and the package test suites pass (256/256 api tests, +6 new)

## Notes

- The web app is not in the CI type-check set; its bare-`tsc` cross-package infra-type noise (Workers `lib`/types over imported source) is pre-existing and unrelated to this change — the new route files, header, and api changes type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)