### PR TITLE
Backend+UI: connect a GitHub account via fine-grained PAT (#110)

### DIFF
--- a/apps/web/src/routes/settings.product.tsx
+++ b/apps/web/src/routes/settings.product.tsx
@@ -31,6 +31,9 @@ const RouteComponent = () => {
 	const catalogQuery = useSuspenseQuery(context.orpc.models.listAvailable.queryOptions());
 	const credentialsQuery = useSuspenseQuery(context.orpc.models.listCredentials.queryOptions());
 	const defaultsQuery = useSuspenseQuery(context.orpc.models.getDefaults.queryOptions());
+	const connectedAccountsQuery = useSuspenseQuery(
+		context.orpc.connectedAccounts.list.queryOptions(),
+	);
 	const [defaultModel, setDefaultModel] = useState(defaultsQuery.data.defaultModel);
 	const [defaultReasoningEffort, setDefaultReasoningEffort] = useState(
 		defaultsQuery.data.reasoningEffort,
@@ -38,6 +41,7 @@ const RouteComponent = () => {
 	const [providerId, setProviderId] = useState<keyof typeof PROVIDER_LABELS>("openai");
 	const [credential, setCredential] = useState("");
 	const [label, setLabel] = useState("");
+	const [githubToken, setGithubToken] = useState("");
 	const saveDefaults = useMutation(
 		context.orpc.models.updateDefaults.mutationOptions({
 			onSuccess: async (settings) => {
@@ -60,6 +64,25 @@ const RouteComponent = () => {
 						queryKey: context.orpc.models.listCredentials.queryKey(),
 					}),
 				]);
+			},
+		}),
+	);
+	const connectGithub = useMutation(
+		context.orpc.connectedAccounts.connect.mutationOptions({
+			onSuccess: async () => {
+				setGithubToken("");
+				await queryClient.invalidateQueries({
+					queryKey: context.orpc.connectedAccounts.list.queryKey(),
+				});
+			},
+		}),
+	);
+	const disconnectGithub = useMutation(
+		context.orpc.connectedAccounts.disconnect.mutationOptions({
+			onSuccess: async () => {
+				await queryClient.invalidateQueries({
+					queryKey: context.orpc.connectedAccounts.list.queryKey(),
+				});
 			},
 		}),
 	);
@@ -93,6 +116,14 @@ const RouteComponent = () => {
 			return;
 		}
 		saveCredential.mutate({ credential, label: label.trim() || undefined, providerId });
+	};
+
+	const handleGithubSubmit = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (githubToken.trim().length < 20 || connectGithub.isPending) {
+			return;
+		}
+		connectGithub.mutate({ token: githubToken.trim() });
 	};
 
 	return (
@@ -294,6 +325,84 @@ const RouteComponent = () => {
 				) : (
 					<p className="text-muted-foreground text-sm">No credentials saved.</p>
 				)}
