### PR TITLE
Backend: ground the agent prompt against fabricated tool actions + fix local-dev auth cookies

### DIFF
--- a/packages/api/src/thinkspaces/turn-assembly.test.ts
+++ b/packages/api/src/thinkspaces/turn-assembly.test.ts
@@ -7,7 +7,11 @@ import {
 	createMemoryPermissionPolicy,
 } from "./permission-policy";
 import { THINKSPACE_RUNTIME_MAX_STEPS } from "./runtime-policy";
-import { assembleThinkspaceTurn } from "./turn-assembly";
+import {
+	assembleThinkspaceTurn,
+	buildThinkspaceAgentSystemPrompt,
+	THINKSPACE_AGENT_GROUNDING_CLAUSE,
+} from "./turn-assembly";
 
 const NOW = new Date("2026-06-10T12:00:00.000Z");
 
@@ -65,4 +69,21 @@ test("enabled tools without a potency verdict stay inert", () => {
 	const assembly = assembleThinkspaceTurn({ revision: REVISION, toolPotencies: [] });
 
 	assert.deepEqual(assembly.activeTools, []);
+});
+
+test("the system prompt grounds the agent against claiming actions it has no tool for", () => {
+	const assembly = assembleThinkspaceTurn({ revision: REVISION, toolPotencies: [] });
+
+	assert.ok(assembly.systemPrompt.includes(THINKSPACE_AGENT_GROUNDING_CLAUSE));
+});
+
+test("the grounding clause is present even when the profile has no custom instructions", () => {
+	const prompt = buildThinkspaceAgentSystemPrompt({
+		...REVISION,
+		identity: { displayName: "Release Monitor", instructions: "" },
+	});
+
+	assert.match(prompt, /Release Monitor/u);
+	assert.ok(prompt.includes(THINKSPACE_AGENT_GROUNDING_CLAUSE));
+	assert.doesNotMatch(prompt, /\n\n\n/u);
 });

--- a/packages/api/src/thinkspaces/turn-assembly.ts
+++ b/packages/api/src/thinkspaces/turn-assembly.ts
@@ -39,10 +39,25 @@ export interface AssembleThinkspaceTurnInput {
 	toolPotencies: ToolPotencyVerdict[];
 }
 
+/**
+ * A grounding clause appended to every turn's system prompt. The agent acts
+ * only through the tools assembled for the turn (enabled ∩ potent), so when a
+ * capability is off no tool is present — and a weaker model will otherwise
+ * narrate a plausible success it never performed (e.g. "Memory recorded"). This
+ * forbids that: the agent must not report an action it has no tool for, and a
+ * durable Memory exists only once the held `memory_write` tool runs on an
+ * owner-approved continuation.
+ */
+export const THINKSPACE_AGENT_GROUNDING_CLAUSE =
+	"You act only through the tools made available to you on this turn. Never claim to have recorded a Memory, read a Source, searched the web, or taken any other action unless you actually called the tool for it on this turn. Recording a durable Memory happens only by calling the memory_write tool, which is held for the owner's Approval; if that tool is not available to you, you cannot record Memories — say so plainly instead of describing it as done.";
+
 export const buildThinkspaceAgentSystemPrompt = (revision: ActiveAgentProfileRevision): string => {
 	const header = `You are ${revision.identity.displayName}, a Thinkspace Agent for Better Agent.`;
+	const sections = revision.identity.instructions
+		? [header, revision.identity.instructions, THINKSPACE_AGENT_GROUNDING_CLAUSE]
+		: [header, THINKSPACE_AGENT_GROUNDING_CLAUSE];
 
-	return revision.identity.instructions ? `${header}\n\n${revision.identity.instructions}` : header;
+	return sections.join("\n\n");
 };
 
 /**

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -14,13 +14,19 @@ export interface CreateAuthOptions {
 	env: AuthBindings;
 }
 
-export const createAuth = ({ db, env }: CreateAuthOptions) =>
-	betterAuth({
+export const createAuth = ({ db, env }: CreateAuthOptions) => {
+	// In local dev BETTER_AUTH_URL is plain http (e.g. http://localhost:3000), where
+	// browsers refuse to persist `secure` / `sameSite: "none"` cookies — so the session
+	// silently disappears and protected requests start 401ing. Only harden the cookie
+	// when we're actually served over https (the deployed, cross-origin setup).
+	const isSecureOrigin = env.BETTER_AUTH_URL.startsWith("https://");
+
+	return betterAuth({
 		advanced: {
 			defaultCookieAttributes: {
 				httpOnly: true,
-				sameSite: "none",
-				secure: true,
+				sameSite: isSecureOrigin ? "none" : "lax",
+				secure: isSecureOrigin,
 			},
 		},
 		basePath: "/api/auth",
@@ -35,3 +41,4 @@ export const createAuth = ({ db, env }: CreateAuthOptions) =>
 		secret: env.BETTER_AUTH_SECRET,
 		trustedOrigins: [env.CORS_ORIGIN],
 	});
+};


### PR DESCRIPTION
Two independent backend fixes, split out of the `ui-phase1-polish` working tree (the UI work itself is PR #104, untouched).

## 1. Agent prompt grounding (`turn-assembly.ts`)
The Thinkspace Agent turn system prompt named the agent but never stated its capabilities, so a weaker model would fabricate success for an action it had no tool for — observed in a Sitting as "Memory recorded" with **no `memory_write` tool call, no Approval, and no DB row** (`thinkspace_approvals`/`thinkspace_memories` both empty). The tool was correctly absent because it wasn't enabled + granted; the model simply narrated a success it never performed.

Adds a constant `THINKSPACE_AGENT_GROUNDING_CLAUSE` to `buildThinkspaceAgentSystemPrompt`: the agent acts only through the turn's assembled tools and must not claim an untaken action — a durable Memory exists only once the held `memory_write` tool runs on an owner-approved continuation. Two `turn-assembly.test.ts` cases pin the clause's presence (with and without custom instructions).

## 2. Local-dev session cookie (`auth/index.ts`)
Browsers refuse to persist `secure` / `sameSite:none` cookies over plain http, so the local-dev session silently dropped and protected requests 401'd. Cookies now fall back to `sameSite:lax` / `secure:false` unless `BETTER_AUTH_URL` is https (the deployed, cross-origin setup), preserving production hardening. Unblocks the local Sitting round-trip.

---
api tests (258 pass), `turbo check-types`, and ultracite all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)