### PR TITLE
Backend: held create_github_issue tool — propose, hold, create after approval (#113)

### DIFF
--- a/apps/server/src/agents/thinkspace-agent.ts
+++ b/apps/server/src/agents/thinkspace-agent.ts
@@ -21,7 +21,13 @@ import {
 	prepareThinkspaceBuiltInRuntimeTools,
 	THINKSPACE_BUILT_IN_TOOL_BLOCKED_REASON,
 } from "@better-agent/api/thinkspaces/built-in-runtime-tools";
-import { assertThinkspaceRuntimePolicySupportsExternalMutationTools } from "@better-agent/api/thinkspaces/connected-account-runtime-tools";
+import {
+	assertThinkspaceRuntimePolicySupportsExternalMutationTools,
+	evaluateConnectedAccountRuntimeToolCallPermission,
+	prepareThinkspaceConnectedAccountRuntimeTools,
+	THINKSPACE_CONNECTED_ACCOUNT_TOOL_BLOCKED_REASON,
+} from "@better-agent/api/thinkspaces/connected-account-runtime-tools";
+import { createThinkspaceGitHubIssueCreator } from "@better-agent/api/thinkspaces/github-issue-creator";
 import { createFetchWebReader } from "@better-agent/api/thinkspaces/web-reader";
 import {
 	extractPendingMemoryApprovals,
@@ -407,8 +413,24 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 			connectServer: ({ server }) => this.connectBuiltInMcpServerForTurn(server),
 			servers: mcpPlan.servers,
 		});
+
+		// Held external mutations: the credential is bound but read only inside the
+		// tool's execute, which runs only on an owner-approved continuation.
+		const connectedAccountPreparation = prepareThinkspaceConnectedAccountRuntimeTools({
+			activeProductToolIds: assembly.activeTools,
+			gitHubIssueCreator: createThinkspaceGitHubIssueCreator({
+				db,
+				encryptionSecret: this.env.API_ENCRYPTION_KEY ?? this.env.BETTER_AUTH_SECRET,
+				ownerUserId: turnContext.ownerUserId,
+			}),
+		});
+
 		const turnConfig = createThinkspaceRuntimeTurnConfig({
-			activeTools: [...builtInPreparation.activeToolNames, ...mcpPreparation.activeToolNames],
+			activeTools: [
+				...builtInPreparation.activeToolNames,
+				...mcpPreparation.activeToolNames,
+				...connectedAccountPreparation.activeToolNames,
+			],
 		});
 		const systemNotices = [
 			builtInPreparation.sourceManifestNotice,
@@ -419,7 +441,11 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 			...turnConfig,
 			model: resolved.model,
 			system: [assembly.systemPrompt, ...systemNotices].join("\n\n"),
-			tools: { ...builtInPreparation.tools, ...mcpPreparation.tools },
+			tools: {
+				...builtInPreparation.tools,
+				...mcpPreparation.tools,
+				...connectedAccountPreparation.tools,
+			},
 		};
 	}
 
@@ -474,6 +500,25 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 				return {
 					action: "block",
 					reason: builtInDecision.reason ?? THINKSPACE_BUILT_IN_TOOL_BLOCKED_REASON,
+				};
+			}
+
+			const connectedAccountDecision = await evaluateConnectedAccountRuntimeToolCallPermission({
+				permissionPolicy,
+				revision: resolved.activeRevision,
+				runtimeToolName: ctx.toolName,
+				thinkspaceId: turnContext.thinkspaceId,
+			});
+
+			if (connectedAccountDecision.applies) {
+				if (connectedAccountDecision.allowed) {
+					return;
+				}
+
+				return {
+					action: "block",
+					reason:
+						connectedAccountDecision.reason ?? THINKSPACE_CONNECTED_ACCOUNT_TOOL_BLOCKED_REASON,
 				};
 			}
 

--- a/packages/api/src/connected-accounts/github-issues.test.ts
+++ b/packages/api/src/connected-accounts/github-issues.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createGitHubIssue, GitHubIssueCreationError, isValidGitHubRepo } from "./github-issues";
+
+/** Replace global fetch with a stub for the duration of one test. */
+const withFetch = async (impl: typeof fetch, run: () => Promise<void>) => {
+	const original = globalThis.fetch;
+	globalThis.fetch = impl;
+	try {
+		await run();
+	} finally {
+		globalThis.fetch = original;
+	}
+};
+
+const isCreationError =
+	(predicate: (error: GitHubIssueCreationError) => boolean) =>
+	(error: unknown): boolean =>
+		error instanceof GitHubIssueCreationError && predicate(error);
+
+test("isValidGitHubRepo accepts owner/name and rejects malformed input", () => {
+	assert.equal(isValidGitHubRepo("octocat/hello-world"), true);
+	assert.equal(isValidGitHubRepo("octo-cat/hello.world_2"), true);
+
+	// No slash.
+	assert.equal(isValidGitHubRepo("octocat"), false);
+	// Two slashes.
+	assert.equal(isValidGitHubRepo("octocat/hello/world"), false);
+	// Path traversal.
+	assert.equal(isValidGitHubRepo("octocat/../secrets"), false);
+	// Space.
+	assert.equal(isValidGitHubRepo("octocat/ hello"), false);
+	// Empty owner.
+	assert.equal(isValidGitHubRepo("/hello-world"), false);
+	assert.equal(isValidGitHubRepo(""), false);
+});
+
+test("createGitHubIssue posts to the repo issues endpoint and returns the real number and url", async () => {
+	let captured: { init?: RequestInit; url: string } | undefined;
+	const stub = ((url: string, init?: RequestInit) => {
+		captured = { init, url };
+
+		return Promise.resolve(
+			Response.json(
+				{ html_url: "https://github.com/octocat/hello-world/issues/42", number: 42 },
+				{ status: 201 },
+			),
+		);
+	}) as typeof fetch;
+
+	await withFetch(stub, async () => {
+		const issue = await createGitHubIssue("ghp_live", {
+			body: "Steps to reproduce.",
+			repo: "octocat/hello-world",
+			title: "Something broke",
+		});
+
+		assert.deepEqual(issue, {
+			number: 42,
+			url: "https://github.com/octocat/hello-world/issues/42",
+		});
+	});
+
+	assert.match(captured?.url ?? "", /\/repos\/octocat\/hello-world\/issues$/u);
+	assert.equal(captured?.init?.method, "POST");
+});
+
+test("a malformed repo aborts before any GitHub call", async () => {
+	let called = false;
+	const stub = (() => {
+		called = true;
+
+		return Promise.resolve(Response.json({ html_url: "x", number: 1 }, { status: 201 }));
+	}) as typeof fetch;
+
+	await withFetch(stub, async () => {
+		await assert.rejects(
+			createGitHubIssue("ghp_live", { body: "B", repo: "not-a-repo", title: "T" }),
+			isCreationError((error) => !error.needsReconnect),
+		);
+	});
+
+	assert.equal(called, false);
+});
+
+test("a 401 yields a needs-reconnect error and never claims success", async () => {
+	const stub = (() =>
+		Promise.resolve(
+			Response.json({ message: "Bad credentials" }, { status: 401 }),
+		)) as typeof fetch;
+
+	await withFetch(stub, async () => {
+		await assert.rejects(
+			createGitHubIssue("ghp_dead", { body: "B", repo: "octocat/hello-world", title: "T" }),
+			isCreationError((error) => error.needsReconnect),
+		);
+	});
+});
+
+test("a non-ok API error is a structured failure without reconnect and without fabricated success", async () => {
+	const stub = (() =>
+		Promise.resolve(Response.json({ message: "Not Found" }, { status: 404 }))) as typeof fetch;
+
+	await withFetch(stub, async () => {
+		await assert.rejects(
+			createGitHubIssue("ghp_live", { body: "B", repo: "octocat/ghost-repo", title: "T" }),
+			isCreationError((error) => !error.needsReconnect),
+		);
+	});
+});
+
+test("a network failure surfaces honestly", async () => {
+	const stub = (() => Promise.reject(new Error("network down"))) as typeof fetch;
+
+	await withFetch(stub, async () => {
+		await assert.rejects(
+			createGitHubIssue("ghp_live", { body: "B", repo: "octocat/hello-world", title: "T" }),
+			isCreationError(() => true),
+		);
+	});
+});
+
+test("a 2xx response without issue details is not treated as success", async () => {
+	const stub = (() => Promise.resolve(Response.json({}, { status: 201 }))) as typeof fetch;
+
+	await withFetch(stub, async () => {
+		await assert.rejects(
+			createGitHubIssue("ghp_live", { body: "B", repo: "octocat/hello-world", title: "T" }),
+			isCreationError(() => true),
+		);
+	});
+});