+			</section>
+
+			<Separator />
+
+			<section aria-labelledby="connected-accounts-heading" className="grid gap-4">
+				<div className="grid gap-1">
+					<h3 className="text-sm font-medium" id="connected-accounts-heading">
+						Connected Accounts
+					</h3>
+					<p className="text-muted-foreground text-sm">
+						Connect a GitHub account with a fine-grained personal access token. The token is
+						validated with GitHub, encrypted at rest, and used only after you approve a specific
+						action.
+					</p>
+				</div>
+				<form
+					className="grid max-w-md gap-4 rounded-lg p-4 ring-1 ring-foreground/10"
+					onSubmit={handleGithubSubmit}
+				>
+					<div className="grid gap-1.5">
+						<Label htmlFor="github-token">GitHub personal access token</Label>
+						<Input
+							autoComplete="off"
+							id="github-token"
+							onChange={(event) => setGithubToken(event.target.value)}
+							placeholder="github_pat_…"
+							type="password"
+							value={githubToken}
+						/>
+					</div>
+					{connectGithub.error ? (
+						<p className="text-destructive text-sm" role="alert">
+							{connectGithub.error.message}
+						</p>
+					) : null}
+					<Button
+						className="w-fit"
+						disabled={githubToken.trim().length < 20 || connectGithub.isPending}
+						type="submit"
+					>
+						{connectGithub.isPending ? "Connecting…" : "Connect GitHub"}
+					</Button>
+				</form>
+				{connectedAccountsQuery.data.length > 0 ? (
+					<div className="overflow-hidden rounded-lg ring-1 ring-foreground/10">
+						{connectedAccountsQuery.data.map((account, index) => (
+							<div
+								className={`flex items-center justify-between gap-4 p-4 text-sm ${index < connectedAccountsQuery.data.length - 1 ? "border-b border-border" : ""}`}
+								key={account.id}
+							>
+								<div className="grid gap-1">
+									<span className="font-medium">GitHub</span>
+									<span className="text-muted-foreground text-xs">
+										{account.externalAccountId
+											? `Connected as @${account.externalAccountId}`
+											: "Connected"}
+									</span>
+								</div>
+								<Button
+									disabled={disconnectGithub.isPending}
+									onClick={() => disconnectGithub.mutate({ accountId: account.id })}
+									size="sm"
+									type="button"
+									variant="outline"
+								>
+									{disconnectGithub.isPending ? "Disconnecting…" : "Disconnect"}
+								</Button>
+							</div>
+						))}
+					</div>
+				) : (
+					<p className="text-muted-foreground text-sm">No connected accounts.</p>
+				)}
+				{disconnectGithub.error ? (
+					<p className="text-destructive text-sm" role="alert">
+						{disconnectGithub.error.message}
+					</p>
+				) : null}
 			</section>
 		</div>
 	);

