### PR TITLE
UI: Phase 1 refit + melior alignment polish

### DIFF
--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,3 +1,4 @@
+import { ThemeToggle } from "@better-agent/ui/components/theme-toggle";
 import { Link } from "@tanstack/react-router";
 
 import UserMenu from "./user-menu";
@@ -29,7 +30,10 @@ export default function Header() {
 						))}
 					</nav>
 				</div>
-				<UserMenu />
+				<div className="flex items-center gap-2">
+					<ThemeToggle />
+					<UserMenu />
+				</div>
 			</div>
 		</header>
 	);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,3 +1,4 @@
+import { ThemeProvider } from "@better-agent/ui/components/theme-provider";
 import { Toaster } from "@better-agent/ui/components/sonner";
 import type { QueryClient } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
@@ -14,19 +15,23 @@ export interface RouterAppContext {
 	queryClient: QueryClient;
 }
 
+// suppressHydrationWarning: next-themes sets the theme class on <html> before
+// hydration, so the server-rendered markup intentionally differs for one tick.
 const RootDocument = () => (
-	<html lang="en" className="dark">
+	<html lang="en" suppressHydrationWarning>
 		<head>
 			<HeadContent />
 		</head>
 		<body>
-			<div className="grid h-svh grid-rows-[auto_1fr]">
-				<Header />
-				<main className="min-h-0 overflow-auto">
-					<Outlet />
-				</main>
-			</div>
-			<Toaster richColors />
+			<ThemeProvider attribute="class" defaultTheme="dark" disableTransitionOnChange enableSystem>
+				<div className="grid h-svh grid-rows-[auto_1fr]">
+					<Header />
+					<main className="min-h-0 overflow-auto">
+						<Outlet />
+					</main>
+				</div>
+				<Toaster richColors />
+			</ThemeProvider>
 			<TanStackRouterDevtools position="bottom-left" />
 			<ReactQueryDevtools position="bottom" buttonPosition="bottom-right" />
 			<Scripts />

--- a/apps/web/src/routes/settings.product.tsx
+++ b/apps/web/src/routes/settings.product.tsx
@@ -2,6 +2,13 @@ import { Badge } from "@better-agent/ui/components/badge";
 import { Button } from "@better-agent/ui/components/button";
 import { Input } from "@better-agent/ui/components/input";
 import { Label } from "@better-agent/ui/components/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@better-agent/ui/components/select";
 import { Separator } from "@better-agent/ui/components/separator";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, getRouteApi } from "@tanstack/react-router";
@@ -57,6 +64,17 @@ const RouteComponent = () => {
 		}),
 	);
 
+	// Base UI Select reads `items` to show the selected label in the trigger.
+	const modelItems = catalogQuery.data.map((model) => ({
+		label: `${model.name} · ${model.providerName}`,
+		value: model.id,
+	}));
+	const reasoningItems = REASONING_EFFORTS.map((effort) => ({ label: effort, value: effort }));
+	const providerItems = Object.entries(PROVIDER_LABELS).map(([value, providerName]) => ({
+		label: providerName,
+		value,
+	}));
+
 	const defaultsChanged =
 		defaultModel !== defaultsQuery.data.defaultModel ||
 		defaultReasoningEffort !== defaultsQuery.data.reasoningEffort;