--- a/packages/api/src/connected-accounts/github-issues.ts
+++ b/packages/api/src/connected-accounts/github-issues.ts
@@ -1,0 +1,95 @@
+/**
+ * The first credentialed external mutation: creating a GitHub issue as a
+ * Connected Account. The token that backs this is read only at execute time,
+ * after the owner approves the held proposal (PRD #108, ADR-0009). Every GitHub
+ * failure becomes a typed `GitHubIssueCreationError` — never a fabricated
+ * success and never an uncaught throw (PR #106 grounding); there is no
+ * auto-retry.
+ */
+import { GITHUB_API_BASE, githubAuthHeaders } from "./github";
+
+/**
+ * `owner/name`: owner is a GitHub login (alphanumeric or single hyphens, ≤39),
+ * repo name starts alphanumeric then allows `-` `_` `.`. Anchored and
+ * single-slash, so path traversal and malformed input never reach a request.
+ */
+const GITHUB_REPO_PATTERN =
+	/^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,38})\/[a-zA-Z0-9](?:[a-zA-Z0-9._-]{0,99})$/u;
+
+export const isValidGitHubRepo = (repo: string): boolean => GITHUB_REPO_PATTERN.test(repo);
+
+/**
+ * A GitHub mutation that did not happen. `needsReconnect` marks the credential
+ * itself as the cause (401/403) so the agent can tell the owner to reconnect
+ * the account rather than retry; every other cause is a transient/API failure.
+ */
+export class GitHubIssueCreationError extends Error {
+	readonly needsReconnect: boolean;
+
+	constructor(message: string, options: { needsReconnect?: boolean } = {}) {
+		super(message);
+		this.name = "GitHubIssueCreationError";
+		this.needsReconnect = options.needsReconnect ?? false;
+	}
+}
+
+export interface CreateGitHubIssueInput {
+	body: string;
+	repo: string;
+	title: string;
+}
+
+export interface CreatedGitHubIssue {
+	number: number;
+	url: string;
+}
+
+/**
+ * Create one issue in `input.repo` as the connected account. Validates the repo
+ * format before any network call; a single attempt, with an honest typed result
+ * either way.
+ */
+export const createGitHubIssue = async (
+	token: string,
+	input: CreateGitHubIssueInput,
+): Promise<CreatedGitHubIssue> => {
+	if (!isValidGitHubRepo(input.repo)) {
+		throw new GitHubIssueCreationError(
+			"The repository must be given as owner/name (for example, octocat/hello-world).",
+		);
+	}
+
+	let response: Response;
+	try {
+		response = await fetch(`${GITHUB_API_BASE}/repos/${input.repo}/issues`, {
+			body: JSON.stringify({ body: input.body, title: input.title }),
+			headers: { ...githubAuthHeaders(token), "Content-Type": "application/json" },
+			method: "POST",
+		});
+	} catch {
+		throw new GitHubIssueCreationError(
+			"Could not reach GitHub to create the issue. Nothing was created.",
+		);
+	}
+
+	if (response.status === 401 || response.status === 403) {
+		throw new GitHubIssueCreationError(
+			"GitHub rejected the connected account's credential, so nothing was created. The GitHub account needs to be reconnected before this will work.",
+			{ needsReconnect: true },
+		);
+	}
+	if (!response.ok) {
+		throw new GitHubIssueCreationError(
+			"GitHub could not create the issue (the repository may not exist or the token may lack issue access). Nothing was created.",
+		);
+	}
+
+	const issue = (await response.json()) as { html_url?: unknown; number?: unknown };
+	if (typeof issue.number !== "number" || typeof issue.html_url !== "string") {
+		throw new GitHubIssueCreationError(
+			"GitHub accepted the request but did not return the created issue's details.",
+		);
+	}
+
+	return { number: issue.number, url: issue.html_url };
+};

--- a/packages/api/src/connected-accounts/github.ts
+++ b/packages/api/src/connected-accounts/github.ts
@@ -2,9 +2,21 @@
  * GitHub credential validation for Connected Accounts. A pasted fine-grained
  * Personal Access Token is validated against GitHub `GET /user` so we resolve
  * and store the account identity at connect time, and reject anything GitHub