--- a/packages/api/src/connected-accounts/github.ts
+++ b/packages/api/src/connected-accounts/github.ts
@@ -1,0 +1,53 @@
+/**
+ * GitHub credential validation for Connected Accounts. A pasted fine-grained
+ * Personal Access Token is validated against GitHub `GET /user` so we resolve
+ * and store the account identity at connect time, and reject anything GitHub
+ * will not honour before it is ever persisted (ADR-0009).
+ */
+const GITHUB_USER_ENDPOINT = "https://api.github.com/user";
+
+/** A token GitHub would not accept, or an identity it would not return. */
+export class GitHubValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "GitHubValidationError";
+	}
+}
+
+export interface GitHubAccountIdentity {
+	login: string;
+}
+
+export const resolveGitHubAccount = async (token: string): Promise<GitHubAccountIdentity> => {
+	let response: Response;
+	try {
+		response = await fetch(GITHUB_USER_ENDPOINT, {
+			headers: {
+				Accept: "application/vnd.github+json",
+				Authorization: `Bearer ${token}`,
+				"User-Agent": "better-agent",
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+		});
+	} catch {
+		throw new GitHubValidationError(
+			"Could not reach GitHub to validate the token. Try again shortly.",
+		);
+	}
+
+	if (response.status === 401 || response.status === 403) {
+		throw new GitHubValidationError(
+			"GitHub rejected this token. Check that it is valid and has not expired, then try again.",
+		);
+	}
+	if (!response.ok) {
+		throw new GitHubValidationError("GitHub could not validate this token. Try again shortly.");
+	}
+
+	const body = (await response.json()) as { login?: unknown };
+	if (typeof body.login !== "string" || body.login.length === 0) {
+		throw new GitHubValidationError("GitHub did not return an account identity for this token.");
+	}
+
+	return { login: body.login };
+};

--- a/packages/api/src/connected-accounts/repository.ts
+++ b/packages/api/src/connected-accounts/repository.ts
@@ -1,0 +1,66 @@
+import type { ProductDb } from "@better-agent/db";
+import { userConnectedAccounts } from "@better-agent/db/schema/connected-accounts";
+import { and, eq } from "drizzle-orm";
+
+export interface UpsertConnectedAccountInput {
+	catalogId: string;
+	credentialType: "oauth" | "pat";
+	encryptedCredential: string;
+	externalAccountId: string;
+	id: string;
+	label?: string;
+	userId: string;
+}
+
+/**
+ * One Connected Account per provider per user: upsert keyed on
+ * (userId, catalogId) so reconnecting replaces the credential and identity
+ * in place rather than accumulating rows.
+ */
+export const upsertConnectedAccount = async (db: ProductDb, input: UpsertConnectedAccountInput) => {
+	const now = new Date();
+	const [row] = await db
+		.insert(userConnectedAccounts)
+		.values({
+			catalogId: input.catalogId,
+			credentialType: input.credentialType,
+			encryptedCredential: input.encryptedCredential,
+			externalAccountId: input.externalAccountId,
+			id: input.id,
+			label: input.label,
+			updatedAt: now,
+			userId: input.userId,
+		})
+		.onConflictDoUpdate({
+			set: {
+				credentialType: input.credentialType,
+				encryptedCredential: input.encryptedCredential,
+				externalAccountId: input.externalAccountId,
+				label: input.label,
+				updatedAt: now,
+			},
+			target: [userConnectedAccounts.userId, userConnectedAccounts.catalogId],
+		})
+		.returning();
+	if (!row) {
+		throw new Error("Connected account was not persisted.");
+	}
+
+	return row;
+};
+
+export const listConnectedAccounts = async (db: ProductDb, userId: string) =>
+	await db.select().from(userConnectedAccounts).where(eq(userConnectedAccounts.userId, userId));
+
+export const deleteConnectedAccount = async (
+	db: ProductDb,
+	input: { id: string; userId: string },
+) => {
+	const deleted = await db
+		.delete(userConnectedAccounts)
+		.where(
+			and(eq(userConnectedAccounts.id, input.id), eq(userConnectedAccounts.userId, input.userId)),
+		)
+		.returning();
+	return deleted.length > 0;
+};

--- a/packages/api/src/connected-accounts/router.test.ts
+++ b/packages/api/src/connected-accounts/router.test.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+import { user } from "@better-agent/db/schema/auth";
+import { userConnectedAccounts } from "@better-agent/db/schema/connected-accounts";
+import { ORPCError, call } from "@orpc/server";
+import { eq } from "drizzle-orm";
+
+import type { Context } from "../context";
+import { decryptCredential } from "../crypto";
+import { createTestProductDb } from "../testing/product-db";
+import { connectedAccountsRouter } from "./router";
+
+const TEST_SECRET = "test-secret";
+const OWNER = { session: { id: "session_owner" }, user: { id: "owner_user" } };
+const OTHER = { session: { id: "session_other" }, user: { id: "other_user" } };
+
+const createCallContext = (db: ProductDb, session: typeof OWNER): Context =>
+	({
+		db,
+		env: { BETTER_AUTH_SECRET: TEST_SECRET },
+		executionCtx: undefined,
+		headers: new Headers(),
+		session,
+	}) as unknown as Context;
+
+const seedUsers = async (db: ProductDb) => {
+	await db.insert(user).values([
+		{ email: "owner@example.com", id: OWNER.user.id, name: "Owner" },
+		{ email: "other@example.com", id: OTHER.user.id, name: "Other" },
+	]);
+};
+
+/** Replace global fetch with a stub for the duration of one test. */
+const withFetch = async (impl: typeof fetch, run: () => Promise<void>) => {
+	const original = globalThis.fetch;
+	globalThis.fetch = impl;
+	try {
+		await run();
+	} finally {
+		globalThis.fetch = original;
+	}
+};
+
+const githubUser = (login: string, status = 200): typeof fetch =>
+	(() => Promise.resolve(Response.json({ login }, { status }))) as typeof fetch;
+
+const expectCode =
+	(code: string) =>
+	(error: unknown): boolean =>
+		error instanceof ORPCError && error.code === code;
+
+test("connect validates the token, resolves the login, and stores it encrypted", async () => {
+	const db = createTestProductDb();
+	await seedUsers(db);
+
+	await withFetch(githubUser("octocat"), async () => {
+		const result = await call(
+			connectedAccountsRouter.connect,
+			{ token: "ghp_fineGrainedExampleToken" },
+			{ context: createCallContext(db, OWNER) },
+		);
+		assert.equal(result.externalAccountId, "octocat");
+		assert.equal(result.catalogId, "github");
+		assert.equal(result.credentialType, "pat");
+		// The connect response previews the credential but never echoes it raw.
+		assert.notEqual(result.redactedCredential, "ghp_fineGrainedExampleToken");
+	});
+
+	const [row] = await db
+		.select()
+		.from(userConnectedAccounts)
+		.where(eq(userConnectedAccounts.userId, OWNER.user.id));
+	assert.equal(row?.externalAccountId, "octocat");
+	assert.notEqual(row?.encryptedCredential, "ghp_fineGrainedExampleToken");
+	assert.equal(
+		await decryptCredential(row?.encryptedCredential ?? "", TEST_SECRET),
+		"ghp_fineGrainedExampleToken",
+	);
+});
+
+test("an invalid token is rejected and nothing is stored", async () => {
+	const db = createTestProductDb();
+	await seedUsers(db);
+
+	await withFetch(githubUser("", 401), async () => {
+		await assert.rejects(
+			call(
+				connectedAccountsRouter.connect,
+				{ token: "ghp_expiredOrRevoked" },
+				{ context: createCallContext(db, OWNER) },
+			),
+			expectCode("BAD_REQUEST"),
+		);
+	});
+
+	const rows = await db
+		.select()
+		.from(userConnectedAccounts)
+		.where(eq(userConnectedAccounts.userId, OWNER.user.id));
+	assert.equal(rows.length, 0);
+});
+
+test("a network failure at connect surfaces honestly and stores nothing", async () => {
+	const db = createTestProductDb();
+	await seedUsers(db);
+
+	const failingFetch = (() => Promise.reject(new Error("network down"))) as typeof fetch;
+	await withFetch(failingFetch, async () => {
+		await assert.rejects(
+			call(
+				connectedAccountsRouter.connect,
+				{ token: "ghp_anything" },
+				{ context: createCallContext(db, OWNER) },
+			),
+			expectCode("BAD_REQUEST"),
+		);
+	});
+
+	const rows = await db
+		.select()
+		.from(userConnectedAccounts)
+		.where(eq(userConnectedAccounts.userId, OWNER.user.id));
+	assert.equal(rows.length, 0);
+});
+
+test("list returns the identity redacted and never the raw token", async () => {
+	const db = createTestProductDb();
+	await seedUsers(db);
+
+	await withFetch(githubUser("octocat"), async () => {
+		await call(
+			connectedAccountsRouter.connect,
+			{ token: "ghp_fineGrainedExampleToken" },
+			{ context: createCallContext(db, OWNER) },
+		);
+	});
+
+	const accounts = await call(connectedAccountsRouter.list, undefined, {
+		context: createCallContext(db, OWNER),
+	});
+	assert.equal(accounts.length, 1);
+	assert.equal(accounts[0]?.externalAccountId, "octocat");
+	assert.equal(accounts[0]?.redactedCredential, "••••");
+	assert.equal(Object.values(accounts[0] ?? {}).includes("ghp_fineGrainedExampleToken"), false);
+});
+
+test("reconnecting keeps one account per provider and refreshes the credential", async () => {
+	const db = createTestProductDb();
+	await seedUsers(db);
+
+	await withFetch(githubUser("octocat"), async () => {
+		await call(
+			connectedAccountsRouter.connect,
+			{ token: "ghp_firstToken" },
+			{ context: createCallContext(db, OWNER) },
+		);
+	});
+	await withFetch(githubUser("octocat-renamed"), async () => {
+		await call(
+			connectedAccountsRouter.connect,
+			{ token: "ghp_secondToken" },
+			{ context: createCallContext(db, OWNER) },
+		);
+	});
+
+	const rows = await db
+		.select()
+		.from(userConnectedAccounts)
+		.where(eq(userConnectedAccounts.userId, OWNER.user.id));
+	assert.equal(rows.length, 1);
+	assert.equal(rows[0]?.externalAccountId, "octocat-renamed");
+	assert.equal(
+		await decryptCredential(rows[0]?.encryptedCredential ?? "", TEST_SECRET),
+		"ghp_secondToken",
+	);
+});
+
+test("disconnect removes the credential row", async () => {
+	const db = createTestProductDb();
+	await seedUsers(db);
+
+	let accountId = "";
+	await withFetch(githubUser("octocat"), async () => {
+		const connected = await call(
+			connectedAccountsRouter.connect,
+			{ token: "ghp_fineGrainedExampleToken" },
+			{ context: createCallContext(db, OWNER) },
+		);
+		accountId = connected.id;
+	});
+
+	const result = await call(
+		connectedAccountsRouter.disconnect,
+		{ accountId },
+		{ context: createCallContext(db, OWNER) },
+	);
+	assert.equal(result.success, true);
+
+	const rows = await db
+		.select()
+		.from(userConnectedAccounts)
+		.where(eq(userConnectedAccounts.userId, OWNER.user.id));
+	assert.equal(rows.length, 0);
+});
+
+test("a non-owner cannot see or disconnect another user's account (404-first)", async () => {
+	const db = createTestProductDb();
+	await seedUsers(db);
+
+	let accountId = "";
+	await withFetch(githubUser("octocat"), async () => {
+		const connected = await call(
+			connectedAccountsRouter.connect,
+			{ token: "ghp_ownerToken" },
+			{ context: createCallContext(db, OWNER) },
+		);
+		accountId = connected.id;
+	});
+
+	const otherList = await call(connectedAccountsRouter.list, undefined, {
+		context: createCallContext(db, OTHER),
+	});
+	assert.equal(otherList.length, 0);
+
+	await assert.rejects(
+		call(
+			connectedAccountsRouter.disconnect,
+			{ accountId },
+			{ context: createCallContext(db, OTHER) },
+		),
+		expectCode("NOT_FOUND"),
+	);
+
+	// The owner's row is untouched.
+	const ownerRows = await db
+		.select()
+		.from(userConnectedAccounts)
+		.where(eq(userConnectedAccounts.userId, OWNER.user.id));
+	assert.equal(ownerRows.length, 1);
+});

--- a/packages/api/src/connected-accounts/router.ts
+++ b/packages/api/src/connected-accounts/router.ts
@@ -1,0 +1,76 @@
+import { ORPCError } from "@orpc/server";
+import { z } from "zod";
+
+import { encryptCredential, redactCredential } from "../crypto";
+import { protectedProcedure } from "../procedures";
+import { GitHubValidationError, resolveGitHubAccount } from "./github";
+import {
+	deleteConnectedAccount,
+	listConnectedAccounts,
+	upsertConnectedAccount,
+} from "./repository";
+
+const GITHUB_CATALOG_ID = "github";
+const REDACTED_PLACEHOLDER = "••••";
+
+const connectInput = z.object({ token: z.string().trim().min(1) });
+const disconnectInput = z.object({ accountId: z.string().min(1) });
+
+const encryptionSecret = (env: { API_ENCRYPTION_KEY?: string; BETTER_AUTH_SECRET: string }) =>
+	env.API_ENCRYPTION_KEY ?? env.BETTER_AUTH_SECRET;
+
+/**
+ * The raw token never leaves the server. List surfaces only the resolved
+ * identity ("Connected as @login") and a static redacted placeholder; the
+ * real first/last preview is shown once, at connect time, when the plaintext
+ * is already in hand.
+ */
+const toAccountOutput = (row: Awaited<ReturnType<typeof listConnectedAccounts>>[number]) => ({
+	catalogId: row.catalogId,
+	createdAt: row.createdAt,
+	credentialType: row.credentialType,
+	externalAccountId: row.externalAccountId,
+	id: row.id,
+	label: row.label,
+	redactedCredential: REDACTED_PLACEHOLDER,
+	updatedAt: row.updatedAt,
+});
+
+export const connectedAccountsRouter = {
+	connect: protectedProcedure.input(connectInput).handler(async ({ context, input }) => {
+		let identity: Awaited<ReturnType<typeof resolveGitHubAccount>>;
+		try {
+			identity = await resolveGitHubAccount(input.token);
+		} catch (error) {
+			if (error instanceof GitHubValidationError) {
+				throw new ORPCError("BAD_REQUEST", { message: error.message });
+			}
+			throw error;
+		}
+
+		const connected = await upsertConnectedAccount(context.db, {
+			catalogId: GITHUB_CATALOG_ID,
+			credentialType: "pat",
+			encryptedCredential: await encryptCredential(input.token, encryptionSecret(context.env)),
+			externalAccountId: identity.login,
+			id: `connected_account_${crypto.randomUUID()}`,
+			userId: context.session.user.id,
+		});
+
+		return { ...toAccountOutput(connected), redactedCredential: redactCredential(input.token) };
+	}),
+	disconnect: protectedProcedure.input(disconnectInput).handler(async ({ context, input }) => {
+		const deleted = await deleteConnectedAccount(context.db, {
+			id: input.accountId,
+			userId: context.session.user.id,
+		});
+		if (!deleted) {
+			throw new ORPCError("NOT_FOUND", { message: "Connected account was not found." });
+		}
+		return { success: true };
+	}),
+	list: protectedProcedure.handler(async ({ context }) => {
+		const rows = await listConnectedAccounts(context.db, context.session.user.id);
+		return rows.map(toAccountOutput);
+	}),
+};

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -1,6 +1,7 @@
 import type { InferRouterInputs, InferRouterOutputs, RouterClient } from "@orpc/server";
 
 import { approvalsRouter } from "../approvals/router";
+import { connectedAccountsRouter } from "../connected-accounts/router";
 import { mcpRouter } from "../mcp/router";
 import { modelsRouter } from "../models/router";
 import { profileRouter } from "../profile/router";
@@ -10,6 +11,7 @@ import { thinkspacesRouter } from "../thinkspaces/router";
 
 export const appRouter = {
 	approvals: approvalsRouter,
+	connectedAccounts: connectedAccountsRouter,
 	healthCheck: publicProcedure.handler(() => "OK"),
 	mcp: mcpRouter,
 	models: modelsRouter,


### PR DESCRIPTION
Closes #110. The Connected Account credential seam, end to end, with no agent involvement yet (PRD #108).

## What this does
A mirror of the BYOK + MCP credential routers, plus a settings UI.

- **`connectedAccounts` oRPC router** (owner-gated):
  - `connect` — validates a pasted fine-grained PAT against GitHub `GET /user`, stores the resolved login as `externalAccountId`, encrypts the token (hoisted crypto from #109), and upserts the `(user, github)` row. An invalid/expired/unreachable token is rejected (`BAD_REQUEST`) and **stores nothing** — honest failure, never fabricated success (extends #106 / ADR-0009).
  - `list` — returns redacted credentials + the **"Connected as @login"** identity; the raw token is never returned.
  - `disconnect` — deletes the credential row. All endpoints are owner-scoped and **404-first** for non-owner / unauthenticated callers.
- **Connect GitHub settings UI** (`settings.product.tsx`) alongside the existing model-credential settings: paste-and-validate field, "Connected as @x" confirmation, disconnect control. Single provider (GitHub) for now.

## Verification
- 7 router tests against the in-memory SQLite test DB (fetch stubbed): connect/validate, invalid-token-stores-nothing, network-failure-stores-nothing, redacted list, reconnect-keeps-one-row, disconnect, non-owner 404-first.
- `check-types` ✓ · ultracite ✓ · **271/271 api tests pass** ✓.
- ⚠️ The **live** connect→confirm→disconnect round-trip against real GitHub is **deferred to #115** (needs a user-supplied fine-grained PAT, per the PRD). The web app is not tsc-gated in this repo (ships via Vite); the UI mirrors the proven `settings.product.tsx` patterns exactly.

No Thinkspace grant, tool, or policy change here — those are #111–#113.