### PR TITLE
Backend: governed_tools_v4 enables external_mutations (held-external-write class) (#112)

### DIFF
--- a/apps/server/src/agents/thinkspace-agent.ts
+++ b/apps/server/src/agents/thinkspace-agent.ts
@@ -21,6 +21,7 @@ import {
 	prepareThinkspaceBuiltInRuntimeTools,
 	THINKSPACE_BUILT_IN_TOOL_BLOCKED_REASON,
 } from "@better-agent/api/thinkspaces/built-in-runtime-tools";
+import { assertThinkspaceRuntimePolicySupportsExternalMutationTools } from "@better-agent/api/thinkspaces/connected-account-runtime-tools";
 import { createFetchWebReader } from "@better-agent/api/thinkspaces/web-reader";
 import {
 	extractPendingMemoryApprovals,
@@ -374,6 +375,9 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 			toolPotencies,
 		});
 		assertThinkspaceRuntimePolicySupportsBuiltInTools({
+			activeProductToolIds: assembly.activeTools,
+		});
+		assertThinkspaceRuntimePolicySupportsExternalMutationTools({
 			activeProductToolIds: assembly.activeTools,
 		});
 

--- a/packages/api/src/thinkspaces/connected-account-runtime-tools.test.ts
+++ b/packages/api/src/thinkspaces/connected-account-runtime-tools.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	assertThinkspaceRuntimePolicySupportsExternalMutationTools,
+	EXTERNAL_MUTATION_TOOL_IDS,
+	externalMutationToolRuntimeCapabilityId,
+	isExternalMutationToolId,
+} from "./connected-account-runtime-tools";
+import { THINKSPACE_RUNTIME_POLICY } from "./runtime-policy";
+
+test("recognizes only the catalog-keyed external-mutation tool ids", () => {
+	assert.deepEqual([...EXTERNAL_MUTATION_TOOL_IDS], ["github:create_issue"]);
+
+	assert.equal(isExternalMutationToolId("github:create_issue"), true);
+
+	// The bare runtime name, the catalog id alone, a read tool, an MCP tool, and
+	// the empty string are all rejected — matching happens on the product id.
+	assert.equal(isExternalMutationToolId("create_github_issue"), false);
+	assert.equal(isExternalMutationToolId("github"), false);
+	assert.equal(isExternalMutationToolId("memory_write"), false);
+	assert.equal(isExternalMutationToolId("cloudflare-docs:search_docs"), false);
+	assert.equal(isExternalMutationToolId(""), false);
+});
+
+test("maps every external-mutation tool to the held-external-write capability", () => {
+	assert.equal(
+		externalMutationToolRuntimeCapabilityId("github:create_issue"),
+		"external_mutations",
+	);
+});
+
+test("the policy guard passes for the shipped policy with the external-mutation tool active", () => {
+	assert.doesNotThrow(() =>
+		assertThinkspaceRuntimePolicySupportsExternalMutationTools({
+			activeProductToolIds: ["github:create_issue"],
+		}),
+	);
+});
+
+test("the policy guard is a no-op for revisions with no potent external-mutation tool", () => {
+	// Read-only and memory-only turns: the guard never sees an external-mutation
+	// tool, so assembly output is untouched even when the capability is enabled.
+	assert.doesNotThrow(() =>
+		assertThinkspaceRuntimePolicySupportsExternalMutationTools({
+			activeProductToolIds: ["web_search", "source_read", "memory_write"],
+		}),
+	);
+	assert.doesNotThrow(() =>
+		assertThinkspaceRuntimePolicySupportsExternalMutationTools({
+			activeProductToolIds: [],
+		}),
+	);
+});
+
+test("the policy guard gates external mutations on the held-external-write capability", () => {
+	// A policy with held external writes disabled must reject an assembled
+	// external-mutation tool while still admitting non-external tools.
+	const noExternalWritesPolicy = {
+		...THINKSPACE_RUNTIME_POLICY,
+		capabilities: THINKSPACE_RUNTIME_POLICY.capabilities.map((capability) =>
+			capability.id === "external_mutations" ? { ...capability, enabled: false } : capability,
+		),
+	};
+
+	assert.throws(
+		() =>
+			assertThinkspaceRuntimePolicySupportsExternalMutationTools({
+				activeProductToolIds: ["github:create_issue"],
+				policy: noExternalWritesPolicy,
+			}),
+		/thinkspace-turn-product-safe:.*runtime safety policy/u,
+	);
+
+	assert.doesNotThrow(() =>
+		assertThinkspaceRuntimePolicySupportsExternalMutationTools({
+			activeProductToolIds: ["web_search"],
+			policy: noExternalWritesPolicy,
+		}),
+	);
+});
+
+test("the policy guard fails closed if workspace bash is ever not forced off", () => {
+	const bashPolicy = {
+		...THINKSPACE_RUNTIME_POLICY,
+		workspaceBash: true as unknown as false,
+	};
+
+	assert.throws(
+		() =>
+			assertThinkspaceRuntimePolicySupportsExternalMutationTools({
+				activeProductToolIds: [],
+				policy: bashPolicy,
+			}),
+		/thinkspace-turn-product-safe:/u,
+	);
+});