- * will not honour before it is ever persisted (ADR-0009).
+ * will not honour before it is ever persisted (ADR-0009). The shared transport
+ * helpers here are reused by the issue-mutation module (`github-issues.ts`).
  */
-const GITHUB_USER_ENDPOINT = "https://api.github.com/user";
+export const GITHUB_API_BASE = "https://api.github.com";
+const GITHUB_USER_ENDPOINT = `${GITHUB_API_BASE}/user`;
+
+/** The connected_account_catalog id GitHub was seeded under (migration 0010). */
+export const GITHUB_CONNECTED_ACCOUNT_CATALOG_ID = "github";
+
+export const githubAuthHeaders = (token: string): HeadersInit => ({
+	Accept: "application/vnd.github+json",
+	Authorization: `Bearer ${token}`,
+	"User-Agent": "better-agent",
+	"X-GitHub-Api-Version": "2022-11-28",
+});
 
 /** A token GitHub would not accept, or an identity it would not return. */
 export class GitHubValidationError extends Error {
@@ -21,14 +33,7 @@ export interface GitHubAccountIdentity {
 export const resolveGitHubAccount = async (token: string): Promise<GitHubAccountIdentity> => {
 	let response: Response;
 	try {
-		response = await fetch(GITHUB_USER_ENDPOINT, {
-			headers: {
-				Accept: "application/vnd.github+json",
-				Authorization: `Bearer ${token}`,
-				"User-Agent": "better-agent",
-				"X-GitHub-Api-Version": "2022-11-28",
-			},
-		});
+		response = await fetch(GITHUB_USER_ENDPOINT, { headers: githubAuthHeaders(token) });
 	} catch {
 		throw new GitHubValidationError(
 			"Could not reach GitHub to validate the token. Try again shortly.",

--- a/packages/api/src/connected-accounts/repository.ts
+++ b/packages/api/src/connected-accounts/repository.ts
@@ -2,6 +2,8 @@ import type { ProductDb } from "@better-agent/db";
 import { userConnectedAccounts } from "@better-agent/db/schema/connected-accounts";
 import { and, eq } from "drizzle-orm";
 
+import { decryptCredential } from "../crypto";
+
 export interface UpsertConnectedAccountInput {
 	catalogId: string;
 	credentialType: "oauth" | "pat";
@@ -63,4 +65,30 @@ export const deleteConnectedAccount = async (
 		)
 		.returning();
 	return deleted.length > 0;
+};
+
+/**
+ * Decrypt the owner's stored credential for one provider, or `null` if no
+ * Connected Account exists for (userId, catalogId). Mirrors the model-provider
+ * `getDecryptedCredential`: plaintext is materialised only here, at the moment
+ * of use — for the held GitHub-issue tool, that is inside `execute`, after the
+ * owner approves the proposal (the PRD #108 / ADR-0009 security invariant).
+ */
+export const getDecryptedConnectedAccountCredential = async (
+	db: ProductDb,
+	input: { catalogId: string; secret: string; userId: string },
+): Promise<string | null> => {
+	const [row] = await db
+		.select()
+		.from(userConnectedAccounts)
+		.where(
+			and(
+				eq(userConnectedAccounts.userId, input.userId),
+				eq(userConnectedAccounts.catalogId, input.catalogId),
+			),
+		)
+		.limit(1);
+	return typeof row?.encryptedCredential === "string"
+		? await decryptCredential(row.encryptedCredential, input.secret)
+		: null;
 };

--- a/packages/api/src/thinkspaces/connected-account-runtime-tools.test.ts
+++ b/packages/api/src/thinkspaces/connected-account-runtime-tools.test.ts
@@ -1,13 +1,56 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import type { Tool, ToolCallOptions } from "ai";
+
+import { GitHubIssueCreationError } from "../connected-accounts/github-issues";
+import type { ActiveAgentProfileRevision } from "./agent-profile";
 import {
 	assertThinkspaceRuntimePolicySupportsExternalMutationTools,
+	connectedAccountRuntimeToolProductId,
+	CREATE_GITHUB_ISSUE_TOOL_ID,
+	CREATE_GITHUB_ISSUE_TOOL_NAME,
 	EXTERNAL_MUTATION_TOOL_IDS,
+	evaluateConnectedAccountRuntimeToolCallPermission,
 	externalMutationToolRuntimeCapabilityId,
 	isExternalMutationToolId,
+	prepareThinkspaceConnectedAccountRuntimeTools,
 } from "./connected-account-runtime-tools";
+import type { ThinkspaceGitHubIssueCreator } from "./github-issue-creator";
+import { createMemoryPermissionPolicy } from "./permission-policy";
 import { THINKSPACE_RUNTIME_POLICY } from "./runtime-policy";
+
+const TOOL_CALL_OPTIONS = { messages: [], toolCallId: "tool_call_1" } as ToolCallOptions;
+
+const executeTool = async (toolDefinition: Tool | undefined, input: unknown): Promise<string> => {
+	assert.ok(toolDefinition?.execute, "tool must be constructed with an execute handler");
+
+	return (await toolDefinition.execute(input as never, TOOL_CALL_OPTIONS)) as string;
+};
+
+const recordingIssueCreator = (
+	impl: ThinkspaceGitHubIssueCreator["create"],
+): {
+	calls: { body: string; repo: string; title: string }[];
+	creator: ThinkspaceGitHubIssueCreator;
+} => {
+	const calls: { body: string; repo: string; title: string }[] = [];
+
+	return {
+		calls,
+		creator: {
+			create: (proposal) => {
+				calls.push(proposal);
+
+				return impl(proposal);
+			},
+		},
+	};
+};
+
+const REVISION_WITH_GITHUB_ISSUE = {
+	toolEnablements: [{ source: "connected_account", toolId: CREATE_GITHUB_ISSUE_TOOL_ID }],
+} as unknown as ActiveAgentProfileRevision;
 
 test("recognizes only the catalog-keyed external-mutation tool ids", () => {
 	assert.deepEqual([...EXTERNAL_MUTATION_TOOL_IDS], ["github:create_issue"]);
@@ -93,5 +136,144 @@ test("the policy guard fails closed if workspace bash is ever not forced off", (
 				policy: bashPolicy,
 			}),
 		/thinkspace-turn-product-safe:/u,
+	);
+});
+
+test("maps the runtime tool name back to its product tool id", () => {
+	assert.equal(
+		connectedAccountRuntimeToolProductId(CREATE_GITHUB_ISSUE_TOOL_NAME),
+		CREATE_GITHUB_ISSUE_TOOL_ID,
+	);
+	assert.equal(connectedAccountRuntimeToolProductId("github:create_issue"), null);
+	assert.equal(connectedAccountRuntimeToolProductId("web_search"), null);
+});
+
+test("prepare assembles the held tool only when its product id is active", () => {
+	const { creator } = recordingIssueCreator(() =>
+		Promise.resolve({ number: 1, url: "https://github.com/o/r/issues/1" }),
+	);
+
+	const absent = prepareThinkspaceConnectedAccountRuntimeTools({
+		activeProductToolIds: ["web_search", "memory_write"],
+		gitHubIssueCreator: creator,
+	});
+	assert.deepEqual(absent.tools, {});
+	assert.deepEqual(absent.activeToolNames, []);
+
+	const present = prepareThinkspaceConnectedAccountRuntimeTools({
+		activeProductToolIds: [CREATE_GITHUB_ISSUE_TOOL_ID],
+		gitHubIssueCreator: creator,
+	});
+	assert.deepEqual(present.activeToolNames, [CREATE_GITHUB_ISSUE_TOOL_NAME]);
+	assert.equal((present.tools[CREATE_GITHUB_ISSUE_TOOL_NAME] as Tool).needsApproval, true);
+});
+
+test("the credential is read only inside execute: preparing the tool never creates anything", async () => {
+	const { calls, creator } = recordingIssueCreator(() =>
+		Promise.resolve({ number: 11, url: "https://github.com/octocat/x/issues/11" }),
+	);
+
+	const preparation = prepareThinkspaceConnectedAccountRuntimeTools({
+		activeProductToolIds: [CREATE_GITHUB_ISSUE_TOOL_ID],
+		gitHubIssueCreator: creator,
+	});
+
+	// Assembling the tool (the held proposal stage) touches the creator zero
+	// times; a rejected proposal whose execute never runs reads no credential.
+	assert.equal(calls.length, 0);
+
+	// Only running execute (the owner-approved continuation) reaches the creator.
+	const result = await executeTool(preparation.tools[CREATE_GITHUB_ISSUE_TOOL_NAME], {
+		body: "Steps.",
+		repo: "octocat/x",
+		title: "Bug",
+	});
+	assert.equal(calls.length, 1);
+	assert.match(result, /Created GitHub issue #11/u);
+	assert.match(result, /octocat\/x/u);
+});
+
+test("execute returns an honest reconnect message on a dead token and never fabricates success", async () => {
+	const { creator } = recordingIssueCreator(() =>
+		Promise.reject(
+			new GitHubIssueCreationError("GitHub rejected the connected account's credential.", {
+				needsReconnect: true,
+			}),
+		),
+	);
+
+	const preparation = prepareThinkspaceConnectedAccountRuntimeTools({
+		activeProductToolIds: [CREATE_GITHUB_ISSUE_TOOL_ID],
+		gitHubIssueCreator: creator,
+	});
+
+	const result = await executeTool(preparation.tools[CREATE_GITHUB_ISSUE_TOOL_NAME], {
+		body: "B",
+		repo: "octocat/x",
+		title: "T",
+	});
+
+	assert.match(result, /rejected the connected account's credential/u);
+	assert.doesNotMatch(result, /Created GitHub issue/u);
+});
+
+test("execute degrades an unexpected error to a product-safe no-change message", async () => {
+	const { creator } = recordingIssueCreator(() => Promise.reject(new Error("boom")));
+
+	const preparation = prepareThinkspaceConnectedAccountRuntimeTools({
+		activeProductToolIds: [CREATE_GITHUB_ISSUE_TOOL_ID],
+		gitHubIssueCreator: creator,
+	});
+
+	const result = await executeTool(preparation.tools[CREATE_GITHUB_ISSUE_TOOL_NAME], {
+		body: "B",
+		repo: "octocat/x",
+		title: "T",
+	});
+
+	assert.match(result, /nothing was created/u);
+	assert.doesNotMatch(result, /Created GitHub issue/u);
+});
+
+test("the call boundary allows the held tool only while its enablement is potent", async () => {
+	const potent = await evaluateConnectedAccountRuntimeToolCallPermission({
+		permissionPolicy: createMemoryPermissionPolicy({ [CREATE_GITHUB_ISSUE_TOOL_ID]: "potent" }),
+		revision: REVISION_WITH_GITHUB_ISSUE,
+		runtimeToolName: CREATE_GITHUB_ISSUE_TOOL_NAME,
+		thinkspaceId: "thinkspace_1",
+	});
+	assert.deepEqual(
+		{ allowed: potent.allowed, applies: potent.applies },
+		{ allowed: true, applies: true },
+	);
+
+	const inert = await evaluateConnectedAccountRuntimeToolCallPermission({
+		permissionPolicy: createMemoryPermissionPolicy({ [CREATE_GITHUB_ISSUE_TOOL_ID]: "inert" }),
+		revision: REVISION_WITH_GITHUB_ISSUE,
+		runtimeToolName: CREATE_GITHUB_ISSUE_TOOL_NAME,
+		thinkspaceId: "thinkspace_1",
+	});
+	assert.equal(inert.allowed, false);
+	assert.equal(inert.applies, true);
+	assert.match(inert.reason ?? "", /not currently available/u);
+
+	const notEnabled = await evaluateConnectedAccountRuntimeToolCallPermission({
+		permissionPolicy: createMemoryPermissionPolicy({ [CREATE_GITHUB_ISSUE_TOOL_ID]: "potent" }),
+		revision: { toolEnablements: [] } as unknown as ActiveAgentProfileRevision,
+		runtimeToolName: CREATE_GITHUB_ISSUE_TOOL_NAME,
+		thinkspaceId: "thinkspace_1",
+	});
+	assert.equal(notEnabled.allowed, false);
+	assert.equal(notEnabled.applies, true);
+
+	const notConnectedAccount = await evaluateConnectedAccountRuntimeToolCallPermission({
+		permissionPolicy: createMemoryPermissionPolicy({}),
+		revision: REVISION_WITH_GITHUB_ISSUE,
+		runtimeToolName: "web_search",
+		thinkspaceId: "thinkspace_1",
+	});
+	assert.deepEqual(
+		{ allowed: notConnectedAccount.allowed, applies: notConnectedAccount.applies },
+		{ allowed: true, applies: false },
 	);
 });

--- a/packages/api/src/thinkspaces/connected-account-runtime-tools.ts
+++ b/packages/api/src/thinkspaces/connected-account-runtime-tools.ts
@@ -1,17 +1,31 @@
 /**
- * The external-mutation half of the Thinkspace Agent turn loop's policy guard.
+ * Connected-account (external-mutation) tools for the Thinkspace Agent turn
+ * loop — the parallel of `built-in-runtime-tools.ts` for credentialed external
+ * writes.
  *
  * External-mutation tools are connected-account tools whose action class is a
- * held external write — `create_github_issue` (tool id `github:create_issue`)
- * is the first (PRD #108). They ride the `external_mutations` capability, the
- * held-external-write class, exactly as the held Memory-proposing tool rides
- * `memory_writes`, the held-internal-write class. The held tool factory itself
- * arrives in a later issue; this module carries the policy-level pieces #112
- * needs: which tool ids are external mutations, which capability governs them,
- * and the fail-closed assembly guard mirroring the built-in-tools support
- * assertion.
+ * held external write. `create_github_issue` (product tool id
+ * `github:create_issue`) is the first: it rides the `external_mutations`
+ * capability — the held-external-write class — exactly as the held
+ * Memory-proposing tool rides `memory_writes`, and it is held on the same Think
+ * `needsApproval` holdpoint, so calling it records nothing until the owner
+ * approves. The owner's credential is read only inside `execute`, which the AI
+ * SDK runs only on an approved continuation; a rejected proposal never touches
+ * the token (PRD #108, ADR-0009).
+ *
+ * This module owns: which tool ids are external mutations, the capability that
+ * governs them, the fail-closed assembly guard, the held tool factory, the
+ * turn-assembly preparation, and the call-boundary permission re-check.
  */
+import { tool } from "ai";
+import type { ToolSet } from "ai";
+import { z } from "zod";
+
+import { GitHubIssueCreationError } from "../connected-accounts/github-issues";
+import type { ActiveAgentProfileRevision } from "./agent-profile";
+import type { ThinkspaceGitHubIssueCreator } from "./github-issue-creator";
 import { markThinkspaceTurnProductSafeError } from "./inspect";
+import type { ThinkspacePermissionPolicy } from "./permission-policy";
 import {
 	isThinkspaceRuntimeCapabilityEnabled,
 	THINKSPACE_RUNTIME_HELD_EXTERNAL_WRITE_CAPABILITY_ID,
@@ -22,13 +36,29 @@ import type { ThinkspaceRuntimeCapabilityId, ThinkspaceRuntimePolicy } from "./r
 const POLICY_ASSEMBLY_MISMATCH_MESSAGE =
 	"This Thinkspace Agent turn was stopped before it started: the runtime safety policy and the assembled tools disagree.";
 
+export const THINKSPACE_CONNECTED_ACCOUNT_TOOL_BLOCKED_REASON =
+	"This external mutation tool is not currently available for this Thinkspace Agent turn.";
+
+export const THINKSPACE_GITHUB_ISSUE_TITLE_MAX_LENGTH = 256;
+export const THINKSPACE_GITHUB_ISSUE_BODY_MAX_LENGTH = 60_000;
+const GITHUB_REPO_MAX_LENGTH = 200;
+
 /**
- * The external-mutation tool ids, in the `${catalogId}:${toolName}` product
- * convention shared with MCP (`serverId:tool`) and the connected-account
- * Permission/credential lookup. `github:create_issue` is the only one today;
- * its held tool factory lands in a later issue.
+ * The held GitHub-issue tool. Its **runtime name** (the toolset key, the
+ * `ctx.toolName` at the call boundary, and the `tool-create_github_issue`
+ * transcript part) is `create_github_issue`; its **product tool id** (the
+ * enablement id, the entry in `assembly.activeTools`, and the Permission keying)
+ * is `github:create_issue` in the locked `${catalogId}:${toolName}` convention.
  */
-export const EXTERNAL_MUTATION_TOOL_IDS = ["github:create_issue"] as const;
+export const CREATE_GITHUB_ISSUE_TOOL_NAME = "create_github_issue";
+export const CREATE_GITHUB_ISSUE_TOOL_ID = "github:create_issue";
+
+/**
+ * The external-mutation product tool ids. `github:create_issue` is the only one
+ * today; mirrors MCP's `serverId:tool` form and the connected-account
+ * Permission/credential lookup.
+ */
+export const EXTERNAL_MUTATION_TOOL_IDS = [CREATE_GITHUB_ISSUE_TOOL_ID] as const;
 
 export type ExternalMutationToolId = (typeof EXTERNAL_MUTATION_TOOL_IDS)[number];
 
@@ -38,6 +68,15 @@ export const isExternalMutationToolId = (value: string): value is ExternalMutati
 const activeExternalMutationToolIds = (
 	activeProductToolIds: readonly string[],
 ): ExternalMutationToolId[] => activeProductToolIds.filter(isExternalMutationToolId);
+
+/** Maps a runtime tool name back to its product tool id; unknown names → null. */
+const RUNTIME_TOOL_NAME_TO_PRODUCT_ID: Readonly<Record<string, ExternalMutationToolId>> = {
+	[CREATE_GITHUB_ISSUE_TOOL_NAME]: CREATE_GITHUB_ISSUE_TOOL_ID,
+};
+
+export const connectedAccountRuntimeToolProductId = (
+	runtimeToolName: string,
+): ExternalMutationToolId | null => RUNTIME_TOOL_NAME_TO_PRODUCT_ID[runtimeToolName] ?? null;
 
 /**
  * Which runtime capability class governs an external-mutation tool: every one
@@ -78,4 +117,146 @@ export const assertThinkspaceRuntimePolicySupportsExternalMutationTools = ({
 			throw new Error(markThinkspaceTurnProductSafeError(POLICY_ASSEMBLY_MISMATCH_MESSAGE));
 		}
 	}
+};
+
+/**
+ * Failure becomes a tool result, not an exception: the model sees an honest
+ * product-safe sentence (never a fabricated success) and the bounded loop keeps
+ * running. A typed `GitHubIssueCreationError` already carries owner-facing
+ * guidance (including reconnect when the credential is the cause); anything else
+ * collapses to a generic no-change message.
+ */
+const toExternalMutationToolFailure = (error: unknown): string => {
+	if (error instanceof GitHubIssueCreationError) {
+		return error.message;
+	}
+
+	return "This tool failed unexpectedly, so nothing was created. Mention the limitation rather than describing the action as done.";
+};
+
+/**
+ * The held GitHub-issue-proposing tool. `needsApproval` is a constant `true`, so
+ * the hold can never be ambiguous (fail closed). The AI SDK does not run
+ * `execute` until the owner approves, so the credential fetch + GitHub write
+ * inside it happen only on an approved continuation; a rejection never reaches
+ * it and nothing is created.
+ */
+const createCreateGitHubIssueTool = (gitHubIssueCreator: ThinkspaceGitHubIssueCreator) =>
+	tool({
+		description:
+			"Propose creating a GitHub issue in a connected repository — held for the owner's Approval, so calling it creates nothing until the owner approves the proposal. The repository must be given as owner/name.",
+		execute: async ({ body, repo, title }) => {
+			try {
+				const issue = await gitHubIssueCreator.create({ body, repo, title });
+
+				return `Created GitHub issue #${issue.number} in ${repo}: ${issue.url}`;
+			} catch (error) {
+				return toExternalMutationToolFailure(error);
+			}
+		},
+		inputSchema: z.object({
+			body: z
+				.string()
+				.min(1)
+				.max(THINKSPACE_GITHUB_ISSUE_BODY_MAX_LENGTH)
+				.describe("The issue body, as Markdown."),
+			repo: z
+				.string()
+				.min(1)
+				.max(GITHUB_REPO_MAX_LENGTH)
+				.describe("The target repository as owner/name, e.g. octocat/hello-world."),
+			title: z
+				.string()
+				.min(1)
+				.max(THINKSPACE_GITHUB_ISSUE_TITLE_MAX_LENGTH)
+				.describe("The issue title."),
+		}),
+		needsApproval: true,
+	});
+
+export interface PrepareThinkspaceConnectedAccountRuntimeToolsInput {
+	activeProductToolIds: readonly string[];
+	gitHubIssueCreator: ThinkspaceGitHubIssueCreator;
+}
+
+export interface ThinkspaceConnectedAccountRuntimePreparation {
+	activeToolNames: string[];
+	tools: ToolSet;
+}
+
+/**
+ * Builds the connected-account half of the turn's toolset from the active set.
+ * The active set already reflects enable ∩ potent (turn assembly) — this only
+ * instantiates a tool definition for each external-mutation tool present, so
+ * the tool is absent whenever its `external_mutations` capability is off or its
+ * potency is inert.
+ */
+export const prepareThinkspaceConnectedAccountRuntimeTools = ({
+	activeProductToolIds,
+	gitHubIssueCreator,
+}: PrepareThinkspaceConnectedAccountRuntimeToolsInput): ThinkspaceConnectedAccountRuntimePreparation => {
+	const tools: ToolSet = {};
+
+	for (const toolId of activeExternalMutationToolIds(activeProductToolIds)) {
+		if (toolId === CREATE_GITHUB_ISSUE_TOOL_ID) {
+			tools[CREATE_GITHUB_ISSUE_TOOL_NAME] = createCreateGitHubIssueTool(gitHubIssueCreator);
+		}
+	}
+
+	return { activeToolNames: Object.keys(tools), tools };
+};
+
+export interface ThinkspaceConnectedAccountToolCallDecision {
+	allowed: boolean;
+	applies: boolean;
+	reason?: string;
+	toolId: ExternalMutationToolId | null;
+}
+
+/**
+ * Defense in depth at the call boundary, mirroring the built-in and MCP
+ * enforcement: a connected-account tool call is allowed only while its
+ * enablement is still potent (enable ∩ grant ∩ credential-exists). Tools
+ * outside the external-mutation catalog are not this evaluator's concern.
+ */
+export const evaluateConnectedAccountRuntimeToolCallPermission = async ({
+	permissionPolicy,
+	revision,
+	runtimeToolName,
+	thinkspaceId,
+}: {
+	permissionPolicy: ThinkspacePermissionPolicy;
+	revision: ActiveAgentProfileRevision;
+	runtimeToolName: string;
+	thinkspaceId: string;
+}): Promise<ThinkspaceConnectedAccountToolCallDecision> => {
+	const productToolId = connectedAccountRuntimeToolProductId(runtimeToolName);
+
+	if (!productToolId) {
+		return { allowed: true, applies: false, toolId: null };
+	}
+
+	const enablements = revision.toolEnablements.filter(
+		(enablement) =>
+			enablement.source === "connected_account" && enablement.toolId === productToolId,
+	);
+
+	if (enablements.length === 0) {
+		return {
+			allowed: false,
+			applies: true,
+			reason: THINKSPACE_CONNECTED_ACCOUNT_TOOL_BLOCKED_REASON,
+			toolId: productToolId,
+		};
+	}
+
+	const verdicts = await permissionPolicy.evaluateToolPotency({ enablements, thinkspaceId });
+	const allowed = verdicts.some((verdict) => verdict.potency === "potent");
+
+	return {
+		allowed,
+		applies: true,
+		reason: allowed ? undefined : THINKSPACE_CONNECTED_ACCOUNT_TOOL_BLOCKED_REASON,
+		toolId: productToolId,
+	};
 };

--- a/packages/api/src/thinkspaces/connected-account-tools.test.ts
+++ b/packages/api/src/thinkspaces/connected-account-tools.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	connectedAccountCatalogIdFromToolId,
+	connectedAccountToolPermissionKind,
+	createConnectedAccountToolPermissionRequests,
+} from "./connected-account-tools";
+
+test("derives the catalog id from a connected-account tool id", () => {
+	assert.equal(connectedAccountCatalogIdFromToolId("github:create_issue"), "github");
+	assert.equal(connectedAccountCatalogIdFromToolId("github"), "github");
+});
+
+test("every connected-account tool is governed by the one credential kind; empty fails closed", () => {
+	assert.equal(
+		connectedAccountToolPermissionKind("github:create_issue"),
+		"connected_account_credential",
+	);
+	assert.equal(connectedAccountToolPermissionKind(""), null);
+});
+
+test("builds one connected_account_credential request per catalog id", () => {
+	const requests = createConnectedAccountToolPermissionRequests(["github:create_issue"]);
+
+	assert.equal(requests.length, 1);
+	assert.equal(requests[0]?.kind, "connected_account_credential");
+	assert.equal(requests[0]?.catalogId, "github");
+	assert.match(requests[0]?.reason ?? "", /GitHub/u);
+});
+
+test("dedupes by catalog id and skips empty tool ids", () => {
+	const requests = createConnectedAccountToolPermissionRequests([
+		"github:create_issue",
+		"github:other_tool",
+		"",
+	]);
+
+	assert.deepEqual(
+		requests.map((request) => request.catalogId),
+		["github"],
+	);
+});
+
+test("returns nothing when no connected-account tools are enabled", () => {
+	assert.deepEqual(createConnectedAccountToolPermissionRequests([]), []);
+});

--- a/packages/api/src/thinkspaces/connected-account-tools.ts
+++ b/packages/api/src/thinkspaces/connected-account-tools.ts
@@ -11,6 +11,8 @@
  */
 import { THINKSPACE_PERMISSION_KINDS } from "@better-agent/db/schema/permissions";
 
+import type { ConnectedAccountCredentialPermissionRequest } from "./agent-profile";
+
 export type ConnectedAccountToolPermissionKind =
 	typeof THINKSPACE_PERMISSION_KINDS.CONNECTED_ACCOUNT_CREDENTIAL;
 
@@ -34,3 +36,40 @@ export const connectedAccountToolPermissionKind = (
 	toolId: string,
 ): ConnectedAccountToolPermissionKind | null =>
 	toolId.length > 0 ? THINKSPACE_PERMISSION_KINDS.CONNECTED_ACCOUNT_CREDENTIAL : null;
+
+const CONNECTED_ACCOUNT_PERMISSION_REASONS: Readonly<Record<string, string>> = {
+	github:
+		"Allow this Thinkspace Agent to act with your connected GitHub account — for example, to create an issue you approve.",
+};
+
+const DEFAULT_CONNECTED_ACCOUNT_PERMISSION_REASON =
+	"Allow this Thinkspace Agent to act with this connected account, held for your Approval.";
+
+/**
+ * One `connected_account_credential` Permission request per catalog id, however
+ * many of that catalog's tools are enabled — mirroring
+ * `createBuiltInToolPermissionRequests`. The request grants the Thinkspace the
+ * use of the owner's product-level credential; potency still also requires the
+ * account to be connected (credential-exists, PRD #108).
+ */
+export const createConnectedAccountToolPermissionRequests = (
+	toolIds: readonly string[],
+): ConnectedAccountCredentialPermissionRequest[] => {
+	const catalogIds = new Set<string>();
+
+	for (const toolId of toolIds) {
+		const catalogId = connectedAccountCatalogIdFromToolId(toolId);
+
+		if (catalogId) {
+			catalogIds.add(catalogId);
+		}
+	}
+
+	return [...catalogIds].map((catalogId) => ({
+		catalogId,
+		kind: "connected_account_credential",
+		reason:
+			CONNECTED_ACCOUNT_PERMISSION_REASONS[catalogId] ??
+			DEFAULT_CONNECTED_ACCOUNT_PERMISSION_REASON,
+	}));
+};

--- a/packages/api/src/thinkspaces/github-issue-creator.test.ts
+++ b/packages/api/src/thinkspaces/github-issue-creator.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { user } from "@better-agent/db/schema/auth";
+import { userConnectedAccounts } from "@better-agent/db/schema/connected-accounts";
+import type { ProductDb } from "@better-agent/db";
+
+import { GitHubIssueCreationError } from "../connected-accounts/github-issues";
+import { encryptCredential } from "../crypto";
+import { createTestProductDb } from "../testing/product-db";
+import { createThinkspaceGitHubIssueCreator } from "./github-issue-creator";
+
+const SECRET = "test-secret";
+const OWNER_ID = "owner_user";
+
+const withFetch = async (impl: typeof fetch, run: () => Promise<void>) => {
+	const original = globalThis.fetch;
+	globalThis.fetch = impl;
+	try {
+		await run();
+	} finally {
+		globalThis.fetch = original;
+	}
+};
+
+const seedOwner = async (db: ProductDb) => {
+	await db.insert(user).values({ email: "owner@example.com", id: OWNER_ID, name: "Owner" });
+};
+
+const seedGitHubAccount = async (db: ProductDb, token: string) => {
+	await db.insert(userConnectedAccounts).values({
+		catalogId: "github",
+		credentialType: "pat",
+		encryptedCredential: await encryptCredential(token, SECRET),
+		externalAccountId: "octocat",
+		id: "connected_account_1",
+		userId: OWNER_ID,
+	});
+};
+
+test("create decrypts the owner's stored credential and creates the issue with it", async () => {
+	const db = createTestProductDb();
+	await seedOwner(db);
+	await seedGitHubAccount(db, "ghp_live");
+
+	let sentAuthorization: string | null = null;
+	const stub = ((_url: string, init?: RequestInit) => {
+		sentAuthorization = new Headers(init?.headers).get("Authorization");
+
+		return Promise.resolve(
+			Response.json(
+				{ html_url: "https://github.com/octocat/x/issues/7", number: 7 },
+				{ status: 201 },
+			),
+		);
+	}) as typeof fetch;
+
+	const creator = createThinkspaceGitHubIssueCreator({
+		db,
+		encryptionSecret: SECRET,
+		ownerUserId: OWNER_ID,
+	});
+
+	await withFetch(stub, async () => {
+		const issue = await creator.create({ body: "B", repo: "octocat/x", title: "T" });
+
+		assert.deepEqual(issue, { number: 7, url: "https://github.com/octocat/x/issues/7" });
+	});
+
+	// The token reached GitHub decrypted — proving the store-backed decrypt-getter.
+	assert.equal(sentAuthorization, "Bearer ghp_live");
+});
+
+test("a missing connected account is a needs-reconnect failure, not a silent no-op", async () => {
+	const db = createTestProductDb();
+	await seedOwner(db);
+
+	let called = false;
+	const stub = (() => {
+		called = true;
+
+		return Promise.resolve(Response.json({ html_url: "x", number: 1 }, { status: 201 }));
+	}) as typeof fetch;
+
+	const creator = createThinkspaceGitHubIssueCreator({
+		db,
+		encryptionSecret: SECRET,
+		ownerUserId: OWNER_ID,
+	});
+
+	await withFetch(stub, async () => {
+		await assert.rejects(
+			creator.create({ body: "B", repo: "octocat/x", title: "T" }),
+			(error: unknown) => error instanceof GitHubIssueCreationError && error.needsReconnect,
+		);
+	});
+
+	// No credential → no GitHub call at all.
+	assert.equal(called, false);
+});

--- a/packages/api/src/thinkspaces/github-issue-creator.ts
+++ b/packages/api/src/thinkspaces/github-issue-creator.ts
@@ -1,0 +1,62 @@
+import type { ProductDb } from "@better-agent/db";
+
+import { GITHUB_CONNECTED_ACCOUNT_CATALOG_ID } from "../connected-accounts/github";
+import { createGitHubIssue, GitHubIssueCreationError } from "../connected-accounts/github-issues";
+import type { CreatedGitHubIssue } from "../connected-accounts/github-issues";
+import { getDecryptedConnectedAccountCredential } from "../connected-accounts/repository";
+
+export interface ThinkspaceGitHubIssueProposal {
+	body: string;
+	repo: string;
+	title: string;
+}
+
+/**
+ * The seam the held GitHub-issue tool writes through once an Approval is
+ * granted. Defined as an interface so the runtime tool stays unaware of
+ * credential storage and GitHub transport, and tests can substitute a recorder.
+ * `create` throws on failure (validation, dead token, API error); the runtime
+ * tool maps those to a product-safe message so the model never sees transport
+ * detail and never fabricates success.
+ */
+export interface ThinkspaceGitHubIssueCreator {
+	create: (proposal: ThinkspaceGitHubIssueProposal) => Promise<CreatedGitHubIssue>;
+}
+
+export interface CreateThinkspaceGitHubIssueCreatorInput {
+	db: ProductDb;
+	/** AES-GCM secret: `env.API_ENCRYPTION_KEY ?? env.BETTER_AUTH_SECRET`. */
+	encryptionSecret: string;
+	/** The Thinkspace owner whose product-level GitHub credential backs the tool. */
+	ownerUserId: string;
+}
+
+/**
+ * Store-backed GitHub-issue creator. The owner's credential is fetched and
+ * decrypted only inside `create`, which the AI SDK runs only after the owner
+ * approves the held proposal — so a rejected proposal never materialises the
+ * token (PRD #108, ADR-0009). A missing/disconnected account surfaces as a
+ * needs-reconnect error rather than a silent no-op.
+ */
+export const createThinkspaceGitHubIssueCreator = ({
+	db,
+	encryptionSecret,
+	ownerUserId,
+}: CreateThinkspaceGitHubIssueCreatorInput): ThinkspaceGitHubIssueCreator => ({
+	create: async (proposal) => {
+		const token = await getDecryptedConnectedAccountCredential(db, {
+			catalogId: GITHUB_CONNECTED_ACCOUNT_CATALOG_ID,
+			secret: encryptionSecret,
+			userId: ownerUserId,
+		});
+
+		if (!token) {
+			throw new GitHubIssueCreationError(
+				"No connected GitHub account is available, so nothing was created. Connect a GitHub account before using this tool.",
+				{ needsReconnect: true },
+			);
+		}
+
+		return await createGitHubIssue(token, proposal);
+	},
+});


### PR DESCRIPTION
## What

The first credentialed external mutation (PRD #108). `create_github_issue` rides the existing Think `needsApproval` holdpoint exactly like `memory_write`: calling it creates nothing until the owner approves, and **the owner's GitHub credential is read only inside `execute`** — which the AI SDK runs only on an approved continuation. A rejected proposal never touches the token (the PRD #108 / ADR-0009 security invariant).

The gate for this opened in #112 (`governed_tools_v4` → `external_mutations`); this issue puts the tool through it.

## Changes

- **`connected-accounts/github-issues.ts`** (new) — `isValidGitHubRepo` + `createGitHubIssue` + `GitHubIssueCreationError`. Validates `owner/name` *before any network call*; turns 401/403 into a **needs-reconnect** error and every other failure into a structured error — never a fabricated success, never an uncaught throw, no auto-retry (extends PR #106 grounding). Shared GitHub transport (`GITHUB_API_BASE`, `githubAuthHeaders`) hoisted from `github.ts` (kept separate so each file holds one error class).
- **`connected-accounts/repository.ts`** — `getDecryptedConnectedAccountCredential` (mirrors the model-provider decrypt-getter; plaintext materialised only at point of use).
- **`thinkspaces/github-issue-creator.ts`** (new) — the `ThinkspaceGitHubIssueCreator` seam + store-backed factory (mirrors `memory-writer.ts`). Fetches/decrypts the owner's credential only inside `create()`; a missing/disconnected account is a needs-reconnect failure, not a silent no-op.
- **`thinkspaces/connected-account-runtime-tools.ts`** — the `create_github_issue` held tool (`needsApproval` constant `true`); `prepareThinkspaceConnectedAccountRuntimeTools` (tool present only when its product id is in the enable∩potent active set); `evaluateConnectedAccountRuntimeToolCallPermission` (call-boundary re-check); the runtime-name ↔ product-id map (`create_github_issue` ↔ `github:create_issue`).
- **`thinkspaces/connected-account-tools.ts`** — `createConnectedAccountToolPermissionRequests` (one `connected_account_credential` request per catalog id; mirrors the built-in builder).
- **`apps/server` `thinkspace-agent.ts`** — bind the creator + prepare the tool in `beforeTurn`, merge it into the turn toolset and `activeTools`, and enforce potency at the `beforeToolCall` seam alongside built-in/MCP.

## Acceptance (per #113)

- [x] `create_github_issue` is a `needsApproval`-held tool with a `{ repo, title, body }` schema
- [x] Assembled into a turn only when `external_mutations` is enabled and potency is potent; otherwise absent
- [x] On approval, `execute` decrypts the owner's credential, validates the repo, creates the issue, returns the real number/url
- [x] On rejection, `execute` never runs and the credential is never read (asserted: prepare → 0 creates, execute → 1 create)
- [x] 401/403 or API error → structured tool error reported truthfully, reconnect flagged, no auto-retry
- [x] `repo` validated to `owner/name`; malformed repo aborts before any GitHub call
- [x] Tests cover propose→hold, approve→create, reject→nothing, dead-token→honest failure; type checks, Ultracite, suites pass

## Scope note

The profile-side request builder is built and tested but **not yet wired into the router's `toRequestedPermissions`**, and there is no UI checkbox to enable a connected-account tool yet — the user-facing **equip surface** (router input schema accepting connected-account selections + UI) lands with **#114**'s surfaces (which is also where the issue Approval is rendered). Until then the tool is equippable only by writing a `connected_account` enablement directly (the tests do this). This keeps #113 to the held tool + seam, matching its acceptance criteria, and mirrors #111's forward-compatible "exported but not yet consumed" pattern. #115's manual round trip therefore depends on #114.

## Gates

`bun run check-types` ✓ · `ultracite check` ✓ · **307/307 api tests** ✓

Closes #113