### PR TITLE
Add inline Approval to a live Sitting (#97)

### DIFF
--- a/apps/web/src/components/sitting-section.tsx
+++ b/apps/web/src/components/sitting-section.tsx
@@ -1,9 +1,16 @@
+import { MEMORY_WRITE_TOOL_PART_TYPE } from "@better-agent/api/thinkspaces/approvals";
 import { env } from "@better-agent/env/web";
 import { Badge } from "@better-agent/ui/components/badge";
 import { Button } from "@better-agent/ui/components/button";
 import { Textarea } from "@better-agent/ui/components/textarea";
-import { useAgentChat } from "@cloudflare/ai-chat/react";
+import {
+	getToolApproval,
+	getToolInput,
+	getToolPartState,
+	useAgentChat,
+} from "@cloudflare/ai-chat/react";
 import { useAgent } from "agents/react";
+import { CheckIcon, XIcon } from "lucide-react";
 import type { FormEvent } from "react";
 import { useState } from "react";
 
@@ -49,6 +56,108 @@ const getSittingBlockedMessage = ({
 const getMessageRoleLabel = (role: string): string =>
 	role === "user" ? "You" : "Thinkspace Agent";
 
+type ProposalDecisionView = "approved" | "pending" | "rejected";
+
+const PROPOSAL_BADGE: Record<
+	ProposalDecisionView,
+	{ label: string; variant: "default" | "outline" | "secondary" }
+> = {
+	approved: { label: "Approved", variant: "default" },
+	pending: { label: "Awaiting your decision", variant: "secondary" },
+	rejected: { label: "Rejected", variant: "outline" },
+};
+
+const readProposedMemory = (input: unknown): string | null => {
+	if (typeof input !== "object" || input === null) {
+		return null;
+	}
+
+	const { content } = input as { content?: unknown };
+
+	return typeof content === "string" && content.length > 0 ? content : null;
+};
+
+/**
+ * Maps the live tool-part state onto the product decision the transcript shows.
+ * A held proposal is `pending` only while genuinely awaiting the owner; once
+ * decided it reads as `approved` (responded, executed, or failed mid-execution)
+ * or `rejected`. A failed write still reads as approved because the owner did
+ * approve it — the agent narrates the failure in the turn — and keeping the card
+ * means an approved proposal never silently vanishes. Transient states before
+ * the hold is raised return null so a half-formed proposal never renders a
+ * decidable card.
+ */
+const toProposalDecisionView = (state: string): ProposalDecisionView | null => {
+	switch (state) {
+		case "waiting-approval": {
+			return "pending";
+		}
+		case "approved":
+		case "complete":
+		case "error": {
+			return "approved";
+		}
+		case "denied": {
+			return "rejected";
+		}
+		default: {
+			return null;
+		}
+	}
+};
+
+const HeldMemoryProposal = ({
+	approvalId,
+	content,
+	decision,
+	disabled,
+	onDecide,
+}: {
+	approvalId: string;
+	content: string;
+	decision: ProposalDecisionView;
+	disabled: boolean;
+	onDecide: (approvalId: string, approved: boolean) => void;
+}) => {
+	const badge = PROPOSAL_BADGE[decision];
+
+	return (
+		<div className="grid gap-3 rounded-lg border border-border bg-card p-4">
+			<div className="flex items-start justify-between gap-3">
+				<p className="text-sm font-medium">Memory proposal</p>
+				<Badge variant={badge.variant}>{badge.label}</Badge>
+			</div>
+			<p className="whitespace-pre-wrap text-foreground text-sm leading-relaxed">{content}</p>
+			{decision === "pending" ? (
+				<div className="flex flex-wrap items-center justify-between gap-3">
+					<p className="text-muted-foreground text-xs">
+						Held until you decide — approve to write this Memory, reject to discard it.
+					</p>
+					<div className="flex gap-2">
+						<Button
+							disabled={disabled}
+							onClick={() => onDecide(approvalId, false)}
+							size="sm"
+							variant="outline"
+						>
+							<XIcon />
+							Reject
+						</Button>
+						<Button disabled={disabled} onClick={() => onDecide(approvalId, true)} size="sm">
+							<CheckIcon />
+							Approve
+						</Button>
+					</div>
+				</div>
+			) : (
+				<p className="text-muted-foreground text-xs">
+					{decision === "approved" ? "You approved this proposal." : "You rejected this proposal."}
+				</p>
+			)}
+		</div>
+	);
+};
+
 const LiveSitting = ({ thinkspaceId }: { thinkspaceId: string }) => {
 	const agent = useAgent({
 		agent: THINKSPACE_AGENT_RUNTIME,
@@ -56,12 +165,22 @@ const LiveSitting = ({ thinkspaceId }: { thinkspaceId: string }) => {
 		host: env.VITE_SERVER_URL,
 		name: thinkspaceId,
 	});
-	const { error, isRecovering, messages, sendMessage, status, stop } = useAgentChat({
-		agent,
-		credentials: "include",
-	});
+	const { addToolApprovalResponse, error, isRecovering, messages, sendMessage, status, stop } =
+		useAgentChat({
+			agent,
+			credentials: "include",
+		});
 	const [draft, setDraft] = useState("");
 	const isBusy = status === "submitted" || status === "streaming";
+
+	// One Approval, two surfaces: deciding inline drives the agents-stack native
+	// tool-approval response (the same hold the Review Queue's control-plane decide
+	// resolves), which flips the held part and resumes the parked turn over the
+	// live transcript. Multiple Sitting tabs stay consistent through the shared
+	// Durable Object transcript broadcast.
+	const handleDecideProposal = (approvalId: string, approved: boolean) => {
+		addToolApprovalResponse({ approved, id: approvalId });
+	};
 
 	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
@@ -89,9 +208,20 @@ const LiveSitting = ({ thinkspaceId }: { thinkspaceId: string }) => {
 					</p>
 				) : (
 					messages.map((message) => {
-						const renderableParts = message.parts.filter(
-							(part) => part.type === "text" || part.type === "reasoning",
-						);
+						const renderableParts = message.parts.filter((part) => {
+							if (part.type === "text" || part.type === "reasoning") {
+								return true;
+							}
+
+							// A held Memory proposal is renderable once it carries a decidable
+							// state and content; a half-formed or malformed hold is skipped so it
+							// never surfaces a card with nothing to decide.
+							return (
+								part.type === MEMORY_WRITE_TOOL_PART_TYPE &&
+								toProposalDecisionView(getToolPartState(part)) !== null &&
+								readProposedMemory(getToolInput(part)) !== null
+							);
+						});
 
 						// Skip turns with nothing to show: a turn that returned no text, or
 						// the brief window before the first streamed token arrives. The
@@ -114,6 +244,27 @@ const LiveSitting = ({ thinkspaceId }: { thinkspaceId: string }) => {
 											>
 												{part.text}
 											</p>
+										);
+									}
+
+									if (part.type === MEMORY_WRITE_TOOL_PART_TYPE) {
+										const approval = getToolApproval(part);
+										const content = readProposedMemory(getToolInput(part));
+										const decision = toProposalDecisionView(getToolPartState(part));
+
+										if (!(approval && content && decision)) {
+											return null;
+										}
+
+										return (
+											<HeldMemoryProposal
+												approvalId={approval.id}
+												content={content}
+												decision={decision}
+												disabled={isBusy}
+												key={`${message.id}-proposal-${index}`}
+												onDecide={handleDecideProposal}
+											/>
 										);
 									}
 

--- a/packages/api/src/thinkspaces/approval-surfaces.test.ts
+++ b/packages/api/src/thinkspaces/approval-surfaces.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+import { user } from "@better-agent/db/schema/auth";
+import { thinkspaces } from "@better-agent/db/schema/thinkspaces";
+
+import { createTestProductDb } from "../testing/product-db";
+import {
+	extractResolvedMemoryApprovals,
+	flipMemoryApprovalInTranscript,
+	MEMORY_WRITE_TOOL_PART_TYPE,
+} from "./approvals";
+import type { ThinkspaceApprovalDecision } from "./approvals";
+import {
+	listPendingThinkspaceApprovals,
+	resolveThinkspaceApproval,
+	upsertPendingThinkspaceApproval,
+} from "./approvals-repository";
+
+/**
+ * One Approval, two surfaces. A held Memory proposal can be decided inline in a
+ * live Sitting or from the cross-Thinkspace Review Queue, and both must resolve
+ * the *same* product Approval through the *same* index resolve. These tests pin
+ * that convergence so the two surfaces can never drift into two mechanisms.
+ *
+ * - The Review Queue (control plane) flips the held part in place with
+ *   `flipMemoryApprovalInTranscript` and resolves the index row directly — what
+ *   the runtime's `decideMemoryApproval` does.
+ * - An inline Sitting decision drives the agents/ai-chat native tool-approval
+ *   transition over the live transcript, and the runtime's `onChatResponse`
+ *   reconciliation reads the decided part back out (`extractResolvedMemoryApprovals`)
+ *   and resolves the same index row.
+ */
+
+const OWNER_ID = "owner_user";
+const THINKSPACE_ID = "thinkspace_surfaces";
+const TOOL_CALL_ID = "tool_call_1";
+const APPROVAL_ID = "approval_1";
+const APPROVAL_REQUEST_ID = "approval_req_1";
+const PROPOSED_CONTENT = "The user prefers Vendor A.";
+
+const DECISIONS: ThinkspaceApprovalDecision[] = ["approved", "rejected"];
+
+const seed = async (db: ProductDb) => {
+	await db.insert(user).values({ email: "owner@example.com", id: OWNER_ID, name: "Owner" });
+	await db.insert(thinkspaces).values({
+		goal: "Decide vendors",
+		id: THINKSPACE_ID,
+		ownerUserId: OWNER_ID,
+		status: "active",
+	});
+	await upsertPendingThinkspaceApproval(db, {
+		record: {
+			actionKind: "memory_write",
+			approvalRequestId: APPROVAL_REQUEST_ID,
+			id: APPROVAL_ID,
+			ownerUserId: OWNER_ID,
+			profileRevisionId: null,
+			profileVersion: null,
+			proposedContent: PROPOSED_CONTENT,
+			proposedSummary: `Proposed a durable Product Memory: "${PROPOSED_CONTENT}"`,
+			submissionId: null,
+			thinkspaceId: THINKSPACE_ID,
+			toolCallId: TOOL_CALL_ID,
+		},
+	});
+};
+
+const parkedTranscript = () => [
+	{
+		parts: [
+			{
+				approval: { id: APPROVAL_REQUEST_ID },
+				input: { content: PROPOSED_CONTENT },
+				state: "approval-requested",
+				toolCallId: TOOL_CALL_ID,
+				type: MEMORY_WRITE_TOOL_PART_TYPE,
+			},
+		],
+		role: "assistant",
+	},
+];
+
+/**
+ * The agents/ai-chat server transition an inline Sitting decision drives
+ * (`_applyToolApproval`): an inline approve flips the held part to
+ * `approval-responded`, an inline reject to `output-denied`, both stamping
+ * `approval.approved`. Mirrored here so the test exercises the real inline part
+ * shape without a live WebSocket. Verified against `@cloudflare/ai-chat` dist.
+ */
+const applyInlineNativeDecision = (
+	messages: ReturnType<typeof parkedTranscript>,
+	approved: boolean,
+) =>
+	messages.map((message) => ({
+		...message,
+		parts: message.parts.map((part) =>
+			part.type === MEMORY_WRITE_TOOL_PART_TYPE
+				? {
+						...part,
+						approval: { ...part.approval, approved },
+						state: approved ? "approval-responded" : "output-denied",
+					}
+				: part,
+		),
+	}));
+
+test("an inline Sitting decision reconciles to the same outcome the control-plane decide records", () => {
+	for (const decision of DECISIONS) {
+		const approved = decision === "approved";
+
+		// The Review Queue flips the held part in place.
+		const controlPlane = flipMemoryApprovalInTranscript({
+			decision,
+			messages: parkedTranscript(),
+			toolCallId: TOOL_CALL_ID,
+		});
+		assert.equal(controlPlane.flipped, true);
+
+		// An inline decision drives the native transition over the live transcript.
+		const inline = applyInlineNativeDecision(parkedTranscript(), approved);
+
+		// The runtime's index reconciliation reads both surfaces to the identical
+		// resolution — even though an inline reject lands in `output-denied` while a
+		// control-plane reject lands in `approval-responded`.
+		const fromControlPlane = extractResolvedMemoryApprovals(controlPlane.messages);
+		const fromInline = extractResolvedMemoryApprovals(inline);
+
+		assert.deepEqual(fromInline, fromControlPlane);
+		assert.deepEqual(fromInline, [{ status: decision, toolCallId: TOOL_CALL_ID }]);
+	}
+});
+
+test("either surface resolves the same pending Approval row out of the queue", async () => {
+	for (const decision of DECISIONS) {
+		const approved = decision === "approved";
+		const resolvedAt = new Date();
+
+		// The control plane resolves the row with the decision directly, the way
+		// `decideMemoryApproval` does after flipping the transcript.
+		const controlPlaneDb = createTestProductDb();
+		await seed(controlPlaneDb);
+		const controlPlaneRow = await resolveThinkspaceApproval(controlPlaneDb, {
+			approvalId: APPROVAL_ID,
+			resolvedAt,
+			status: decision,
+			thinkspaceId: THINKSPACE_ID,
+		});
+
+		// The inline surface resolves the row the way `reconcilePendingApprovals`
+		// does: derive the status from the native-decided transcript, then resolve
+		// through the same repository call.
+		const inlineDb = createTestProductDb();
+		await seed(inlineDb);
+		const [resolution] = extractResolvedMemoryApprovals(
+			applyInlineNativeDecision(parkedTranscript(), approved),
+		);
+		assert.ok(resolution);
+		const inlineRow = await resolveThinkspaceApproval(inlineDb, {
+			approvalId: APPROVAL_ID,
+			resolvedAt,
+			status: resolution.status,
+			thinkspaceId: THINKSPACE_ID,
+		});
+
+		// Both land the row in the identical decided state and clear it from the queue.
+		assert.equal(inlineRow?.status, controlPlaneRow?.status);
+		assert.equal(inlineRow?.status, decision);
+		assert.deepEqual(
+			await listPendingThinkspaceApprovals(inlineDb, { thinkspaceId: THINKSPACE_ID }),
+			[],
+		);
+	}
+});


### PR DESCRIPTION
Closes #97. A slice of the `governed_tools_v3` epic (PRD #92).

## What this adds

Surfaces a held Memory proposal **inline in the live Sitting transcript** so the owner can decide it in the flow of working with the agent — the second surface over the same Approval the cross-Thinkspace Review Queue (#96) already exposes.

When a turn parks on the Memory-write holdpoint (#95), the `approval-requested` tool part now renders as a Workbench card with **Approve / Reject** (mirroring the Review Queue's affordance). Deciding inline calls the agents-stack native tool-approval response — `addToolApprovalResponse({ id, approved })`, which sends `CF_AGENT_TOOL_APPROVAL` over the live WebSocket — so the runtime flips the held part and **auto-resumes the parked turn**. The runtime's existing `onChatResponse → reconcilePendingApprovals` then resolves the **same D1 Approval row** out of the queue.

So inline and Review-Queue decisions are **two surfaces over one Approval, not two mechanisms** — no new backend path was needed; the inline decision rides the same resolve-and-resume seam the control-plane `decideMemoryApproval` uses (`extractResolvedMemoryApprovals` + `resolveThinkspaceApproval`). Multiple Sitting tabs on the same Thinkspace stay consistent through the shared Durable Object transcript broadcast.

## Notes

- A decided proposal stays visible across its terminal states (approved / rejected / failed-mid-execution), so an approved proposal never silently vanishes from the transcript.
- The held-tool part-type string is now imported from `@better-agent/api/thinkspaces/approvals` (single source of truth) rather than duplicated in the web client.

## Tests

`packages/api/src/thinkspaces/approval-surfaces.test.ts` pins the convergence (AC: *"the inline decision drives the same resolve-and-resume path as the control-plane decide endpoint"*): the inline native transition and the control-plane flip reconcile to the same outcome and resolve the same pending Approval row out of the queue, for both approve and reject — including that an inline reject (`output-denied`) and a control-plane reject (`approval-responded`) both reconcile to `rejected`.

## Verification

- ✅ `packages/api` suite: 258 pass
- ✅ `turbo check-types` (api/server/ui): green
- ✅ `web` bare `tsc`: changed file clean (pre-existing infra-type noise unchanged)
- ✅ `ultracite check`: clean on both files
- ⏳ **Live round-trip not run this session** (no dev server / auth available). Before merge, confirm `propose → hold → approve-inline → resume` in a Sitting at `localhost:3001`, plus cross-tab consistency and that the Review Queue row reconciles — per `.agents/docs/thinkspace-agent-runtime-smoke-checks.md` (#98).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>