--- a/packages/api/src/thinkspaces/connected-account-runtime-tools.ts
+++ b/packages/api/src/thinkspaces/connected-account-runtime-tools.ts
@@ -1,0 +1,81 @@
+/**
+ * The external-mutation half of the Thinkspace Agent turn loop's policy guard.
+ *
+ * External-mutation tools are connected-account tools whose action class is a
+ * held external write — `create_github_issue` (tool id `github:create_issue`)
+ * is the first (PRD #108). They ride the `external_mutations` capability, the
+ * held-external-write class, exactly as the held Memory-proposing tool rides
+ * `memory_writes`, the held-internal-write class. The held tool factory itself
+ * arrives in a later issue; this module carries the policy-level pieces #112
+ * needs: which tool ids are external mutations, which capability governs them,
+ * and the fail-closed assembly guard mirroring the built-in-tools support
+ * assertion.
+ */
+import { markThinkspaceTurnProductSafeError } from "./inspect";
+import {
+	isThinkspaceRuntimeCapabilityEnabled,
+	THINKSPACE_RUNTIME_HELD_EXTERNAL_WRITE_CAPABILITY_ID,
+	THINKSPACE_RUNTIME_POLICY,
+} from "./runtime-policy";
+import type { ThinkspaceRuntimeCapabilityId, ThinkspaceRuntimePolicy } from "./runtime-policy";
+
+const POLICY_ASSEMBLY_MISMATCH_MESSAGE =
+	"This Thinkspace Agent turn was stopped before it started: the runtime safety policy and the assembled tools disagree.";
+
+/**
+ * The external-mutation tool ids, in the `${catalogId}:${toolName}` product
+ * convention shared with MCP (`serverId:tool`) and the connected-account
+ * Permission/credential lookup. `github:create_issue` is the only one today;
+ * its held tool factory lands in a later issue.
+ */
+export const EXTERNAL_MUTATION_TOOL_IDS = ["github:create_issue"] as const;
+
+export type ExternalMutationToolId = (typeof EXTERNAL_MUTATION_TOOL_IDS)[number];
+
+export const isExternalMutationToolId = (value: string): value is ExternalMutationToolId =>
+	EXTERNAL_MUTATION_TOOL_IDS.includes(value as ExternalMutationToolId);
+
+const activeExternalMutationToolIds = (
+	activeProductToolIds: readonly string[],
+): ExternalMutationToolId[] => activeProductToolIds.filter(isExternalMutationToolId);
+
+/**
+ * Which runtime capability class governs an external-mutation tool: every one
+ * rides the `external_mutations` held-external-write class (the action-class
+ * precedent set by `memory_write → memory_writes`; no separate source
+ * capability). The fail-closed assembly guard uses this so an external-mutation
+ * tool can never go active under a policy that has held external writes
+ * disabled.
+ */
+export const externalMutationToolRuntimeCapabilityId = (
+	_toolId: ExternalMutationToolId,
+): ThinkspaceRuntimeCapabilityId => THINKSPACE_RUNTIME_HELD_EXTERNAL_WRITE_CAPABILITY_ID;
+
+/**
+ * The zero-blast-radius guarantee must survive bugs (PRD #92, #108), mirroring
+ * the built-in-tools support assertion: if assembly produced an active
+ * external-mutation tool while the runtime policy has held external writes
+ * disabled — or workspace bash is not forced off — the turn fails
+ * product-safely before any inference happens. A turn with no active
+ * external-mutation tool passes untouched, so read-only and memory-only turns
+ * behave exactly as before.
+ */
+export const assertThinkspaceRuntimePolicySupportsExternalMutationTools = ({
+	activeProductToolIds,
+	policy = THINKSPACE_RUNTIME_POLICY,
+}: {
+	activeProductToolIds: readonly string[];
+	policy?: ThinkspaceRuntimePolicy;
+}): void => {
+	if (policy.workspaceBash !== false) {
+		throw new Error(markThinkspaceTurnProductSafeError(POLICY_ASSEMBLY_MISMATCH_MESSAGE));
+	}
+
+	for (const toolId of activeExternalMutationToolIds(activeProductToolIds)) {
+		if (
+			!isThinkspaceRuntimeCapabilityEnabled(policy, externalMutationToolRuntimeCapabilityId(toolId))
+		) {
+			throw new Error(markThinkspaceTurnProductSafeError(POLICY_ASSEMBLY_MISMATCH_MESSAGE));
+		}
+	}
+};

