### PR TITLE
Backend: connected_account_credential Permission + potency = enable ∩ grant ∩ credential-exists (#111)

### DIFF
--- a/packages/api/src/thinkspaces/agent-profile.ts
+++ b/packages/api/src/thinkspaces/agent-profile.ts
@@ -112,6 +112,18 @@ export interface ModelProviderCredentialPermissionRequest {
 	reason: string;
 }
 
+/**
+ * A request to let this Thinkspace use a product-level Connected Account
+ * credential, identified by its connected_account_catalog id (e.g. "github").
+ * The credential lives at the product level; this grant authorizes one
+ * Thinkspace to act with it (PRD #108, ADR-0009).
+ */
+export interface ConnectedAccountCredentialPermissionRequest {
+	catalogId: string;
+	kind: "connected_account_credential";
+	reason: string;
+}
+
 export const MCP_TOOL_ACCESS_REQUEST_RISKS = ["read_only", "mutating", "unknown"] as const;
 export type McpToolAccessRequestRisk = (typeof MCP_TOOL_ACCESS_REQUEST_RISKS)[number];
 
@@ -146,6 +158,7 @@ export interface BuiltInToolAccessPermissionRequest {
 
 export type RequestedPermission =
 	| BuiltInToolAccessPermissionRequest
+	| ConnectedAccountCredentialPermissionRequest
 	| ModelProviderCredentialPermissionRequest
 	| McpToolAccessPermissionRequest;
 
@@ -372,13 +385,22 @@ const isBuiltInToolAccessPermissionRequest = (
 	BUILT_IN_TOOL_PERMISSION_REQUEST_KINDS.includes(value.kind as BuiltInToolPermissionRequestKind) &&
 	typeof value.reason === "string";
 
+const isConnectedAccountCredentialPermissionRequest = (
+	value: unknown,
+): value is ConnectedAccountCredentialPermissionRequest =>
+	isRecord(value) &&
+	value.kind === "connected_account_credential" &&
+	isNonEmptyString(value.catalogId) &&
+	typeof value.reason === "string";
+
 const isRequestedPermission = (value: unknown): value is RequestedPermission =>
 	(isRecord(value) &&
 		value.kind === "model_provider_credential" &&
 		MODEL_PROVIDER_IDS.includes(value.providerId as ModelProviderId) &&
 		typeof value.reason === "string") ||
 	isMcpToolAccessPermissionRequest(value) ||
-	isBuiltInToolAccessPermissionRequest(value);
+	isBuiltInToolAccessPermissionRequest(value) ||
+	isConnectedAccountCredentialPermissionRequest(value);
 
 const parseJsonArray = <T>(
 	label: string,

--- a/packages/api/src/thinkspaces/connected-account-tools.ts
+++ b/packages/api/src/thinkspaces/connected-account-tools.ts
@@ -1,0 +1,36 @@
+/**
+ * The connected-account tool catalog mapper.
+ *
+ * Connected-account tools are a first-class tool source beside built-ins and
+ * MCP: an Agent Profile revision makes one present with a stable tool id, and
+ * a Thinkspace-owned `connected_account_credential` Permission — plus an
+ * actually-connected account — makes it potent (PRD #108, ADR-0009). Every
+ * connected-account tool is governed by the one credential kind, keyed by the
+ * connected_account_catalog id, exactly as every MCP tool is governed by
+ * `mcp_tool_access` keyed by server id.
+ */
+import { THINKSPACE_PERMISSION_KINDS } from "@better-agent/db/schema/permissions";
+
+export type ConnectedAccountToolPermissionKind =
+	typeof THINKSPACE_PERMISSION_KINDS.CONNECTED_ACCOUNT_CREDENTIAL;
+
+/**
+ * A connected-account tool id is `${catalogId}:${toolName}` (one tool) or
+ * `${catalogId}` (the catalog as a whole), mirroring the MCP `serverId:tool`
+ * convention. The Permission and the backing credential are both keyed by the
+ * catalog id, so matching happens on it.
+ */
+export const connectedAccountCatalogIdFromToolId = (toolId: string): string => {
+	const [catalogId] = toolId.split(":");
+
+	return catalogId ?? toolId;
+};
+
+/**
+ * Which Permission kind governs a connected-account tool. There is one kind for
+ * all of them; an empty tool id maps to nothing so callers fail closed.
+ */
+export const connectedAccountToolPermissionKind = (
+	toolId: string,
+): ConnectedAccountToolPermissionKind | null =>
+	toolId.length > 0 ? THINKSPACE_PERMISSION_KINDS.CONNECTED_ACCOUNT_CREDENTIAL : null;

--- a/packages/api/src/thinkspaces/permission-policy.test.ts
+++ b/packages/api/src/thinkspaces/permission-policy.test.ts
@@ -3,11 +3,13 @@ import test from "node:test";
 
 import type { ProductDb } from "@better-agent/db";
 import { user } from "@better-agent/db/schema/auth";
+import { userConnectedAccounts } from "@better-agent/db/schema/connected-accounts";
 import {
 	THINKSPACE_PERMISSION_KINDS,
 	thinkspacePermissions,
 } from "@better-agent/db/schema/permissions";
 import { thinkspaces } from "@better-agent/db/schema/thinkspaces";
+import { eq } from "drizzle-orm";
 import { createTestProductDb } from "../testing/product-db";
 import type { ActiveAgentProfileRevision, ToolEnablement } from "./agent-profile";
 import { revokeThinkspacePermission } from "./permissions";
@@ -53,6 +55,34 @@ const grantMcpToolAccess = async (
 		kind: THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS,
 		providerId: serverId,
 		thinkspaceId,
+	});
+};
+
+const connectedAccountGrantId = (catalogId: string, thinkspaceId = THINKSPACE_ID): string =>
+	`thinkspace_permission_ca_${catalogId}_${thinkspaceId}`;
+
+const grantConnectedAccountCredential = async (
+	db: ProductDb,
+	catalogId: string,
+	thinkspaceId = THINKSPACE_ID,
+) => {
+	await db.insert(thinkspacePermissions).values({
+		grantedByUserId: OWNER_USER_ID,
+		id: connectedAccountGrantId(catalogId, thinkspaceId),
+		kind: THINKSPACE_PERMISSION_KINDS.CONNECTED_ACCOUNT_CREDENTIAL,
+		providerId: catalogId,
+		thinkspaceId,
+	});
+};
+
+const connectOwnerAccount = async (db: ProductDb, catalogId: string, userId = OWNER_USER_ID) => {
+	await db.insert(userConnectedAccounts).values({
+		catalogId,
+		credentialType: "pat",
+		encryptedCredential: "encrypted",
+		externalAccountId: "octocat",
+		id: `connected_account_${catalogId}_${userId}`,
+		userId,
 	});
 };
 
@@ -351,4 +381,111 @@ test("store-backed verdicts feeding turn assembly never activate tools the revis
 	const assembly = assembleThinkspaceTurn({ revision, toolPotencies });
 
 	assert.deepEqual(assembly.activeTools, ["web_search", "cloudflare-docs"]);
+});
+
+test("a connected-account tool is inert with the grant but no connected account (credential-exists axis missing)", async () => {
+	const db = await createSeededDb();
+	await grantConnectedAccountCredential(db, "github");
+
+	const verdicts = await evaluate(db, [
+		{ source: "connected_account", toolId: "github:create_issue" },
+	]);
+
+	assert.deepEqual(verdicts, [{ potency: "inert", toolId: "github:create_issue" }]);
+});
+
+test("a connected-account tool is inert with a connected account but no grant (grant axis missing)", async () => {
+	const db = await createSeededDb();
+	await connectOwnerAccount(db, "github");
+
+	const verdicts = await evaluate(db, [
+		{ source: "connected_account", toolId: "github:create_issue" },
+	]);
+
+	assert.deepEqual(verdicts, [{ potency: "inert", toolId: "github:create_issue" }]);
+});
+
+test("a connected-account tool is potent only with grant ∩ credential; tool- and catalog-scope both resolve", async () => {
+	const db = await createSeededDb();
+	await grantConnectedAccountCredential(db, "github");
+	await connectOwnerAccount(db, "github");
+
+	const verdicts = await evaluate(db, [
+		{ source: "connected_account", toolId: "github" },
+		{ source: "connected_account", toolId: "github:create_issue" },
+	]);
+
+	assert.deepEqual(verdicts, [
+		{ potency: "potent", toolId: "github" },
+		{ potency: "potent", toolId: "github:create_issue" },
+	]);
+});
+
+test("connected-account grants are catalog-scoped: a github grant + account never powers a gitlab tool", async () => {
+	const db = await createSeededDb();
+	await grantConnectedAccountCredential(db, "github");
+	await connectOwnerAccount(db, "github");
+
+	const verdicts = await evaluate(db, [
+		{ source: "connected_account", toolId: "gitlab:create_issue" },
+	]);
+
+	assert.deepEqual(verdicts, [{ potency: "inert", toolId: "gitlab:create_issue" }]);
+});
+
+test("grants match on kind: an MCP grant for the same id never powers a connected-account tool", async () => {
+	const db = await createSeededDb();
+	await grantMcpToolAccess(db, "github");
+	await connectOwnerAccount(db, "github");
+
+	const verdicts = await evaluate(db, [{ source: "connected_account", toolId: "github" }]);
+
+	assert.deepEqual(verdicts, [{ potency: "inert", toolId: "github" }]);
+});
+
+test("revoking the connected-account grant flips the still-enabled tool inert on the next evaluation", async () => {
+	const db = await createSeededDb();
+	await grantConnectedAccountCredential(db, "github");
+	await connectOwnerAccount(db, "github");
+
+	const enablements: ToolEnablement[] = [
+		{ source: "connected_account", toolId: "github:create_issue" },
+	];
+	const granted = await evaluate(db, enablements);
+	assert.deepEqual(granted, [{ potency: "potent", toolId: "github:create_issue" }]);
+
+	const revoked = await revokeThinkspacePermission(db, {
+		permissionId: connectedAccountGrantId("github"),
+		thinkspaceId: THINKSPACE_ID,
+	});
+	assert.ok(revoked);
+
+	const after = await evaluate(db, enablements);
+	assert.deepEqual(after, [{ potency: "inert", toolId: "github:create_issue" }]);
+});
+
+test("disconnecting the account flips the still-enabled tool inert without editing the grant", async () => {
+	const db = await createSeededDb();
+	await grantConnectedAccountCredential(db, "github");
+	await connectOwnerAccount(db, "github");
+
+	const enablements: ToolEnablement[] = [{ source: "connected_account", toolId: "github" }];
+	assert.deepEqual(await evaluate(db, enablements), [{ potency: "potent", toolId: "github" }]);
+
+	await db.delete(userConnectedAccounts).where(eq(userConnectedAccounts.userId, OWNER_USER_ID));
+
+	assert.deepEqual(await evaluate(db, enablements), [{ potency: "inert", toolId: "github" }]);
+});
+
+test("connected-account grants are Thinkspace-scoped even though the credential is shared by the owner", async () => {
+	const db = await createSeededDb();
+	await seedThinkspace(db, OTHER_THINKSPACE_ID);
+	// The owner connects the account once (product-level), and grants only the
+	// OTHER Thinkspace. THIS Thinkspace holds no grant, so its tool stays inert.
+	await connectOwnerAccount(db, "github");
+	await grantConnectedAccountCredential(db, "github", OTHER_THINKSPACE_ID);
+
+	const verdicts = await evaluate(db, [{ source: "connected_account", toolId: "github" }]);
+
+	assert.deepEqual(verdicts, [{ potency: "inert", toolId: "github" }]);
 });

--- a/packages/api/src/thinkspaces/permission-policy.ts
+++ b/packages/api/src/thinkspaces/permission-policy.ts
@@ -14,19 +14,25 @@
  * held Memory-proposing tool (PRD #73 superseded the earlier enablement-alone
  * rule for built-ins; PRD #92 added the held Memory write). MCP-source
  * enablements are potent only with a matching granted MCP tool access
- * Permission. Connected Account and Local Node sources, and built-in tool ids
- * the catalog does not know, are unconditionally inert.
+ * Permission. Connected-account enablements are potent only with both a
+ * granted connected_account_credential Permission for the tool's catalog id
+ * and an actually-connected account backing it (enable ∩ grant ∩
+ * credential-exists; PRD #108, ADR-0009). Local Node sources, and built-in
+ * tool ids the catalog does not know, are unconditionally inert.
  */
 import type { ProductDb } from "@better-agent/db";
+import { userConnectedAccounts } from "@better-agent/db/schema/connected-accounts";
 import {
 	THINKSPACE_PERMISSION_KINDS,
 	thinkspacePermissions,
 } from "@better-agent/db/schema/permissions";
+import { thinkspaces } from "@better-agent/db/schema/thinkspaces";
 import { and, eq, inArray } from "drizzle-orm";
 
 import type { ToolEnablement } from "./agent-profile";
 import { builtInToolPermissionKind } from "./built-in-tools";
 import type { BuiltInToolPermissionKind } from "./built-in-tools";
+import { connectedAccountCatalogIdFromToolId } from "./connected-account-tools";
 
 export type ToolPotency = "potent" | "inert";
 
@@ -58,7 +64,11 @@ export const mcpServerIdFromToolId = (toolId: string): string => {
 
 interface ThinkspaceToolGrants {
 	builtInKinds: ReadonlySet<BuiltInToolPermissionKind>;
+	/** Catalog ids the Thinkspace holds a connected_account_credential grant for. */
+	connectedAccountGrantCatalogIds: ReadonlySet<string>;
 	mcpServerIds: ReadonlySet<string>;
+	/** Catalog ids the Thinkspace owner has an actually-connected account for. */
+	ownerConnectedAccountCatalogIds: ReadonlySet<string>;
 }
 
 const isPotent = (enablement: ToolEnablement, grants: ThinkspaceToolGrants): boolean => {
@@ -72,8 +82,19 @@ const isPotent = (enablement: ToolEnablement, grants: ThinkspaceToolGrants): boo
 		return grants.mcpServerIds.has(mcpServerIdFromToolId(enablement.toolId));
 	}
 
-	// Connected Account and Local Node tools stay inert: no grant kind for
-	// them exists yet, so the system fails closed.
+	if (enablement.source === "connected_account") {
+		// enable ∩ grant ∩ credential-exists: the Thinkspace must be granted the
+		// catalog and the owner must actually have a connected account for it.
+		const catalogId = connectedAccountCatalogIdFromToolId(enablement.toolId);
+
+		return (
+			grants.connectedAccountGrantCatalogIds.has(catalogId) &&
+			grants.ownerConnectedAccountCatalogIds.has(catalogId)
+		);
+	}
+
+	// Local Node tools stay inert: no grant kind for them exists yet, so the
+	// system fails closed.
 	return false;
 };
 
@@ -88,7 +109,9 @@ const evaluateAgainstGrants = (
 
 const NO_GRANTS: ThinkspaceToolGrants = {
 	builtInKinds: new Set(),
+	connectedAccountGrantCatalogIds: new Set(),
 	mcpServerIds: new Set(),
+	ownerConnectedAccountCatalogIds: new Set(),
 };
 
 /**
@@ -124,9 +147,45 @@ const BUILT_IN_GRANT_KINDS: readonly BuiltInToolPermissionKind[] = [
 const isBuiltInGrantKind = (kind: string): kind is BuiltInToolPermissionKind =>
 	BUILT_IN_GRANT_KINDS.includes(kind as BuiltInToolPermissionKind);
 
+/**
+ * The credential-exists axis: the catalog ids the Thinkspace owner actually
+ * holds a Connected Account for. Grant-scoped potency lives on the Thinkspace;
+ * this lookup crosses to the owner's product-level connected accounts so a
+ * granted-but-unbacked tool stays inert (and disconnecting flips it inert).
+ */
+const listOwnerConnectedAccountCatalogIds = async (
+	db: ProductDb,
+	thinkspaceId: string,
+): Promise<ReadonlySet<string>> => {
+	const [thinkspace] = await db
+		.select({ ownerUserId: thinkspaces.ownerUserId })
+		.from(thinkspaces)
+		.where(eq(thinkspaces.id, thinkspaceId))
+		.limit(1);
+
+	if (!thinkspace) {
+		return new Set();
+	}
+
+	const rows = await db
+		.select({ catalogId: userConnectedAccounts.catalogId })
+		.from(userConnectedAccounts)
+		.where(eq(userConnectedAccounts.userId, thinkspace.ownerUserId));
+
+	const catalogIds = new Set<string>();
+	for (const row of rows) {
+		if (row.catalogId) {
+			catalogIds.add(row.catalogId);
+		}
+	}
+
+	return catalogIds;
+};
+
 const listThinkspaceToolGrants = async (
 	db: ProductDb,
 	thinkspaceId: string,
+	options: { includeOwnerConnectedAccounts: boolean },
 ): Promise<ThinkspaceToolGrants> => {
 	const rows = await db
 		.select({
@@ -140,12 +199,14 @@ const listThinkspaceToolGrants = async (
 				inArray(thinkspacePermissions.kind, [
 					...BUILT_IN_GRANT_KINDS,
 					THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS,
+					THINKSPACE_PERMISSION_KINDS.CONNECTED_ACCOUNT_CREDENTIAL,
 				]),
 			),
 		);
 
 	const builtInKinds = new Set<BuiltInToolPermissionKind>();
 	const mcpServerIds = new Set<string>();
+	const connectedAccountGrantCatalogIds = new Set<string>();
 
 	for (const row of rows) {
 		if (isBuiltInGrantKind(row.kind)) {
@@ -153,18 +214,35 @@ const listThinkspaceToolGrants = async (
 			continue;
 		}
 
-		if (row.providerId) {
-			mcpServerIds.add(row.providerId);
+		if (!row.providerId) {
+			continue;
 		}
+
+		if (row.kind === THINKSPACE_PERMISSION_KINDS.CONNECTED_ACCOUNT_CREDENTIAL) {
+			connectedAccountGrantCatalogIds.add(row.providerId);
+			continue;
+		}
+
+		mcpServerIds.add(row.providerId);
 	}
 
-	return { builtInKinds, mcpServerIds };
+	const ownerConnectedAccountCatalogIds = options.includeOwnerConnectedAccounts
+		? await listOwnerConnectedAccountCatalogIds(db, thinkspaceId)
+		: new Set<string>();
+
+	return {
+		builtInKinds,
+		connectedAccountGrantCatalogIds,
+		mcpServerIds,
+		ownerConnectedAccountCatalogIds,
+	};
 };
 
 /**
  * The real Permission-storage-backed policy: reads granted tool Permissions
- * (built-in read kinds and MCP tool access) from Thinkspace Permission
- * storage and applies the fail-closed decision rule.
+ * (built-in read kinds, MCP tool access, and connected-account credential)
+ * from Thinkspace Permission storage — plus the owner's connected accounts for
+ * the credential-exists axis — and applies the fail-closed decision rule.
  */
 export const createPermissionStorePolicy = ({
 	db,
@@ -173,9 +251,22 @@ export const createPermissionStorePolicy = ({
 }): ThinkspacePermissionPolicy => ({
 	evaluateToolPotency: async ({ enablements, thinkspaceId }) => {
 		const needsGrantLookup = enablements.some(
-			(enablement) => enablement.source === "built_in" || enablement.source === "mcp_server",
+			(enablement) =>
+				enablement.source === "built_in" ||
+				enablement.source === "mcp_server" ||
+				enablement.source === "connected_account",
 		);
-		const grants = needsGrantLookup ? await listThinkspaceToolGrants(db, thinkspaceId) : NO_GRANTS;
+
+		if (!needsGrantLookup) {
+			return evaluateAgainstGrants(enablements, NO_GRANTS);
+		}
+
+		const includeOwnerConnectedAccounts = enablements.some(
+			(enablement) => enablement.source === "connected_account",
+		);
+		const grants = await listThinkspaceToolGrants(db, thinkspaceId, {
+			includeOwnerConnectedAccounts,
+		});
 
 		return evaluateAgainstGrants(enablements, grants);
 	},

--- a/packages/api/src/thinkspaces/permissions.test.ts
+++ b/packages/api/src/thinkspaces/permissions.test.ts
@@ -92,6 +92,22 @@ test("held Memory writing requests convert into a Memory writing grant with a st
 	assert.equal(grant?.resourceScope, JSON.stringify({ type: "memory_write" }));
 });
 
+test("connected-account credential requests convert into a credential grant keyed by catalog id", () => {
+	const grant = toThinkspacePermissionGrant({
+		grantedByUserId: OWNER_USER_ID,
+		permission: {
+			catalogId: "github",
+			kind: "connected_account_credential",
+			reason: "Allow this Thinkspace Agent to act with your connected GitHub account.",
+		},
+		thinkspaceId: THINKSPACE_ID,
+	});
+
+	assert.equal(grant?.kind, THINKSPACE_PERMISSION_KINDS.CONNECTED_ACCOUNT_CREDENTIAL);
+	assert.equal(grant?.providerId, "github");
+	assert.equal(grant?.resourceScope, JSON.stringify({ type: "connected_account_credential" }));
+});
+
 test("grantable MCP requests convert into MCP tool access grants with explicit scope", () => {
 	const grant = toThinkspacePermissionGrant(grantInput(), {
 		builtInMcpServers: [readOnlyAuthFreeServer],

--- a/packages/api/src/thinkspaces/permissions.ts
+++ b/packages/api/src/thinkspaces/permissions.ts
@@ -46,6 +46,15 @@ export class ThinkspacePermissionGrantError extends Error {
 const MODEL_PROVIDER_SCOPE = JSON.stringify({ type: "model_provider" });
 
 /**
+ * The repo-allowlist `resourceScope` is reserved but not enforced this slice
+ * (it pairs with the deferred standing-approval policy, ADR-0003); the grant
+ * just records its type for now.
+ */
+const CONNECTED_ACCOUNT_CREDENTIAL_SCOPE = JSON.stringify({
+	type: "connected_account_credential",
+});
+
+/**
  * Grant rows live on the (thinkspaceId, kind, providerId) unique index, so
  * each built-in kind gets a stable resource identity: the web for web
  * reading, this Thinkspace's Sources for Source reading, this Thinkspace's
@@ -148,6 +157,18 @@ export const toThinkspacePermissionGrant = (
 			providerId: BUILT_IN_GRANT_PROVIDER_IDS[permission.kind],
 			reason: permission.reason,
 			resourceScope: BUILT_IN_GRANT_SCOPES[permission.kind],
+			thinkspaceId,
+		};
+	}
+
+	if (permission.kind === THINKSPACE_PERMISSION_KINDS.CONNECTED_ACCOUNT_CREDENTIAL) {
+		return {
+			grantedByUserId,
+			id: createPermissionId(),
+			kind: THINKSPACE_PERMISSION_KINDS.CONNECTED_ACCOUNT_CREDENTIAL,
+			providerId: permission.catalogId,
+			reason: permission.reason,
+			resourceScope: CONNECTED_ACCOUNT_CREDENTIAL_SCOPE,
 			thinkspaceId,
 		};
 	}

--- a/packages/api/src/thinkspaces/router.test.ts
+++ b/packages/api/src/thinkspaces/router.test.ts
@@ -383,6 +383,36 @@ test("activating a granted MCP request creates a Thinkspace Permission grant and
 	assert.equal(activation.grantedPermissions[0]?.resourceScope, JSON.stringify({ type: "server" }));
 });
 
+test("activating a granted connected-account credential request creates a Thinkspace Permission grant", async () => {
+	const db = createTestProductDb();
+	await seedRealThinkspaceWithProfile({
+		db,
+		requestedPermissions: [
+			{
+				catalogId: "github",
+				kind: "connected_account_credential",
+				reason: "Allow this Thinkspace Agent to act with your connected GitHub account.",
+			},
+		],
+		toolEnablements: [{ source: "connected_account", toolId: "github:create_issue" }],
+	});
+
+	const activation = await call(
+		thinkspacesRouter.activateAgentProfile,
+		{ grantedPermissionIndexes: [0], thinkspaceId: OWNED_THINKSPACE_ID },
+		{ context: createCallContext({ db }) },
+	);
+
+	assert.ok(activation);
+	assert.equal(activation.activatedRevision.status, "active");
+	assert.equal(activation.grantedPermissions.length, 1);
+	assert.equal(
+		activation.grantedPermissions[0]?.kind,
+		THINKSPACE_PERMISSION_KINDS.CONNECTED_ACCOUNT_CREDENTIAL,
+	);
+	assert.equal(activation.grantedPermissions[0]?.providerId, "github");
+});
+
 test("declining an MCP request creates no grant while activation still succeeds", async () => {
 	const db = createTestProductDb();
 	await seedRealThinkspaceWithProfile({

--- a/packages/db/src/schema/permissions.ts
+++ b/packages/db/src/schema/permissions.ts
@@ -16,6 +16,13 @@ export const THINKSPACE_PERMISSION_KINDS = {
 	BUILT_IN_SOURCE_READ: "built_in_source_read",
 	/** Governs built-in web reading — search and fetch together. */
 	BUILT_IN_WEB_READ: "built_in_web_read",
+	/**
+	 * Governs a Thinkspace's use of a product-level Connected Account credential,
+	 * keyed by the connected_account_catalog id in `providerId` (e.g. "github").
+	 * Mirrors `mcp_tool_access` (keyed by server id): the grant is one axis of
+	 * potency; the backing credential must also exist (PRD #108, ADR-0009).
+	 */
+	CONNECTED_ACCOUNT_CREDENTIAL: "connected_account_credential",
 	MCP_TOOL_ACCESS: "mcp_tool_access",
 	MODEL_PROVIDER_CREDENTIAL: "model_provider_credential",
 } as const;


### PR DESCRIPTION
Closes #111. The authorization half of the Connected Account seam (PRD #108, ADR-0009).

## What this does
- **New Permission kind** `THINKSPACE_PERMISSION_KINDS.CONNECTED_ACCOUNT_CREDENTIAL`, keyed by the connected_account_catalog id in `providerId` (mirrors `mcp_tool_access` keyed by server id). **No table change** — `thinkspace_permissions` already carries `kind` + `providerId` + `resourceScope`.
- **Potency = enable ∩ grant ∩ credential-exists**: the hardwired `false` for connected-account sources in `permission-policy.ts` `isPotent` becomes a real branch — potent only when **(a)** the Thinkspace holds a `connected_account_credential` grant for the tool's catalog id **and (b)** the owner has a matching `user_connected_accounts` row. `listThinkspaceToolGrants` loads the new kind and (only when a connected-account tool is in play) looks up the owner's connected accounts. **Fails closed**: any axis missing → inert; revoking the grant or disconnecting the account flips the tool inert on the next assembly without editing the Profile.
- **Mapper** `connected-account-tools.ts` (`toolId → kind`, `toolId → catalogId`) alongside the built-in mapper; the `catalogId:tool` / `catalogId` convention mirrors MCP's `serverId:tool`.
- **Grant wiring**: `ConnectedAccountCredentialPermissionRequest` joins `RequestedPermission` (+ parser predicate); `activateAgentProfile` grants it from a draft revision's requested Permissions.

## Verification
- Potency tests cover the full intersection: each axis independently absent → inert; all present → potent; tool- and catalog-scope both resolve; cross-catalog (github grant never powers gitlab); wrong grant kind (MCP grant for "github" never powers a connected-account tool); revoke → inert; disconnect → inert; Thinkspace-scoping (shared owner credential, per-Thinkspace grant).
- Grant-mapping unit test + an end-to-end `activateAgentProfile` grant test.
- `check-types` ✓ · ultracite ✓ · **281/281 api tests pass** ✓.

`resourceScope` repo-allowlist is reserved but **not** enforced this slice (pairs with the deferred standing-approval policy, ADR-0003).