@@ -98,40 +116,48 @@ const RouteComponent = () => {
 					</p>
 				</div>
 				<form
-					className="grid max-w-xl gap-4 border border-border p-4"
+					className="grid max-w-xl gap-4 rounded-lg p-4 ring-1 ring-foreground/10"
 					onSubmit={handleDefaultsSubmit}
 				>
 					<div className="grid gap-1.5">
 						<Label htmlFor="default-model">Default model</Label>
-						<select
-							className="h-8 w-full border border-input bg-transparent px-2.5 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 dark:bg-input/30"
-							id="default-model"
-							onChange={(event) => setDefaultModel(event.target.value)}
+						<Select
+							items={modelItems}
+							onValueChange={(value) => setDefaultModel(value as string)}
 							value={defaultModel}
 						>
-							{catalogQuery.data.map((model) => (
-								<option key={model.id} value={model.id}>
-									{model.name} · {model.providerName} · {model.id}
-								</option>
-							))}
-						</select>
+							<SelectTrigger className="w-full" id="default-model">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{catalogQuery.data.map((model) => (
+									<SelectItem key={model.id} value={model.id}>
+										{model.name} · {model.providerName} · {model.id}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
 					</div>
 					<div className="grid gap-1.5">
 						<Label htmlFor="default-reasoning-effort">Reasoning effort</Label>
-						<select
-							className="h-8 w-full border border-input bg-transparent px-2.5 text-sm capitalize outline-none transition-colors focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 dark:bg-input/30"
-							id="default-reasoning-effort"
-							onChange={(event) =>
-								setDefaultReasoningEffort(event.target.value as (typeof REASONING_EFFORTS)[number])
+						<Select
+							items={reasoningItems}
+							onValueChange={(value) =>
+								setDefaultReasoningEffort(value as (typeof REASONING_EFFORTS)[number])
 							}
 							value={defaultReasoningEffort}
 						>
-							{REASONING_EFFORTS.map((effort) => (
-								<option key={effort} value={effort}>
-									{effort}
-								</option>
-							))}
-						</select>
+							<SelectTrigger className="w-full capitalize" id="default-reasoning-effort">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{REASONING_EFFORTS.map((effort) => (
+									<SelectItem className="capitalize" key={effort} value={effort}>
+										{effort}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
 					</div>
 					{saveDefaults.error ? (
 						<p className="text-destructive text-sm" role="alert">
@@ -159,7 +185,7 @@ const RouteComponent = () => {
 						Available models and their access status for your account.
 					</p>
 				</div>
-				<div className="border border-border">
+				<div className="overflow-hidden rounded-lg ring-1 ring-foreground/10">
 					{catalogQuery.data.map((model, index) => (
 						<div
 							key={model.id}
@@ -195,23 +221,28 @@ const RouteComponent = () => {
 						API keys are encrypted at rest. Only a redacted preview is shown after saving.
 					</p>
 				</div>
-				<form className="grid max-w-md gap-4 border border-border p-4" onSubmit={handleSubmit}>
+				<form
+					className="grid max-w-md gap-4 rounded-lg p-4 ring-1 ring-foreground/10"
+					onSubmit={handleSubmit}
+				>
 					<div className="grid gap-1.5">
 						<Label htmlFor="provider">Provider</Label>
-						<select
-							className="h-8 w-full border border-input bg-transparent px-2.5 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 dark:bg-input/30"
-							id="provider"
-							onChange={(event) =>
-								setProviderId(event.target.value as keyof typeof PROVIDER_LABELS)
-							}
+						<Select
+							items={providerItems}
+							onValueChange={(value) => setProviderId(value as keyof typeof PROVIDER_LABELS)}
 							value={providerId}
 						>
-							{Object.entries(PROVIDER_LABELS).map(([id, name]) => (
-								<option key={id} value={id}>
-									{name}
-								</option>
-							))}
-						</select>
+							<SelectTrigger className="w-full" id="provider">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{Object.entries(PROVIDER_LABELS).map(([id, name]) => (
+									<SelectItem key={id} value={id}>
+										{name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
 					</div>
 					<div className="grid gap-1.5">
 						<Label htmlFor="credential-label">Label</Label>
@@ -246,7 +277,7 @@ const RouteComponent = () => {
 					</Button>
 				</form>
 				{credentialsQuery.data.length > 0 ? (
-					<div className="border border-border">
+					<div className="overflow-hidden rounded-lg ring-1 ring-foreground/10">
 						{credentialsQuery.data.map((entry, index) => (
 							<div
 								key={entry.id}

--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -1,11 +1,56 @@
 import { Badge } from "@better-agent/ui/components/badge";
 import { Button } from "@better-agent/ui/components/button";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@better-agent/ui/components/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@better-agent/ui/components/dropdown-menu";
 import { Input } from "@better-agent/ui/components/input";
 import { Label } from "@better-agent/ui/components/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@better-agent/ui/components/select";
 import { Separator } from "@better-agent/ui/components/separator";
+import {
+	Tabs,
+	TabsIndicator,
+	TabsList,
+	TabsPanel,
+	TabsTab,
+} from "@better-agent/ui/components/tabs";
 import { Textarea } from "@better-agent/ui/components/textarea";
 import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, getRouteApi, Link, redirect } from "@tanstack/react-router";
+import {
+	ActivityIcon,
+	ArchiveIcon,
+	ChevronRightIcon,
+	CircleDashedIcon,
+	CircleDotIcon,
+	ClockIcon,
+	CpuIcon,
+	FileTextIcon,
+	KeyRoundIcon,
+	MessagesSquareIcon,
+	MoreHorizontalIcon,
+	TargetIcon,
+	UserRoundIcon,
+	WrenchIcon,
+} from "lucide-react";
 import { useState } from "react";
 
 import { SittingSection } from "@/components/sitting-section";
@@ -24,6 +69,39 @@ const formatDateTime = (value: Date | number | string | null): string => {
 	}
 
 	return dateFormatter.format(new Date(value));
+};
+
+// Compact date for metadata pills — pills carry the fact, not the full timestamp.
+const metaDateFormatter = new Intl.DateTimeFormat("en", { dateStyle: "medium" });
+
+const formatMetaDate = (value: Date | number | string): string =>
+	metaDateFormatter.format(new Date(value));
+
+// Active reads affirmative (sage); a draft is neutral; archived is attention.
+const getStatusBadgeVariant = (status: string): "destructive" | "outline" | "sage" => {
+	if (status === "archived") {
+		return "destructive";
+	}
+
+	if (status === "draft") {
+		return "outline";
+	}
+
+	return "sage";
+};
+
+// Status pills lead with a glyph so the state reads at a glance, matching the
+// metadata-pill pattern (DESIGN.md §7 Document Page).
+const renderStatusBadgeIcon = (status: string) => {
+	if (status === "archived") {
+		return <ArchiveIcon aria-hidden />;
+	}
+
+	if (status === "draft") {
+		return <CircleDashedIcon aria-hidden />;
+	}
+
+	return <CircleDotIcon aria-hidden />;
 };
 
 interface EnabledToolSelection {
@@ -329,7 +407,7 @@ const TurnInspectionPanel = ({
 	const inspection = inspectionQuery.data;
 
 	return (
-		<div className="grid gap-3 border border-border p-4">
+		<div className="grid gap-3 rounded-lg p-4 ring-1 ring-foreground/10">
 			<div className="grid gap-1">
 				<p className="text-sm font-medium">Turn status</p>
 				<p className="text-muted-foreground text-xs">
@@ -377,7 +455,7 @@ const TurnInspectionPanel = ({
 					</div>
 					<p className="text-muted-foreground text-sm">{inspection.message}</p>
 					{inspection.resultText ? (
-						<p className="whitespace-pre-wrap border border-border p-3 text-sm leading-relaxed">
+						<p className="whitespace-pre-wrap rounded-md p-3 ring-1 ring-foreground/10 text-sm leading-relaxed">
 							{inspection.resultText}
 						</p>
 					) : null}
@@ -435,7 +513,7 @@ const AgentProfileSection = ({
 				</p>
 			</div>
 			{profileRevision ? (
-				<div className="grid gap-4 border border-border p-4">
+				<div className="grid gap-4 rounded-lg p-4 ring-1 ring-foreground/10">
 					<div className="flex items-start justify-between gap-4">
 						<div className="grid gap-1">
 							<p className="text-sm font-medium">{profileRevision.identity.displayName}</p>
@@ -481,7 +559,7 @@ const AgentProfileSection = ({
 					) : null}
 				</div>
 			) : (
-				<p className="border border-border p-4 text-muted-foreground text-sm">
+				<p className="rounded-lg p-4 ring-1 ring-foreground/10 text-muted-foreground text-sm">
 					No Agent Profile revision has been created for this Thinkspace yet.
 				</p>
 			)}
@@ -528,7 +606,7 @@ const SubmitTurnSection = ({
 				</p>
 			</div>
 			<form
-				className="grid gap-3 border border-border p-4"
+				className="grid gap-3 rounded-lg p-4 ring-1 ring-foreground/10"
 				onSubmit={(event) => {
 					event.preventDefault();
 					if (submitDisabled) {
@@ -676,7 +754,7 @@ const SourcesSection = ({
 				</p>
 			</div>
 			<form
-				className="grid gap-3 border border-border p-4"
+				className="grid gap-3 rounded-lg p-4 ring-1 ring-foreground/10"
 				onSubmit={(event) => {
 					event.preventDefault();
 					if (uploadDisabled) {
@@ -705,21 +783,23 @@ const SourcesSection = ({
 					</div>
 					<div className="grid gap-2">
 						<Label htmlFor="source-content-type">Format</Label>
-						<select
-							className="border-input bg-transparent flex h-9 w-full min-w-0 border px-3 py-1 text-sm shadow-xs outline-none disabled:cursor-not-allowed disabled:opacity-50"
+						<Select
 							disabled={isArchived}
-							id="source-content-type"
-							onChange={(event) =>
-								setSourceContentType(event.target.value as SourceContentTypeOption)
-							}
+							items={SOURCE_CONTENT_TYPE_OPTIONS}
+							onValueChange={(value) => setSourceContentType(value as SourceContentTypeOption)}
 							value={sourceContentType}
 						>
-							{SOURCE_CONTENT_TYPE_OPTIONS.map((option) => (
-								<option key={option.value} value={option.value}>
-									{option.label}
-								</option>
-							))}
-						</select>
+							<SelectTrigger className="w-full" id="source-content-type">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{SOURCE_CONTENT_TYPE_OPTIONS.map((option) => (
+									<SelectItem key={option.value} value={option.value}>
+										{option.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
 					</div>
 				</div>
 				<div className="grid gap-2">
@@ -756,11 +836,11 @@ const SourcesSection = ({
 				</div>
 			</form>
 			{sources.length === 0 ? (
-				<p className="border border-border p-4 text-muted-foreground text-sm">
+				<p className="rounded-lg p-4 ring-1 ring-foreground/10 text-muted-foreground text-sm">
 					No Sources uploaded to this Thinkspace yet.
 				</p>
 			) : (
-				<div className="border border-border">
+				<div className="overflow-hidden rounded-lg ring-1 ring-foreground/10">
 					{sources.map((source, index) => (
 						<div
 							key={source.id}
@@ -813,7 +893,7 @@ const SourcesSection = ({
 										<p className="text-muted-foreground text-xs">Loading content…</p>
 									) : null}
 									{sourceContentQuery.data && sourceContentQuery.data.id === source.id ? (
-										<p className="max-h-80 overflow-y-auto whitespace-pre-wrap border border-border p-3 text-sm leading-relaxed">
+										<p className="max-h-80 overflow-y-auto whitespace-pre-wrap rounded-md p-3 ring-1 ring-foreground/10 text-sm leading-relaxed">
 											{sourceContentQuery.data.content}
 										</p>
 									) : null}
@@ -877,7 +957,7 @@ const ToolsSection = ({
 		</div>
 		<div className="grid gap-2">
 			<p className="text-sm font-medium">Built-in tools</p>
-			<div className="border border-border">
+			<div className="overflow-hidden rounded-lg ring-1 ring-foreground/10">
 				{BUILT_IN_TOOLS.map((tool, index) => {
 					const selected = enabledBuiltInToolIds.includes(tool.id);
 					const toolPotency = selected ? toolPotencyById.get(tool.id) : undefined;
@@ -914,11 +994,11 @@ const ToolsSection = ({
 			</div>
 		</div>
 		{mcpCatalog.length === 0 ? (
-			<p className="border border-border p-4 text-muted-foreground text-sm">
+			<p className="rounded-lg p-4 ring-1 ring-foreground/10 text-muted-foreground text-sm">
 				No tools in the catalog.
 			</p>
 		) : (
-			<div className="border border-border">
+			<div className="overflow-hidden rounded-lg ring-1 ring-foreground/10">
 				{mcpCatalog.map((server, index) => {
 					const selectedTool = enabledTools.find((tool) => tool.serverId === server.id);
 					const selected = Boolean(selectedTool);
@@ -960,7 +1040,7 @@ const ToolsSection = ({
 		<div className="grid gap-2">
 			<p className="text-sm font-medium">Enabled on Agent Profile</p>
 			{profileRevision?.toolEnablements.length ? (
-				<div className="border border-border">
+				<div className="overflow-hidden rounded-lg ring-1 ring-foreground/10">
 					{profileRevision.toolEnablements.map((enablement, index) => {
 						const toolPotency = toolPotencyById.get(enablement.toolId);
 
@@ -987,7 +1067,7 @@ const ToolsSection = ({
 					})}
 				</div>
 			) : (
-				<p className="border border-border p-4 text-muted-foreground text-sm">
+				<p className="rounded-lg p-4 ring-1 ring-foreground/10 text-muted-foreground text-sm">
 					No tools enabled on this Agent Profile revision.
 				</p>
 			)}
@@ -1026,11 +1106,11 @@ const PermissionsSection = ({
 			<div className="grid gap-2">
 				<p className="text-sm font-medium">Requested on draft</p>
 				{requestedPermissions.length === 0 ? (
-					<p className="border border-border p-4 text-muted-foreground text-sm">
+					<p className="rounded-lg p-4 ring-1 ring-foreground/10 text-muted-foreground text-sm">
 						No draft Permission requests.
 					</p>
 				) : (
-					<div className="border border-border">
+					<div className="overflow-hidden rounded-lg ring-1 ring-foreground/10">
 						{requestedPermissions.map((permission, index) => (
 							<div
 								key={`${permission.kind ?? permission.type}:${permission.providerId ?? permission.serverId ?? permission.resource?.serverId ?? index}`}
@@ -1050,11 +1130,11 @@ const PermissionsSection = ({
 			<div className="grid gap-2">
 				<p className="text-sm font-medium">Granted to Thinkspace</p>
 				{grantedPermissions.length === 0 ? (
-					<p className="border border-border p-4 text-muted-foreground text-sm">
+					<p className="rounded-lg p-4 ring-1 ring-foreground/10 text-muted-foreground text-sm">
 						No granted Permissions.
 					</p>
 				) : (
-					<div className="border border-border">
+					<div className="overflow-hidden rounded-lg ring-1 ring-foreground/10">
 						{grantedPermissions.map((permission, index) => {
 							const canRevoke =
 								permission.kind === "mcp_tool_access" ||
@@ -1099,11 +1179,216 @@ const PermissionsSection = ({
 	</section>
 );
 
+const ThinkspaceHeader = ({
+	archiveDialogOpen,
+	archiveError,
+	grantedPermissionsCount,
+	isArchived,
+	isArchiving,
+	isDraft,
+	modelReady,
+	onArchive,
+	onArchiveDialogOpenChange,
+	thinkspace,
+}: {
+	archiveDialogOpen: boolean;
+	archiveError?: Error | null;
+	grantedPermissionsCount: number;
+	isArchived: boolean;
+	isArchiving: boolean;
+	isDraft: boolean;
+	modelReady: boolean;
+	onArchive: () => void;
+	onArchiveDialogOpenChange: (open: boolean) => void;
+	thinkspace: {
+		archivedAt: Date | number | string | null;
+		configurationSummary: string | null;
+		goal: string;
+		status: string;
+		updatedAt: Date | number | string;
+	};
+}) => (
+	<header className="grid gap-4">
+		<nav
+			aria-label="Breadcrumb"
+			className="flex items-center gap-1.5 text-muted-foreground text-xs"
+		>
+			<Link className="transition-colors hover:text-foreground" to="/thinkspaces">
+				Thinkspaces
+			</Link>
+			<ChevronRightIcon aria-hidden className="size-3.5" />
+			<span aria-current="page" className="line-clamp-1 text-foreground">
+				{thinkspace.goal}
+			</span>
+		</nav>
+		<div className="flex items-start justify-between gap-4">
+			<div className="flex items-start gap-2.5">
+				<TargetIcon aria-hidden className="mt-1 size-5 shrink-0 text-muted-foreground" />
+				<h1 className="text-2xl font-semibold tracking-tight text-balance">{thinkspace.goal}</h1>
+			</div>
+			{isArchived ? null : (
+				<DropdownMenu>
+					<DropdownMenuTrigger
+						render={<Button aria-label="Thinkspace actions" size="icon" variant="ghost" />}
+					>
+						<MoreHorizontalIcon />
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end">
+						<DropdownMenuItem
+							disabled={isDraft}
+							onClick={() => onArchiveDialogOpenChange(true)}
+							variant="destructive"
+						>
+							<ArchiveIcon />
+							Archive Thinkspace
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			)}
+		</div>
+		<div className="flex flex-wrap items-center gap-1.5">
+			<Badge variant={getStatusBadgeVariant(thinkspace.status)}>
+				{renderStatusBadgeIcon(thinkspace.status)}
+				<span className="capitalize">{thinkspace.status}</span>
+			</Badge>
+			<Badge variant={modelReady ? "sage" : "destructive"}>
+				<CpuIcon aria-hidden />
+				{modelReady ? "Model ready" : "Model not ready"}
+			</Badge>
+			<Badge variant="outline">
+				<KeyRoundIcon aria-hidden />
+				{grantedPermissionsCount} {grantedPermissionsCount === 1 ? "Permission" : "Permissions"}
+			</Badge>
+			<Badge variant="outline">
+				<ClockIcon aria-hidden />
+				Updated {formatMetaDate(thinkspace.updatedAt)}
+			</Badge>
+			{thinkspace.archivedAt ? (
+				<Badge variant="outline">
+					<ArchiveIcon aria-hidden />
+					Archived {formatMetaDate(thinkspace.archivedAt)}
+				</Badge>
+			) : null}
+		</div>
+		{thinkspace.configurationSummary ? (
+			<p className="max-w-[65ch] text-muted-foreground text-sm leading-relaxed text-pretty">
+				{thinkspace.configurationSummary}
+			</p>
+		) : null}
+		<Dialog onOpenChange={onArchiveDialogOpenChange} open={archiveDialogOpen}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Archive this Thinkspace?</DialogTitle>
+					<DialogDescription>
+						Archiving disables active work and scheduled Routines. The Thinkspace stays inspectable
+						— you can read its full history at any time.
+					</DialogDescription>
+				</DialogHeader>
+				{archiveError ? (
+					<p className="text-destructive text-sm" role="alert">
+						{archiveError.message}
+					</p>
+				) : null}
+				<DialogFooter>
+					<DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
+					<Button disabled={isArchiving} onClick={onArchive} variant="destructive">
+						{isArchiving ? "Archiving…" : "Archive Thinkspace"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	</header>
+);
+
+const RuntimeSection = ({
+	modelReadiness,
+	runtimePolicy,
+	runtimeReadiness,
+}: {
+	modelReadiness: {
+		message: string;
+		modelId: string;
+		modelName?: string | null;
+		providerName?: string | null;
+		status: string;
+	};
+	runtimePolicy: {
+		capabilities: readonly { enabled: boolean; id: string; label: string }[];
+		message: string;
+		mode: string;
+	};
+	runtimeReadiness: {
+		bindingName: string;
+		className: string;
+		runtimeName: string;
+		status: string;
+	};
+}) => (
+	<section aria-labelledby="runtime-heading" className="grid gap-4">
+		<div className="grid gap-1">
+			<h2 className="text-lg font-semibold tracking-tight" id="runtime-heading">
+				Thinkspace Agent runtime
+			</h2>
+			<p className="text-muted-foreground text-sm">
+				This Thinkspace resolves to one durable Thinkspace Agent using the Thinkspace id as its
+				runtime identity.
+			</p>
+		</div>
+		<div className="grid gap-4 rounded-lg p-4 ring-1 ring-foreground/10">
+			<div className="grid gap-2">
+				<div className="flex items-center justify-between gap-4">
+					<p className="text-sm font-medium">Runtime readiness</p>
+					<Badge variant="outline">{runtimeReadiness.status}</Badge>
+				</div>
+				<p className="text-muted-foreground text-xs">
+					Binding: {runtimeReadiness.bindingName} · Class: {runtimeReadiness.className}
+				</p>
+				<p className="break-all text-muted-foreground text-xs">
+					Runtime identity: {runtimeReadiness.runtimeName}
+				</p>
+			</div>
+			<div className="grid gap-2 border-border border-t pt-4">
+				<div className="flex items-center justify-between gap-4">
+					<p className="text-sm font-medium">Model readiness</p>
+					<Badge variant={modelReadiness.status === "ready" ? "sage" : "destructive"}>
+						{modelReadiness.status === "ready" ? "Ready" : "Not ready"}
+					</Badge>
+				</div>
+				<p className="text-muted-foreground text-sm">{modelReadiness.message}</p>
+				<p className="text-muted-foreground text-xs">
+					{modelReadiness.modelName ?? modelReadiness.modelId} ·{" "}
+					{modelReadiness.providerName ?? "Unknown provider"}
+				</p>
+			</div>
+			<div className="grid gap-2 border-border border-t pt-4">
+				<div className="flex items-center justify-between gap-4">
+					<p className="text-sm font-medium">Runtime safety policy</p>
+					<Badge variant="outline">
+						{runtimePolicy.mode === "governed_writes" ? "governed writes" : runtimePolicy.mode}
+					</Badge>
+				</div>
+				<p className="text-muted-foreground text-sm">{runtimePolicy.message}</p>
+				<ul className="grid gap-1">
+					{runtimePolicy.capabilities.map((capability) => (
+						<li className="flex items-center justify-between gap-4 text-xs" key={capability.id}>
+							<span className="text-muted-foreground">{capability.label}</span>
+							<span className={capability.enabled ? "text-sage" : "text-muted-foreground"}>
+								{capability.enabled ? "enabled" : "disabled"}
+							</span>
+						</li>
+					))}
+				</ul>
+			</div>
+		</div>
+	</section>
+);
+
 const RouteComponent = () => {
 	const { thinkspaceId } = routeApi.useParams();
 	const context = routeApi.useRouteContext();
 	const queryClient = useQueryClient();
 	const [revokingPermissionId, setRevokingPermissionId] = useState<string | null>(null);
+	const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
 	const thinkspaceQuery = useSuspenseQuery(
 		context.orpc.thinkspaces.get.queryOptions({ input: { thinkspaceId } }),
 	);
@@ -1120,6 +1405,7 @@ const RouteComponent = () => {
 	const archiveMutation = useMutation(
 		context.orpc.thinkspaces.archive.mutationOptions({
 			onSuccess: async () => {
+				setArchiveDialogOpen(false);
 				await Promise.all([
 					queryClient.invalidateQueries({
 						queryKey: context.orpc.thinkspaces.get.queryKey({ input: { thinkspaceId } }),
@@ -1254,179 +1540,106 @@ const RouteComponent = () => {
 	};
 
 	return (
-		<div className="mx-auto grid w-full max-w-3xl gap-8 px-4 py-8">
-			<Link
-				className="w-fit text-muted-foreground text-sm transition-colors hover:text-foreground"
-				to="/thinkspaces"
-			>
-				← Thinkspaces
-			</Link>
-
-			<div className="grid gap-4">
-				<div className="flex items-start justify-between gap-4">
-					<h1 className="text-2xl font-semibold tracking-tight text-balance">{thinkspace.goal}</h1>
-					<Badge className="shrink-0" variant={isArchived ? "outline" : "default"}>
-						{thinkspace.status}
-					</Badge>
-				</div>
-				<p className="max-w-2xl text-muted-foreground text-sm leading-relaxed">
-					{thinkspace.configurationSummary}
-				</p>
-				<div className="flex gap-4 text-muted-foreground text-xs">
-					<span>Updated {formatDateTime(thinkspace.updatedAt)}</span>
-					{thinkspace.archivedAt ? (
-						<span>Archived {formatDateTime(thinkspace.archivedAt)}</span>
-					) : null}
-				</div>
-			</div>
-
-			<Separator />
-
-			<AgentProfileSection
-				activationError={activateAgentProfileMutation.error}
-				isActivating={activateAgentProfileMutation.isPending}
-				onActivate={handleActivateAgentProfile}
-				pendingDraftRevision={pendingDraftRevision}
-				profileRevision={profileRevision}
-			/>
-
-			<Separator />
-
-			<section aria-labelledby="runtime-heading" className="grid gap-4">
-				<div className="grid gap-1">
-					<h2 className="text-lg font-semibold tracking-tight" id="runtime-heading">
-						Thinkspace Agent runtime
-					</h2>
-					<p className="text-muted-foreground text-sm">
-						This Thinkspace resolves to one durable Thinkspace Agent using the Thinkspace id as its
-						runtime identity.
-					</p>
-				</div>
-				<div className="grid gap-4 border border-border p-4">
-					<div className="grid gap-2">
-						<div className="flex items-center justify-between gap-4">
-							<p className="text-sm font-medium">Runtime readiness</p>
-							<Badge variant="outline">{runtimeReadiness.status}</Badge>
-						</div>
-						<p className="text-muted-foreground text-xs">
-							Binding: {runtimeReadiness.bindingName} · Class: {runtimeReadiness.className}
-						</p>
-						<p className="break-all text-muted-foreground text-xs">
-							Runtime identity: {runtimeReadiness.runtimeName}
-						</p>
-					</div>
-					<div className="grid gap-2 border-border border-t pt-4">
-						<div className="flex items-center justify-between gap-4">
-							<p className="text-sm font-medium">Model readiness</p>
-							<Badge variant={modelReadiness.status === "ready" ? "default" : "destructive"}>
-								{modelReadiness.status === "ready" ? "ready" : "not ready"}
-							</Badge>
-						</div>
-						<p className="text-muted-foreground text-sm">{modelReadiness.message}</p>
-						<p className="text-muted-foreground text-xs">
-							{modelReadiness.modelName ?? modelReadiness.modelId} ·{" "}
-							{modelReadiness.providerName ?? "Unknown provider"}
-						</p>
-					</div>
-					<div className="grid gap-2 border-border border-t pt-4">
-						<div className="flex items-center justify-between gap-4">
-							<p className="text-sm font-medium">Runtime safety policy</p>
-							<Badge variant="outline">
-								{runtimePolicy.mode === "governed_writes" ? "governed writes" : runtimePolicy.mode}
-							</Badge>
-						</div>
-						<p className="text-muted-foreground text-sm">{runtimePolicy.message}</p>
-						<ul className="grid gap-1">
-							{runtimePolicy.capabilities.map((capability) => (
-								<li
-									className="flex items-center justify-between gap-4 text-muted-foreground text-xs"
-									key={capability.id}
-								>
-									<span>{capability.label}</span>
-									<span>{capability.enabled ? "enabled" : "disabled"}</span>
-								</li>
-							))}
-						</ul>
-					</div>
-				</div>
-			</section>
-
-			<Separator />
-
-			<SittingSection
+		<div className="mx-auto grid w-full max-w-3xl gap-6 px-4 py-8">
+			<ThinkspaceHeader
+				archiveDialogOpen={archiveDialogOpen}
+				archiveError={archiveMutation.error}
+				grantedPermissionsCount={grantedPermissions.length}
 				isArchived={isArchived}
+				isArchiving={archiveMutation.isPending}
 				isDraft={isDraft}
 				modelReady={modelReadiness.status === "ready"}
-				thinkspaceId={thinkspaceId}
+				onArchive={handleArchive}
+				onArchiveDialogOpenChange={setArchiveDialogOpen}
+				thinkspace={thinkspace}
 			/>
 
-			<Separator />
+			<Tabs defaultValue="sitting">
+				<TabsList>
+					<TabsTab value="sitting">
+						<MessagesSquareIcon />
+						Sitting
+					</TabsTab>
+					<TabsTab value="profile">
+						<UserRoundIcon />
+						Profile
+					</TabsTab>
+					<TabsTab value="sources">
+						<FileTextIcon />
+						Sources
+					</TabsTab>
+					<TabsTab value="tools">
+						<WrenchIcon />
+						Tools &amp; Permissions
+					</TabsTab>
+					<TabsTab value="runtime">
+						<ActivityIcon />
+						Runtime
+					</TabsTab>
+					<TabsIndicator />
+				</TabsList>
 
-			<SubmitTurnSection
-				isArchived={isArchived}
-				isDraft={isDraft}
-				modelReady={modelReadiness.status === "ready"}
-				thinkspaceId={thinkspaceId}
-			/>
+				<TabsPanel value="sitting">
+					<SittingSection
+						isArchived={isArchived}
+						isDraft={isDraft}
+						modelReady={modelReadiness.status === "ready"}
+						thinkspaceId={thinkspaceId}
+					/>
+				</TabsPanel>
 
-			<Separator />
+				<TabsPanel value="profile">
+					<AgentProfileSection
+						activationError={activateAgentProfileMutation.error}
+						isActivating={activateAgentProfileMutation.isPending}
+						onActivate={handleActivateAgentProfile}
+						pendingDraftRevision={pendingDraftRevision}
+						profileRevision={profileRevision}
+					/>
+				</TabsPanel>
 
-			<SourcesSection isArchived={isArchived} thinkspaceId={thinkspaceId} />
+				<TabsPanel value="sources">
+					<SourcesSection isArchived={isArchived} thinkspaceId={thinkspaceId} />
+				</TabsPanel>
 
-			<Separator />
-
-			<ToolsSection
-				enabledBuiltInToolIds={enabledBuiltInToolIds}
-				enabledTools={enabledTools}
-				isArchived={isArchived}
-				mcpCatalog={mcpCatalogQuery.data}
-				onToggleBuiltInTool={toggleBuiltInTool}
-				onToggleCatalogTool={toggleCatalogTool}
-				profileRevision={editableRevision}
-				toolPotencyById={toolPotencyById}
-				updateToolSelectionsError={updateToolSelectionsMutation.error}
-				updateToolSelectionsPending={updateToolSelectionsMutation.isPending}
-			/>
-
-			<Separator />
-
-			<PermissionsSection
-				grantedPermissions={grantedPermissions}
-				onRevokeGrantedPermission={handleRevokePermission}
-				requestedPermissions={requestedPermissions}
-				revokePermissionError={revokePermissionMutation.error}
-				revokingPermissionId={revokingPermissionId}
-			/>
-
-			{isArchived || isDraft ? null : (
-				<>
+				<TabsPanel className="grid gap-8" value="tools">
+					<ToolsSection
+						enabledBuiltInToolIds={enabledBuiltInToolIds}
+						enabledTools={enabledTools}
+						isArchived={isArchived}
+						mcpCatalog={mcpCatalogQuery.data}
+						onToggleBuiltInTool={toggleBuiltInTool}
+						onToggleCatalogTool={toggleCatalogTool}
+						profileRevision={editableRevision}
+						toolPotencyById={toolPotencyById}
+						updateToolSelectionsError={updateToolSelectionsMutation.error}
+						updateToolSelectionsPending={updateToolSelectionsMutation.isPending}
+					/>
 					<Separator />
-					<section className="grid gap-4">
-						<div className="grid gap-1">
-							<h2 className="text-lg font-semibold tracking-tight">Archive</h2>
-							<p className="text-muted-foreground text-sm">
-								Archiving disables active work and scheduled tasks. The Thinkspace remains
-								inspectable.
-							</p>
-						</div>
-						{archiveMutation.error ? (
-							<p className="text-destructive text-sm" role="alert">
-								{archiveMutation.error.message}
-							</p>
-						) : null}
-						<div>
-							<Button
-								disabled={archiveMutation.isPending}
-								onClick={handleArchive}
-								type="button"
-								variant="destructive"
-							>
-								{archiveMutation.isPending ? "Archiving…" : "Archive Thinkspace"}
-							</Button>
-						</div>
-					</section>
-				</>
-			)}
+					<PermissionsSection
+						grantedPermissions={grantedPermissions}
+						onRevokeGrantedPermission={handleRevokePermission}
+						requestedPermissions={requestedPermissions}
+						revokePermissionError={revokePermissionMutation.error}
+						revokingPermissionId={revokingPermissionId}
+					/>
+				</TabsPanel>
+
+				<TabsPanel className="grid gap-8" value="runtime">
+					<RuntimeSection
+						modelReadiness={modelReadiness}
+						runtimePolicy={runtimePolicy}
+						runtimeReadiness={runtimeReadiness}
+					/>
+					<Separator />
+					<SubmitTurnSection
+						isArchived={isArchived}
+						isDraft={isDraft}
+						modelReady={modelReadiness.status === "ready"}
+						thinkspaceId={thinkspaceId}
+					/>
+				</TabsPanel>
+			</Tabs>
 		</div>
 	);
 };

--- a/apps/web/src/routes/thinkspaces.index.tsx
+++ b/apps/web/src/routes/thinkspaces.index.tsx
@@ -1,21 +1,73 @@
+import { Badge } from "@better-agent/ui/components/badge";
 import { Button } from "@better-agent/ui/components/button";
 import { Input } from "@better-agent/ui/components/input";
 import { Label } from "@better-agent/ui/components/label";
 import { Textarea } from "@better-agent/ui/components/textarea";
+import { cn } from "@better-agent/ui/lib/utils";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router";
-import { useState } from "react";
+import {
+	ArchiveIcon,
+	CircleDashedIcon,
+	CircleDotIcon,
+	ClockIcon,
+	PlusIcon,
+	SearchIcon,
+	TargetIcon,
+} from "lucide-react";
 import type { FormEvent } from "react";
+import { useState } from "react";
 
 const routeApi = getRouteApi("/thinkspaces/");
 
 const dateFormatter = new Intl.DateTimeFormat("en", {
 	dateStyle: "medium",
-	timeStyle: "short",
 });
 
 const formatUpdatedAt = (value: Date | number | string): string =>
 	dateFormatter.format(new Date(value));
+
+// Active reads affirmative (sage); a draft is neutral; archived is attention.
+const getStatusBadgeVariant = (status: string): "destructive" | "outline" | "sage" => {
+	if (status === "archived") {
+		return "destructive";
+	}
+
+	if (status === "draft") {
+		return "outline";
+	}
+
+	return "sage";
+};
+
+// Status pills lead with a glyph so the state reads at a glance (DESIGN.md §7).
+const renderStatusBadgeIcon = (status: string) => {
+	if (status === "archived") {
+		return <ArchiveIcon aria-hidden />;
+	}
+
+	if (status === "draft") {
+		return <CircleDashedIcon aria-hidden />;
+	}
+
+	return <CircleDotIcon aria-hidden />;
+};
+
+const STATUS_FILTERS = [
+	{ label: "All", value: "all" },
+	{ label: "Active", value: "active" },
+	{ label: "Draft", value: "draft" },
+	{ label: "Archived", value: "archived" },
+] as const;
+
+type StatusFilter = (typeof STATUS_FILTERS)[number]["value"];
+
+// The empty state teaches the populated card's anatomy. These ghosts mirror the
+// real grid item: Goal-icon + name, a status pill, and quiet body lines.
+const GHOST_THINKSPACES = [
+	{ status: "Active", title: "Monitor Cloudflare Agents SDK releases" },
+	{ status: "Draft", title: "Reimagine the onboarding flow" },
+] as const;
 
 const RouteComponent = () => {
 	const context = routeApi.useRouteContext();
@@ -25,6 +77,8 @@ const RouteComponent = () => {
 	const [initialInstructions, setInitialInstructions] = useState("");
 	const [configurationSummary, setConfigurationSummary] = useState("");
 	const [showCreate, setShowCreate] = useState(false);
+	const [search, setSearch] = useState("");
+	const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
 	const createMutation = useMutation(
 		context.orpc.thinkspaces.create.mutationOptions({
 			onSuccess: async () => {
@@ -58,28 +112,34 @@ const RouteComponent = () => {
 		});
 	};
 
-	const hasThinkspaces = thinkspacesQuery.data.length > 0;
-	const shouldShowCreate = showCreate || !hasThinkspaces;
+	const thinkspaces = thinkspacesQuery.data;
+	const hasThinkspaces = thinkspaces.length > 0;
+	const query = search.trim().toLowerCase();
+	const filteredThinkspaces = thinkspaces.filter((thinkspace) => {
+		const matchesStatus = statusFilter === "all" || thinkspace.status === statusFilter;
+		const matchesQuery =
+			!query ||
+			thinkspace.goal.toLowerCase().includes(query) ||
+			(thinkspace.configurationSummary ?? "").toLowerCase().includes(query);
+
+		return matchesStatus && matchesQuery;
+	});
 
 	return (
 		<div className="mx-auto grid w-full max-w-3xl gap-8 px-4 py-8">
-			<div className="flex items-start justify-between gap-4">
-				<div className="grid gap-2">
-					<h1 className="text-2xl font-semibold tracking-tight">Thinkspaces</h1>
-					<p className="max-w-lg text-muted-foreground text-sm leading-relaxed">
-						Each Thinkspace holds one bounded Goal with its own Permissions, Sources, Memory, and
-						Artifacts.
-					</p>
-				</div>
-				{hasThinkspaces && !showCreate ? (
-					<Button className="shrink-0" onClick={() => setShowCreate(true)}>
-						Create Thinkspace
-					</Button>
-				) : null}
+			<div className="grid gap-2">
+				<h1 className="text-2xl font-semibold tracking-tight">Thinkspaces</h1>
+				<p className="max-w-lg text-muted-foreground text-sm leading-relaxed text-pretty">
+					Each Thinkspace holds one bounded Goal with its own Permissions, Sources, Memory, and
+					Artifacts.
+				</p>
 			</div>
 
-			{shouldShowCreate ? (
-				<form className="grid gap-4 border border-border p-6" onSubmit={handleSubmit}>
+			{showCreate ? (
+				<form
+					className="grid gap-4 rounded-lg p-6 ring-1 ring-foreground/10"
+					onSubmit={handleSubmit}
+				>
 					<div className="grid gap-1">
 						<h2 className="text-lg font-semibold tracking-tight">Create Thinkspace</h2>
 						<p className="text-muted-foreground text-sm">
@@ -129,52 +189,145 @@ const RouteComponent = () => {
 						<Button disabled={!canCreate} type="submit">
 							{createMutation.isPending ? "Creating…" : "Create Thinkspace"}
 						</Button>
-						{hasThinkspaces ? (
-							<Button onClick={() => setShowCreate(false)} type="button" variant="ghost">
-								Cancel
-							</Button>
-						) : null}
+						<Button onClick={() => setShowCreate(false)} type="button" variant="ghost">
+							Cancel
+						</Button>
 					</div>
 				</form>
 			) : null}
 
-			<section aria-labelledby="thinkspace-list-heading">
-				<h2 className="sr-only" id="thinkspace-list-heading">
-					Your Thinkspaces
-				</h2>
-
-				{hasThinkspaces ? (
-					<div className="border border-border">
-						{thinkspacesQuery.data.map((thinkspace, index) => (
-							<Link
-								key={thinkspace.id}
-								className={`grid gap-1 p-4 transition-colors hover:bg-muted/50 ${index < thinkspacesQuery.data.length - 1 ? "border-b border-border" : ""}`}
-								params={{ thinkspaceId: thinkspace.id }}
-								to="/thinkspaces/$thinkspaceId"
-							>
-								<div className="flex items-start justify-between gap-4">
-									<p className="text-sm font-medium">{thinkspace.goal}</p>
-									<span className="shrink-0 text-muted-foreground text-xs capitalize">
-										{thinkspace.status}
-									</span>
-								</div>
-								<p className="line-clamp-2 text-muted-foreground text-sm">
-									{thinkspace.configurationSummary}
-								</p>
-								<p className="text-muted-foreground text-xs">
-									Updated {formatUpdatedAt(thinkspace.updatedAt)}
-								</p>
-							</Link>
-						))}
+			{!showCreate && hasThinkspaces ? (
+				<section aria-labelledby="thinkspace-list-heading" className="grid gap-4">
+					<h2 className="sr-only" id="thinkspace-list-heading">
+						Your Thinkspaces
+					</h2>
+					<div className="flex flex-wrap items-center gap-2">
+						<div className="relative min-w-48 flex-1 sm:max-w-xs">
+							<SearchIcon
+								aria-hidden
+								className="-translate-y-1/2 absolute top-1/2 left-2.5 size-3.5 text-muted-foreground"
+							/>
+							<Input
+								aria-label="Search Thinkspaces"
+								className="pl-8"
+								onChange={(event) => setSearch(event.target.value)}
+								placeholder="Search Thinkspaces"
+								value={search}
+							/>
+						</div>
+						<div className="flex items-center gap-0.5 rounded-md border border-border p-0.5">
+							{STATUS_FILTERS.map((filter) => (
+								<button
+									className={cn(
+										"h-7 rounded-sm px-2.5 font-medium text-xs transition-colors",
+										statusFilter === filter.value
+											? "bg-muted text-foreground"
+											: "text-muted-foreground hover:text-foreground",
+									)}
+									key={filter.value}
+									onClick={() => setStatusFilter(filter.value)}
+									type="button"
+								>
+									{filter.label}
+								</button>
+							))}
+						</div>
+						<Button className="ml-auto shrink-0" onClick={() => setShowCreate(true)}>
+							<PlusIcon />
+							New Thinkspace
+						</Button>
 					</div>
-				) : (
-					<div className="border border-border p-6 text-center">
-						<p className="text-muted-foreground text-sm">
-							No Thinkspaces yet. Create one above to get started.
+					{filteredThinkspaces.length === 0 ? (
+						<p className="rounded-lg p-8 text-center text-muted-foreground text-sm ring-1 ring-foreground/10">
+							No Thinkspaces match your search.
 						</p>
+					) : (
+						<div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(16rem,1fr))]">
+							{filteredThinkspaces.map((thinkspace) => (
+								<Link
+									className="group grid content-start gap-3 rounded-lg p-4 ring-1 ring-foreground/10 transition-colors hover:bg-muted/40"
+									key={thinkspace.id}
+									params={{ thinkspaceId: thinkspace.id }}
+									to="/thinkspaces/$thinkspaceId"
+								>
+									<div className="flex items-start justify-between gap-3">
+										<div className="flex items-start gap-2">
+											<TargetIcon
+												aria-hidden
+												className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+											/>
+											<p className="font-medium text-sm leading-snug">{thinkspace.goal}</p>
+										</div>
+										<Badge className="shrink-0" variant={getStatusBadgeVariant(thinkspace.status)}>
+											{renderStatusBadgeIcon(thinkspace.status)}
+											<span className="capitalize">{thinkspace.status}</span>
+										</Badge>
+									</div>
+									<p className="line-clamp-2 text-muted-foreground text-sm">
+										{thinkspace.configurationSummary}
+									</p>
+									<p className="flex items-center gap-1.5 text-muted-foreground text-xs">
+										<ClockIcon aria-hidden className="size-3" />
+										Updated {formatUpdatedAt(thinkspace.updatedAt)}
+									</p>
+								</Link>
+							))}
+						</div>
+					)}
+				</section>
+			) : null}
+
+			{!showCreate && !hasThinkspaces ? (
+				<section
+					aria-labelledby="thinkspace-empty-heading"
+					className="grid overflow-hidden rounded-lg ring-1 ring-foreground/10 md:grid-cols-2"
+				>
+					<div className="grid content-center gap-4 p-8">
+						<h2 className="text-lg font-semibold tracking-tight" id="thinkspace-empty-heading">
+							Set up your first Thinkspace
+						</h2>
+						<p className="max-w-sm text-muted-foreground text-sm leading-relaxed text-pretty">
+							A Thinkspace is a bounded environment for one Goal — its own Sources, Permissions, and
+							a dedicated agent. Compose it once, then return to review what it produced.
+						</p>
+						<div>
+							<Button onClick={() => setShowCreate(true)}>
+								<PlusIcon />
+								Create Thinkspace
+							</Button>
+						</div>
 					</div>
-				)}
-			</section>
+					<div className="relative hidden min-h-56 border-border md:block md:border-l">
+						<div
+							aria-hidden
+							className="absolute inset-0 opacity-60 [background-image:radial-gradient(var(--border)_1px,transparent_1px)] [background-size:16px_16px]"
+						/>
+						<div aria-hidden className="relative grid h-full content-center gap-3 p-8">
+							{GHOST_THINKSPACES.map((ghost) => (
+								<div
+									className="grid gap-2.5 rounded-lg bg-background/60 p-4 ring-1 ring-foreground/10"
+									key={ghost.title}
+								>
+									<div className="flex items-center justify-between gap-3">
+										<div className="flex items-center gap-2">
+											<TargetIcon className="size-4 text-muted-foreground/60" />
+											<span className="font-medium text-foreground/70 text-sm">{ghost.title}</span>
+										</div>
+										<span className="h-5 rounded-full bg-muted px-2 text-muted-foreground/70 text-xs leading-5">
+											{ghost.status}
+										</span>
+									</div>
+									<div className="h-2 w-4/5 rounded-full bg-muted" />
+									<div className="flex items-center gap-1.5 text-muted-foreground/50">
+										<ClockIcon className="size-3" />
+										<div className="h-2 w-20 rounded-full bg-muted" />
+									</div>
+								</div>
+							))}
+						</div>
+					</div>
+				</section>
+			) : null}
 		</div>
 	);
 };

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -20,6 +20,7 @@ const badgeVariants = cva(
 				ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
 				link: "text-primary underline-offset-4 hover:underline",
 				outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+				sage: "bg-sage/15 text-sage [a]:hover:bg-sage/25",
 				secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
 			},
 		},

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+import { cn } from "@better-agent/ui/lib/utils";
+
+const Tabs = ({ className, ...props }: TabsPrimitive.Root.Props) => (
+	<TabsPrimitive.Root
+		data-slot="tabs"
+		className={cn("flex flex-col gap-6", className)}
+		{...props}
+	/>
+);
+
+const TabsList = ({ className, ...props }: TabsPrimitive.List.Props) => (
+	<TabsPrimitive.List
+		data-slot="tabs-list"
+		className={cn(
+			"relative flex w-full items-center gap-1 overflow-x-auto border-b border-border",
+			className,
+		)}
+		{...props}
+	/>
+);
+
+const TabsTab = ({ className, ...props }: TabsPrimitive.Tab.Props) => (
+	<TabsPrimitive.Tab
+		data-slot="tabs-tab"
+		className={cn(
+			"relative inline-flex h-9 shrink-0 cursor-default items-center gap-1.5 rounded-t-sm px-3 text-sm font-medium whitespace-nowrap text-muted-foreground transition-colors outline-none select-none hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring/50 data-selected:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+			className,
+		)}
+		{...props}
+	/>
+);
+
+// The active underline. Base UI sets --active-tab-{left,width} on the indicator;
+// data-instant suppresses the transition on first paint so it doesn't slide in
+// from the origin. prefers-reduced-motion falls back to an instant move.
+const TabsIndicator = ({ className, ...props }: TabsPrimitive.Indicator.Props) => (
+	<TabsPrimitive.Indicator
+		data-slot="tabs-indicator"
+		className={cn(
+			"absolute bottom-0 left-0 h-px w-(--active-tab-width) translate-x-(--active-tab-left) bg-foreground transition-[translate,width] duration-200 ease-out data-instant:transition-none motion-reduce:transition-none",
+			className,
+		)}
+		{...props}
+	/>
+);
+
+const TabsPanel = ({ className, ...props }: TabsPrimitive.Panel.Props) => (
+	<TabsPrimitive.Panel
+		data-slot="tabs-panel"
+		className={cn("outline-none focus-visible:ring-1 focus-visible:ring-ring/50", className)}
+		{...props}
+	/>
+);
+
+export { Tabs, TabsIndicator, TabsList, TabsPanel, TabsTab };

--- a/packages/ui/src/components/theme-provider.tsx
+++ b/packages/ui/src/components/theme-provider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ComponentProps } from "react";
+
+/**
+ * Thin wrapper over next-themes so the app wires a single import and the theme
+ * system stays a UI-package concern. Dark is the primary theme (DESIGN.md §2);
+ * the light token block in globals.css keeps light mode one toggle away.
+ */
+export const ThemeProvider = ({
+	children,
+	...props
+}: ComponentProps<typeof NextThemesProvider>) => (
+	<NextThemesProvider {...props}>{children}</NextThemesProvider>
+);

--- a/packages/ui/src/components/theme-toggle.tsx
+++ b/packages/ui/src/components/theme-toggle.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Button } from "@better-agent/ui/components/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@better-agent/ui/components/dropdown-menu";
+import { CheckIcon, MonitorIcon, MoonIcon, SunIcon } from "lucide-react";
+import { useTheme } from "next-themes";
+
+const THEME_OPTIONS = [
+	{ icon: SunIcon, label: "Light", value: "light" },
+	{ icon: MoonIcon, label: "Dark", value: "dark" },
+	{ icon: MonitorIcon, label: "System", value: "system" },
+] as const;
+
+/**
+ * Light / Dark / System switch. The trigger glyph is CSS-driven off the `.dark`
+ * class next-themes sets, so it needs no mount guard and never flashes; the
+ * checkmark reads `theme`, which is safe because menu content only renders once
+ * opened (always post-hydration).
+ */
+export const ThemeToggle = () => {
+	const { setTheme, theme } = useTheme();
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger
+				render={<Button aria-label="Switch theme" size="icon" variant="ghost" />}
+			>
+				<SunIcon className="dark:hidden" />
+				<MoonIcon className="hidden dark:block" />
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="min-w-36">
+				{THEME_OPTIONS.map(({ icon: Icon, label, value }) => (
+					<DropdownMenuItem
+						className="justify-between gap-6"
+						key={value}
+						onClick={() => setTheme(value)}
+					>
+						<span className="flex items-center gap-2">
+							<Icon />
+							{label}
+						</span>
+						{theme === value ? <CheckIcon className="size-3.5 text-muted-foreground" /> : null}
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+};

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -25,6 +25,10 @@
 	--border: oklch(0.922 0 0);
 	--input: oklch(0.922 0 0);
 	--ring: oklch(0.708 0 0);
+	/* Sage accent (DESIGN.md §2). Tuned darker than the canonical 0.65 here so
+	   text-on-light clears WCAG AA; the dark block lightens it for the same
+	   reason. Restrained — affirmative signal only, never decoration. */
+	--sage: oklch(0.5 0.1 148);
 	--chart-1: oklch(0.809 0.105 251.813);
 	--chart-2: oklch(0.623 0.214 259.815);
 	--chart-3: oklch(0.546 0.245 262.881);
@@ -61,6 +65,7 @@
 	--border: oklch(1 0 0 / 10%);
 	--input: oklch(1 0 0 / 15%);
 	--ring: oklch(0.556 0 0);
+	--sage: oklch(0.8 0.07 148);
 	--chart-1: oklch(0.809 0.105 251.813);
 	--chart-2: oklch(0.623 0.214 259.815);
 	--chart-3: oklch(0.546 0.245 262.881);
@@ -93,6 +98,7 @@
 	--color-chart-2: var(--chart-2);
 	--color-chart-1: var(--chart-1);
 	--color-ring: var(--ring);
+	--color-sage: var(--sage);
 	--color-input: var(--input);
 	--color-border: var(--border);
 	--color-destructive: var(--destructive);


### PR DESCRIPTION
## Summary

Lands the deferred Phase 1 UI refit plus the focused melior alignment polish, refitting the live working surfaces to the DESIGN.md "Workbench" identity (achromatic, soft corners, one floating shadow). Light/dark theming added; no backend changes.

This branch sits **directly on `main`** and is independent of #97 (inline Sitting Approval) — the two share no files, so they merge on independent timelines.

### Phase 1 refit
- Theme toggle via a new shared `ThemeProvider`/`ThemeToggle` + `Tabs` primitive in `packages/ui`; wired through `__root` and the header (dark stays default).
- Document Page tabs on the Thinkspace detail surface; Teaching Empty State on the Thinkspaces index; native `<select>` → `Select` on settings.product + Sources Format.
- `Badge` variants and `globals.css` tokens updated to match.

### Melior alignment polish
- Detail header: `TargetIcon` title lockup; a glyph on every metadata pill; Updated/Archived folded into the single pill row (`formatMetaDate`).
- Index: real toolbar (live search + All/Active/Draft/Archived segmented filter + New button) with a "No Thinkspaces match" state; enriched populated cards (glyph status pill + clock-led footer) and ghost cards mirroring the real card anatomy.

## Test plan
- [x] `vite build` (web) green
- [x] `header.tsx` carries both the ThemeToggle and the Review Queue link
- [ ] Live visual review (needs local env: `VITE_SERVER_URL` + CF bindings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)