--- a/packages/api/src/thinkspaces/runtime-policy.test.ts
+++ b/packages/api/src/thinkspaces/runtime-policy.test.ts
@@ -11,6 +11,7 @@ import {
 	THINKSPACE_RUNTIME_CAPABILITY_IDS,
 	THINKSPACE_RUNTIME_DISABLED_CAPABILITY_IDS,
 	THINKSPACE_RUNTIME_ENABLED_CAPABILITY_IDS,
+	THINKSPACE_RUNTIME_HELD_EXTERNAL_WRITE_CAPABILITY_ID,
 	THINKSPACE_RUNTIME_HELD_WRITE_CAPABILITY_ID,
 	THINKSPACE_RUNTIME_POLICY,
 } from "./runtime-policy";
@@ -23,7 +24,7 @@ test("disables workspace Bash against the runtime default", () => {
 	);
 });
 
-test("enables built-in read tools plus held internal writes and disables every other mutation-shaped capability", () => {
+test("enables built-in read tools plus both held-write classes and disables every other mutation-shaped capability", () => {
 	const expectedCapabilityIds = [
 		"builtin_read_tools",
 		"workspace_bash",
@@ -34,7 +35,11 @@ test("enables built-in read tools plus held internal writes and disables every o
 		"memory_writes",
 		"artifact_publishing",
 	];
-	const expectedEnabledCapabilityIds = ["builtin_read_tools", "memory_writes"];
+	const expectedEnabledCapabilityIds = [
+		"builtin_read_tools",
+		"memory_writes",
+		"external_mutations",
+	];
 	const expectedDisabledCapabilityIds = expectedCapabilityIds.filter(
 		(id) => !expectedEnabledCapabilityIds.includes(id),
 	);
@@ -44,9 +49,11 @@ test("enables built-in read tools plus held internal writes and disables every o
 	assert.deepEqual([...THINKSPACE_RUNTIME_DISABLED_CAPABILITY_IDS], expectedDisabledCapabilityIds);
 	assert.equal(THINKSPACE_RUNTIME_POLICY.capabilities.length, expectedCapabilityIds.length);
 
-	// The held internal write is the only mutation-shaped capability newly
-	// enabled over the read-only policy (PRD #92, #93).
+	// The two held-write classes — internal (Memory) and external (Connected
+	// Account mutations) — are the only mutation-shaped capabilities enabled;
+	// `connected_account_tools` stays reserved/disabled (PRD #92, #93, #108).
 	assert.equal(THINKSPACE_RUNTIME_HELD_WRITE_CAPABILITY_ID, "memory_writes");
+	assert.equal(THINKSPACE_RUNTIME_HELD_EXTERNAL_WRITE_CAPABILITY_ID, "external_mutations");
 
 	for (const capability of THINKSPACE_RUNTIME_POLICY.capabilities) {
 		const expectedEnabled = expectedEnabledCapabilityIds.includes(capability.id);
@@ -65,7 +72,7 @@ test("enables built-in read tools plus held internal writes and disables every o
 
 test("declares the governed-writes runtime mode with bounded step counts", () => {
 	assert.equal(THINKSPACE_RUNTIME_POLICY.mode, "governed_writes");
-	assert.equal(THINKSPACE_RUNTIME_POLICY.policyId, "governed_tools_v3");
+	assert.equal(THINKSPACE_RUNTIME_POLICY.policyId, "governed_tools_v4");
 	assert.equal(THINKSPACE_RUNTIME_POLICY.workspaceBash, false);
 	assert.equal(THINKSPACE_RUNTIME_POLICY.maxSteps, 1);
 });
@@ -120,7 +127,7 @@ test("reports the runtime policy only after Thinkspace ownership is confirmed", 
 	});
 
 	assert.equal(ownerPolicy?.thinkspaceId, "thinkspace_owned");
-	assert.equal(ownerPolicy?.policyId, "governed_tools_v3");
+	assert.equal(ownerPolicy?.policyId, "governed_tools_v4");
 	assert.equal(ownerPolicy?.workspaceBash, false);
 	assert.equal(nonOwnerPolicy, null);
 	assert.deepEqual(requestedOwnershipChecks, [

--- a/packages/api/src/thinkspaces/runtime-policy.ts
+++ b/packages/api/src/thinkspaces/runtime-policy.ts
@@ -3,7 +3,7 @@ import type { Thinkspace } from "@better-agent/db/schema/thinkspaces";
 
 import { getThinkspace } from "./repository";
 
-export const THINKSPACE_RUNTIME_POLICY_ID = "governed_tools_v3" as const;
+export const THINKSPACE_RUNTIME_POLICY_ID = "governed_tools_v4" as const;
 export const THINKSPACE_RUNTIME_POLICY_MODE = "governed_writes" as const;
 export const THINKSPACE_RUNTIME_MAX_STEPS = 1 as const;
 export const THINKSPACE_RUNTIME_TOOL_MAX_STEPS = 8 as const;
@@ -22,8 +22,8 @@ export const THINKSPACE_RUNTIME_CAPABILITY_IDS = [
 export type ThinkspaceRuntimeCapabilityId = (typeof THINKSPACE_RUNTIME_CAPABILITY_IDS)[number];
 
 /**
- * The held-internal-write capability class — the single mutation-shaped
- * capability `governed_tools_v3` newly enables over `safe_reads_v2` (PRD #92,
+ * The held-internal-write capability class — the mutation-shaped capability
+ * `governed_tools_v3` first enabled over the read-only `safe_reads_v2` (PRD #92,
  * #93). The agent may propose a durable Product Memory, but the proposal is
  * held for the owner's Approval before it takes effect; the capability being
  * enabled never lets a write execute on its own.
@@ -31,13 +31,27 @@ export type ThinkspaceRuntimeCapabilityId = (typeof THINKSPACE_RUNTIME_CAPABILIT
 export const THINKSPACE_RUNTIME_HELD_WRITE_CAPABILITY_ID = "memory_writes" as const;
 
 /**
- * `governed_tools_v3` keeps built-in read tools enabled and adds exactly one
- * capability class — held internal writes — over the read-only `safe_reads_v2`.
- * Every other mutation-shaped capability stays disabled (PRD #92, #93).
+ * The held-external-write capability class — the one mutation-shaped capability
+ * `governed_tools_v4` newly enables over `governed_tools_v3` (PRD #108). The
+ * agent may propose an external mutation — creating a GitHub issue through a
+ * Connected Account — but, exactly like a held Memory write, the proposal is
+ * held for the owner's Approval before it takes effect; enabling the capability
+ * never lets a mutation execute on its own. `connected_account_tools` stays
+ * disabled (reserved for future read-only Connected Account tools).
+ */
+export const THINKSPACE_RUNTIME_HELD_EXTERNAL_WRITE_CAPABILITY_ID = "external_mutations" as const;
+
+/**
+ * `governed_tools_v4` keeps built-in read tools enabled and holds every write
+ * for Approval: it adds the held-external-write class to the held-internal-write
+ * class `governed_tools_v3` already enabled, so exactly three capabilities are
+ * on. Every other mutation-shaped capability — `connected_account_tools`,
+ * workspace bash, and the rest — stays disabled (PRD #92, #93, #108).
  */
 export const THINKSPACE_RUNTIME_ENABLED_CAPABILITY_IDS = [
 	"builtin_read_tools",
 	THINKSPACE_RUNTIME_HELD_WRITE_CAPABILITY_ID,
+	THINKSPACE_RUNTIME_HELD_EXTERNAL_WRITE_CAPABILITY_ID,
 ] as const;
 
 const ENABLED_CAPABILITY_ID_SET: ReadonlySet<ThinkspaceRuntimeCapabilityId> = new Set(
@@ -107,7 +121,7 @@ export const THINKSPACE_RUNTIME_POLICY: ThinkspaceRuntimePolicy = {
 	})),
 	maxSteps: THINKSPACE_RUNTIME_MAX_STEPS,
 	message:
-		"This Thinkspace Agent can read freely and may propose a durable Product Memory, but every write is held for your Approval before it takes effect: built-in read-only tools and held Memory writes are the only enabled capabilities, and each still requires enablement on the active Agent Profile revision plus a potent Permission verdict.",
+		"This Thinkspace Agent can read freely and may propose durable changes — a Product Memory, or an external mutation such as creating a GitHub issue through a Connected Account — but every write is held for your Approval before it takes effect: built-in read-only tools, held Memory writes, and held external mutations are the only enabled capabilities, and each still requires enablement on the active Agent Profile revision plus a potent Permission verdict.",
 	mode: THINKSPACE_RUNTIME_POLICY_MODE,
 	policyId: THINKSPACE_RUNTIME_POLICY_ID,
 	workspaceBash: false,


### PR DESCRIPTION
## What

Opens the policy gate for held external mutations (PRD #108). Replaces `governed_tools_v3` with `governed_tools_v4` as the single Thinkspace Agent runtime policy. The new policy keeps `builtin_read_tools` and `memory_writes` enabled and enables exactly one new capability class — `external_mutations`, the held-external-write class and direct analog of `memory_writes` (the held-internal-write class).

Every other mutation-shaped capability stays disabled — including `connected_account_tools`, reserved for future read-only Connected Account tools — and workspace bash stays explicitly forced off and asserted.

**The gate opens; nothing walks through until the held `create_github_issue` tool exists (#113).** A Thinkspace with no potent external-mutation tool behaves exactly as it does today.

## Changes

- **`runtime-policy.ts`** — bump `THINKSPACE_RUNTIME_POLICY_ID` to `governed_tools_v4`; add `THINKSPACE_RUNTIME_HELD_EXTERNAL_WRITE_CAPABILITY_ID = "external_mutations"`; add it to the enabled set; refresh the product-language `message` (rendered on the Thinkspace detail surface) and the capability doc comments. Mode stays `governed_writes`.
- **`connected-account-runtime-tools.ts`** (new, mirrors `built-in-runtime-tools.ts`) — the external-mutation tool-id registry (`github:create_issue`, in the locked `${catalogId}:${toolName}` convention), the recognizer, the tool → `external_mutations` capability map, and a fail-closed assembly guard `assertThinkspaceRuntimePolicySupportsExternalMutationTools`.
- **`thinkspace-agent.ts`** — wire the guard into the turn seam alongside the built-in guard. It's a no-op until the held tool exists, so read-only and memory-only turns are unchanged.

## Acceptance (per #112)

- [x] Runtime policy reports id `governed_tools_v4` and its mode
- [x] Enabled set is exactly `builtin_read_tools` + `memory_writes` + `external_mutations`; `connected_account_tools` and all other mutation capabilities remain disabled
- [x] Workspace bash remains explicitly forced off and asserted
- [x] `create_github_issue` (tool id `github:create_issue`) maps to the `external_mutations` capability
- [x] Turn-assembly output unchanged for revisions with no potent external-mutation tool
- [x] Thinkspace detail surface renders the new mode/capability in product language (data-driven from the policy report + refreshed message)
- [x] Policy tests assert the new constants following the existing policy assertion suite
- [x] Type checks, Ultracite, and the package test suites pass

## Gates

`bun run check-types` ✓ · `ultracite check` ✓ · **287/287 api tests** ✓

Closes #112