### PR TITLE
Backend+UI: generalize the approval seam to action kinds; render the GitHub issue Approval + equip connected-account tools (#114)

### DIFF
--- a/apps/server/src/agents/thinkspace-agent.ts
+++ b/apps/server/src/agents/thinkspace-agent.ts
@@ -30,10 +30,9 @@ import {
 import { createThinkspaceGitHubIssueCreator } from "@better-agent/api/thinkspaces/github-issue-creator";
 import { createFetchWebReader } from "@better-agent/api/thinkspaces/web-reader";
 import {
-	extractPendingMemoryApprovals,
-	extractResolvedMemoryApprovals,
-	flipMemoryApprovalInTranscript,
-	summarizeMemoryProposal,
+	extractPendingApprovals,
+	extractResolvedApprovals,
+	flipApprovalInTranscript,
 } from "@better-agent/api/thinkspaces/approvals";
 import {
 	getThinkspaceApproval,
@@ -43,11 +42,11 @@ import {
 } from "@better-agent/api/thinkspaces/approvals-repository";
 import { validateThinkspaceApprovalId } from "@better-agent/api/thinkspaces/approval-decisions";
 import type {
-	ThinkspaceMemoryApprovalDecisionRequest,
-	ThinkspaceMemoryApprovalDecisionResult,
+	ThinkspaceApprovalDecisionRequest,
+	ThinkspaceApprovalDecisionResult,
 } from "@better-agent/api/thinkspaces/approval-decisions";
 import { createThinkspaceMemoryWriter } from "@better-agent/api/thinkspaces/memory-writer";
-import { THINKSPACE_APPROVAL_ACTION_KIND } from "@better-agent/db/schema/approvals";
+import { isThinkspaceApprovalActionKind } from "@better-agent/db/schema/approvals";
 import { createThinkspaceSourceReader } from "@better-agent/api/sources/reader";
 import {
 	createThinkspaceMcpDegradationNotice,
@@ -246,20 +245,22 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 	}
 
 	/**
-	 * Decides one pending Memory Approval out-of-band: the same apply-and-continue
-	 * path an inline Sitting approval drives, invoked from the control plane. The
-	 * decision flips the parked tool part to `approval-responded` in place and
-	 * resumes the turn — on approval the held tool's `execute` finally runs and
-	 * writes the Memory; on rejection it never runs and nothing persists. The
-	 * runtime is authoritative: a forged or mismatched context, an Approval that
-	 * is unknown, already decided, or no longer parked, all resolve to
-	 * `not_found` so the control plane can render the sealed 404.
+	 * Decides one pending Approval out-of-band, of any held action kind: the same
+	 * apply-and-continue path an inline Sitting approval drives, invoked from the
+	 * control plane. The decision flips the parked tool part to
+	 * `approval-responded` in place and resumes the turn — on approval the held
+	 * tool's `execute` finally runs and performs the action (writes the Memory,
+	 * creates the GitHub issue); on rejection it never runs and nothing happens.
+	 * The runtime is authoritative: a forged or mismatched context, an Approval
+	 * that is unknown, already decided, of an unrecognized kind, or no longer
+	 * parked, all resolve to `not_found` so the control plane renders the sealed
+	 * 404.
 	 */
-	async decideMemoryApproval(
-		request: ThinkspaceMemoryApprovalDecisionRequest,
-	): Promise<ThinkspaceMemoryApprovalDecisionResult> {
+	async decideApproval(
+		request: ThinkspaceApprovalDecisionRequest,
+	): Promise<ThinkspaceApprovalDecisionResult> {
 		const approvalId = validateThinkspaceApprovalId(request.approvalId);
-		const notFound: ThinkspaceMemoryApprovalDecisionResult = {
+		const notFound: ThinkspaceApprovalDecisionResult = {
 			approvalId,
 			decision: request.decision,
 			status: "not_found",
@@ -286,13 +287,13 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 		if (
 			!approval ||
 			approval.status !== "pending" ||
-			approval.actionKind !== THINKSPACE_APPROVAL_ACTION_KIND.MEMORY_WRITE
+			!isThinkspaceApprovalActionKind(approval.actionKind)
 		) {
 			return notFound;
 		}
 
 		const messages = await this.getMessages();
-		const flip = flipMemoryApprovalInTranscript({
+		const flip = flipApprovalInTranscript({
 			decision: request.decision,
 			messages,
 			reason: request.reason,
@@ -305,8 +306,11 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 
 		// Persist the single flipped message in place (never append — that would
 		// duplicate the transcript), then resolve the index row before resuming.
-		// The decision is final once the transcript records it; resuming only
-		// fires its consequence, which the held tool's idempotent write absorbs.
+		// The decision is final once the transcript records it: the flip only acts
+		// on an `approval-requested` part and the resolve guards on a still-pending
+		// row, so a repeated decide finds the hold already gone and never fires the
+		// consequence twice (the held tool's `execute` — a Memory write or a GitHub
+		// issue creation — runs once on the resumed continuation).
 		for (const [index, message] of messages.entries()) {
 			const flippedMessage = flip.messages[index];
 
@@ -593,17 +597,17 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 			const messages = await this.getMessages();
 			const db = createDb(this.env.DB);
 
-			for (const pending of extractPendingMemoryApprovals(messages)) {
+			for (const pending of extractPendingApprovals(messages)) {
 				await upsertPendingThinkspaceApproval(db, {
 					record: {
-						actionKind: THINKSPACE_APPROVAL_ACTION_KIND.MEMORY_WRITE,
+						actionKind: pending.actionKind,
 						approvalRequestId: pending.approvalRequestId,
 						id: `approval_${crypto.randomUUID()}`,
 						ownerUserId: turnContext.ownerUserId,
 						profileRevisionId: attribution?.profileRevisionId ?? null,
 						profileVersion: attribution?.profileVersion ?? null,
-						proposedContent: pending.content,
-						proposedSummary: summarizeMemoryProposal(pending.content),
+						proposedContent: pending.proposedContent,
+						proposedSummary: pending.proposedSummary,
 						submissionId: null,
 						thinkspaceId: turnContext.thinkspaceId,
 						toolCallId: pending.toolCallId,
@@ -611,7 +615,7 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 				});
 			}
 
-			const resolvedProposals = extractResolvedMemoryApprovals(messages);
+			const resolvedProposals = extractResolvedApprovals(messages);
 
 			if (resolvedProposals.length === 0) {
 				return;

--- a/apps/web/src/components/sitting-section.tsx
+++ b/apps/web/src/components/sitting-section.tsx
@@ -1,4 +1,9 @@
-import { MEMORY_WRITE_TOOL_PART_TYPE } from "@better-agent/api/thinkspaces/approvals";
+import {
+	CREATE_GITHUB_ISSUE_TOOL_PART_TYPE,
+	MEMORY_WRITE_TOOL_PART_TYPE,
+	readProposedGitHubIssue,
+} from "@better-agent/api/thinkspaces/approvals";
+import type { ProposedGitHubIssue } from "@better-agent/api/thinkspaces/approvals";
 import { env } from "@better-agent/env/web";
 import { Badge } from "@better-agent/ui/components/badge";
 import { Button } from "@better-agent/ui/components/button";
@@ -106,6 +111,50 @@ const toProposalDecisionView = (state: string): ProposalDecisionView | null => {
 	}
 };
 
+/**
+ * The shared footer for any held proposal card: while pending, the decision
+ * hint and the approve/reject controls; once decided, a line recording the
+ * owner's choice. Both the Memory and GitHub-issue cards resolve the same
+ * Approval through `onDecide`, so they share this rather than drift.
+ */
+const ProposalDecisionFooter = ({
+	approvalId,
+	decision,
+	disabled,
+	onDecide,
+	pendingHint,
+}: {
+	approvalId: string;
+	decision: ProposalDecisionView;
+	disabled: boolean;
+	onDecide: (approvalId: string, approved: boolean) => void;
+	pendingHint: string;
+}) =>
+	decision === "pending" ? (
+		<div className="flex flex-wrap items-center justify-between gap-3">
+			<p className="text-muted-foreground text-xs">{pendingHint}</p>
+			<div className="flex gap-2">
+				<Button
+					disabled={disabled}
+					onClick={() => onDecide(approvalId, false)}
+					size="sm"
+					variant="outline"
+				>
+					<XIcon />
+					Reject
+				</Button>
+				<Button disabled={disabled} onClick={() => onDecide(approvalId, true)} size="sm">
+					<CheckIcon />
+					Approve
+				</Button>
+			</div>
+		</div>
+	) : (
+		<p className="text-muted-foreground text-xs">
+			{decision === "approved" ? "You approved this proposal." : "You rejected this proposal."}
+		</p>
+	);
+
 const HeldMemoryProposal = ({
 	approvalId,
 	content,
@@ -128,32 +177,50 @@ const HeldMemoryProposal = ({
 				<Badge variant={badge.variant}>{badge.label}</Badge>
 			</div>
 			<p className="whitespace-pre-wrap text-foreground text-sm leading-relaxed">{content}</p>
-			{decision === "pending" ? (
-				<div className="flex flex-wrap items-center justify-between gap-3">
-					<p className="text-muted-foreground text-xs">
-						Held until you decide — approve to write this Memory, reject to discard it.
-					</p>
-					<div className="flex gap-2">
-						<Button
-							disabled={disabled}
-							onClick={() => onDecide(approvalId, false)}
-							size="sm"
-							variant="outline"
-						>
-							<XIcon />
-							Reject
-						</Button>
-						<Button disabled={disabled} onClick={() => onDecide(approvalId, true)} size="sm">
-							<CheckIcon />
-							Approve
-						</Button>
-					</div>
+			<ProposalDecisionFooter
+				approvalId={approvalId}
+				decision={decision}
+				disabled={disabled}
+				onDecide={onDecide}
+				pendingHint="Held until you decide — approve to write this Memory, reject to discard it."
+			/>
+		</div>
+	);
+};
+
+const HeldGitHubIssueProposal = ({
+	approvalId,
+	decision,
+	disabled,
+	issue,
+	onDecide,
+}: {
+	approvalId: string;
+	decision: ProposalDecisionView;
+	disabled: boolean;
+	issue: ProposedGitHubIssue;
+	onDecide: (approvalId: string, approved: boolean) => void;
+}) => {
+	const badge = PROPOSAL_BADGE[decision];
+
+	return (
+		<div className="grid gap-3 rounded-lg border border-border bg-card p-4">
+			<div className="flex items-start justify-between gap-3">
+				<div className="grid gap-1">
+					<p className="text-sm font-medium">GitHub issue proposal</p>
+					<p className="break-all font-mono text-muted-foreground text-xs">{issue.repo}</p>
 				</div>
-			) : (
-				<p className="text-muted-foreground text-xs">
-					{decision === "approved" ? "You approved this proposal." : "You rejected this proposal."}
-				</p>
-			)}
+				<Badge variant={badge.variant}>{badge.label}</Badge>
+			</div>
+			<p className="text-foreground text-sm font-medium leading-relaxed">{issue.title}</p>
+			<p className="whitespace-pre-wrap text-foreground text-sm leading-relaxed">{issue.body}</p>
+			<ProposalDecisionFooter
+				approvalId={approvalId}
+				decision={decision}
+				disabled={disabled}
+				onDecide={onDecide}
+				pendingHint={`Held until you decide — approve to create this issue in ${issue.repo}, reject to discard it.`}
+			/>
 		</div>
 	);
 };
@@ -213,14 +280,22 @@ const LiveSitting = ({ thinkspaceId }: { thinkspaceId: string }) => {
 								return true;
 							}
 
-							// A held Memory proposal is renderable once it carries a decidable
-							// state and content; a half-formed or malformed hold is skipped so it
+							// A held proposal is renderable once it carries a decidable state and a
+							// well-formed payload; a half-formed or malformed hold is skipped so it
 							// never surfaces a card with nothing to decide.
-							return (
-								part.type === MEMORY_WRITE_TOOL_PART_TYPE &&
-								toProposalDecisionView(getToolPartState(part)) !== null &&
-								readProposedMemory(getToolInput(part)) !== null
-							);
+							if (toProposalDecisionView(getToolPartState(part)) === null) {
+								return false;
+							}
+
+							if (part.type === MEMORY_WRITE_TOOL_PART_TYPE) {
+								return readProposedMemory(getToolInput(part)) !== null;
+							}
+
+							if (part.type === CREATE_GITHUB_ISSUE_TOOL_PART_TYPE) {
+								return readProposedGitHubIssue(getToolInput(part)) !== null;
+							}
+
+							return false;
 						});
 
 						// Skip turns with nothing to show: a turn that returned no text, or
@@ -263,6 +338,27 @@ const LiveSitting = ({ thinkspaceId }: { thinkspaceId: string }) => {
 												decision={decision}
 												disabled={isBusy}
 												key={`${message.id}-proposal-${index}`}
+												onDecide={handleDecideProposal}
+											/>
+										);
+									}
+
+									if (part.type === CREATE_GITHUB_ISSUE_TOOL_PART_TYPE) {
+										const approval = getToolApproval(part);
+										const issue = readProposedGitHubIssue(getToolInput(part));
+										const decision = toProposalDecisionView(getToolPartState(part));
+
+										if (!(approval && issue && decision)) {
+											return null;
+										}
+
+										return (
+											<HeldGitHubIssueProposal
+												approvalId={approval.id}
+												decision={decision}
+												disabled={isBusy}
+												issue={issue}
+												key={`${message.id}-issue-${index}`}
 												onDecide={handleDecideProposal}
 											/>
 										);

--- a/apps/web/src/routes/review-queue.index.tsx
+++ b/apps/web/src/routes/review-queue.index.tsx
@@ -1,3 +1,4 @@
+import { parseProposedGitHubIssue } from "@better-agent/api/thinkspaces/approvals";
 import { Badge } from "@better-agent/ui/components/badge";
 import { Button } from "@better-agent/ui/components/button";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
@@ -15,10 +16,42 @@ const formatProposedAt = (value: Date | number | string): string =>
 	dateFormatter.format(new Date(value));
 
 const ACTION_LABELS: Record<string, string> = {
+	github_create_issue: "GitHub issue",
 	memory_write: "Memory proposal",
 };
 
 const actionLabel = (actionKind: string): string => ACTION_LABELS[actionKind] ?? "Held action";
+
+/**
+ * The held proposal's detail. A GitHub-issue proposal parses its serialized
+ * payload to show the target repo prominently above the title and body; any
+ * other kind (and a malformed issue payload) falls back to the product-language
+ * summary line.
+ */
+const ProposalDetail = ({
+	actionKind,
+	proposedContent,
+	proposedSummary,
+}: {
+	actionKind: string;
+	proposedContent: string;
+	proposedSummary: string;
+}) => {
+	const issue =
+		actionKind === "github_create_issue" ? parseProposedGitHubIssue(proposedContent) : null;
+
+	if (!issue) {
+		return <p className="text-foreground text-sm leading-relaxed">{proposedSummary}</p>;
+	}
+
+	return (
+		<div className="grid gap-1">
+			<p className="break-all font-mono text-muted-foreground text-xs">{issue.repo}</p>
+			<p className="text-foreground text-sm font-medium leading-relaxed">{issue.title}</p>
+			<p className="whitespace-pre-wrap text-foreground text-sm leading-relaxed">{issue.body}</p>
+		</div>
+	);
+};
 
 const RouteComponent = () => {
 	const context = routeApi.useRouteContext();
@@ -92,7 +125,11 @@ const RouteComponent = () => {
 										<Badge variant="secondary">{actionLabel(item.actionKind)}</Badge>
 									</div>
 
-									<p className="text-foreground text-sm leading-relaxed">{item.proposedSummary}</p>
+									<ProposalDetail
+										actionKind={item.actionKind}
+										proposedContent={item.proposedContent}
+										proposedSummary={item.proposedSummary}
+									/>
 
 									<div className="flex items-center justify-between gap-3">
 										<p className="text-muted-foreground text-xs">

--- a/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.$thinkspaceId.tsx
@@ -148,13 +148,37 @@ const BUILT_IN_TOOLS: readonly BuiltInToolView[] = [
 const isBuiltInToolId = (value: string): value is BuiltInToolId =>
 	BUILT_IN_TOOLS.some((tool) => tool.id === value);
 
+type ConnectedAccountToolId = "github:create_issue";
+
+interface ConnectedAccountToolView {
+	description: string;
+	id: ConnectedAccountToolId;
+	name: string;
+	risk: "mutating";
+}
+
+const CONNECTED_ACCOUNT_TOOLS: readonly ConnectedAccountToolView[] = [
+	{
+		description:
+			"Propose creating a GitHub issue in a connected repository, held for your Approval before it is created. Potent only with a connected GitHub account and the Connected Account credential Permission.",
+		id: "github:create_issue",
+		name: "Create GitHub issue",
+		risk: "mutating",
+	},
+];
+
+const isConnectedAccountToolId = (value: string): value is ConnectedAccountToolId =>
+	CONNECTED_ACCOUNT_TOOLS.some((tool) => tool.id === value);
+
 interface PermissionRequestView {
 	actions?: string[];
 	approvalRequired?: boolean;
+	catalogId?: string;
 	kind?:
 		| "built_in_memory_write"
 		| "built_in_source_read"
 		| "built_in_web_read"
+		| "connected_account_credential"
 		| "mcp_tool_access"
 		| "model_provider_credential";
 	providerId?: string;
@@ -292,6 +316,10 @@ const getPermissionRequestTitle = (permission: PermissionRequestView, index: num
 		return `Model credential: ${permission.providerId}`;
 	}
 
+	if (permission.kind === "connected_account_credential") {
+		return `Connected Account credential: ${permission.catalogId ?? "account"}`;
+	}
+
 	if (permission.kind === "mcp_tool_access") {
 		return `External information access: ${permission.serverId}`;
 	}
@@ -331,6 +359,10 @@ const getGrantedPermissionTitle = (permission: GrantedPermissionView): string =>
 
 	if (permission.kind === "model_provider_credential") {
 		return `Model credential: ${permission.providerId ?? "provider"}`;
+	}
+
+	if (permission.kind === "connected_account_credential") {
+		return `Connected Account credential: ${permission.providerId ?? "account"}`;
 	}
 
 	return `${permission.kind}: ${permission.providerId ?? "scoped resource"}`;
@@ -921,22 +953,26 @@ interface McpCatalogServerView {
 
 const ToolsSection = ({
 	enabledBuiltInToolIds,
+	enabledConnectedAccountToolIds,
 	enabledTools,
 	isArchived,
 	mcpCatalog,
 	onToggleBuiltInTool,
 	onToggleCatalogTool,
+	onToggleConnectedAccountTool,
 	profileRevision,
 	toolPotencyById,
 	updateToolSelectionsError,
 	updateToolSelectionsPending,
 }: {
 	enabledBuiltInToolIds: BuiltInToolId[];
+	enabledConnectedAccountToolIds: ConnectedAccountToolId[];
 	enabledTools: EnabledToolSelection[];
 	isArchived: boolean;
 	mcpCatalog: McpCatalogServerView[];
 	onToggleBuiltInTool: (toolId: BuiltInToolId) => void;
 	onToggleCatalogTool: (serverId: string, risk: EnabledToolSelection["risk"]) => void;
+	onToggleConnectedAccountTool: (toolId: ConnectedAccountToolId) => void;
 	profileRevision: AgentProfileRevisionView | null;
 	toolPotencyById: ReadonlyMap<string, EnabledToolPotencyView>;
 	updateToolSelectionsError?: Error | null;
@@ -982,6 +1018,44 @@ const ToolsSection = ({
 							<Button
 								disabled={isArchived || updateToolSelectionsPending}
 								onClick={() => onToggleBuiltInTool(tool.id)}
+								size="sm"
+								type="button"
+								variant={selected ? "secondary" : "outline"}
+							>
+								{selected ? "Remove" : "Select"}
+							</Button>
+						</div>
+					);
+				})}
+			</div>
+		</div>
+		<div className="grid gap-2">
+			<p className="text-sm font-medium">Connected Account tools</p>
+			<div className="overflow-hidden rounded-lg ring-1 ring-foreground/10">
+				{CONNECTED_ACCOUNT_TOOLS.map((tool, index) => {
+					const selected = enabledConnectedAccountToolIds.includes(tool.id);
+					const toolPotency = selected ? toolPotencyById.get(tool.id) : undefined;
+
+					return (
+						<div
+							key={tool.id}
+							className={`flex items-center justify-between gap-4 p-4 ${index < CONNECTED_ACCOUNT_TOOLS.length - 1 ? "border-b border-border" : ""} ${selected ? "bg-muted/30" : ""}`}
+						>
+							<div className="grid gap-0.5">
+								<div className="flex items-center gap-2">
+									<p className="text-sm font-medium">{tool.name}</p>
+									<span className="text-muted-foreground text-xs">{tool.risk}</span>
+									{toolPotency ? (
+										<Badge variant={getToolPotencyBadgeVariant(toolPotency.potency)}>
+											{getToolPotencyLabel(toolPotency.potency)}
+										</Badge>
+									) : null}
+								</div>
+								<p className="text-muted-foreground text-sm">{tool.description}</p>
+							</div>
+							<Button
+								disabled={isArchived || updateToolSelectionsPending}
+								onClick={() => onToggleConnectedAccountTool(tool.id)}
 								size="sm"
 								type="button"
 								variant={selected ? "secondary" : "outline"}
@@ -1479,6 +1553,11 @@ const RouteComponent = () => {
 			.filter((enablement) => enablement.source === "built_in")
 			.map((enablement) => enablement.toolId)
 			.filter(isBuiltInToolId) ?? [];
+	const enabledConnectedAccountToolIds =
+		editableRevision?.toolEnablements
+			.filter((enablement) => enablement.source === "connected_account")
+			.map((enablement) => enablement.toolId)
+			.filter(isConnectedAccountToolId) ?? [];
 	const enabledToolPotencies = (thinkspace.enabledToolPotencies ?? []) as EnabledToolPotencyView[];
 	const toolPotencyById = new Map(
 		enabledToolPotencies.map((toolPotency) => [toolPotency.toolId, toolPotency] as const),
@@ -1494,6 +1573,7 @@ const RouteComponent = () => {
 
 		updateToolSelectionsMutation.mutate({
 			builtInToolIds: enabledBuiltInToolIds,
+			connectedAccountToolIds: enabledConnectedAccountToolIds,
 			selections,
 			thinkspaceId,
 		});
@@ -1507,6 +1587,21 @@ const RouteComponent = () => {
 
 		updateToolSelectionsMutation.mutate({
 			builtInToolIds,
+			connectedAccountToolIds: enabledConnectedAccountToolIds,
+			selections: enabledTools,
+			thinkspaceId,
+		});
+	};
+
+	const toggleConnectedAccountTool = (toolId: ConnectedAccountToolId) => {
+		const selected = enabledConnectedAccountToolIds.includes(toolId);
+		const connectedAccountToolIds = selected
+			? enabledConnectedAccountToolIds.filter((enabledToolId) => enabledToolId !== toolId)
+			: [...enabledConnectedAccountToolIds, toolId];
+
+		updateToolSelectionsMutation.mutate({
+			builtInToolIds: enabledBuiltInToolIds,
+			connectedAccountToolIds,
 			selections: enabledTools,
 			thinkspaceId,
 		});
@@ -1605,11 +1700,13 @@ const RouteComponent = () => {
 				<TabsPanel className="grid gap-8" value="tools">
 					<ToolsSection
 						enabledBuiltInToolIds={enabledBuiltInToolIds}
+						enabledConnectedAccountToolIds={enabledConnectedAccountToolIds}
 						enabledTools={enabledTools}
 						isArchived={isArchived}
 						mcpCatalog={mcpCatalogQuery.data}
 						onToggleBuiltInTool={toggleBuiltInTool}
 						onToggleCatalogTool={toggleCatalogTool}
+						onToggleConnectedAccountTool={toggleConnectedAccountTool}
 						profileRevision={editableRevision}
 						toolPotencyById={toolPotencyById}
 						updateToolSelectionsError={updateToolSelectionsMutation.error}

--- a/packages/api/src/approvals/router.test.ts
+++ b/packages/api/src/approvals/router.test.ts
@@ -9,7 +9,7 @@ import { call } from "@orpc/server";
 
 import type { Context } from "../context";
 import { createTestProductDb } from "../testing/product-db";
-import type { ThinkspaceMemoryApprovalDecisionResult } from "../thinkspaces/approval-decisions";
+import type { ThinkspaceApprovalDecisionResult } from "../thinkspaces/approval-decisions";
 import { approvalsRouter } from "./router";
 
 const OWNED_THINKSPACE_ID = "thinkspace_owned";
@@ -29,11 +29,11 @@ const untouchableDb = new Proxy({} as Record<string, unknown>, {
  * result mapping are testable without a live runtime.
  */
 const createAgentNamespace = (
-	decide: () => Promise<ThinkspaceMemoryApprovalDecisionResult>,
+	decide: () => Promise<ThinkspaceApprovalDecisionResult>,
 	calls: { count: number },
 ) => ({
 	get: () => ({
-		decideMemoryApproval: () => {
+		decideApproval: () => {
 			calls.count += 1;
 
 			return decide();
@@ -239,6 +239,7 @@ test("the Review Queue lists the owner's pending Approvals most-recent first, in
 			actionKind: "memory_write",
 			approvalId: "approval_new",
 			proposedAt: new Date(2000),
+			proposedContent: "The user prefers Vendor B.",
 			proposedSummary: 'Proposed a durable Product Memory: "The user prefers Vendor B."',
 			thinkspaceGoal: "Decide between vendors",
 			thinkspaceId: OWNED_THINKSPACE_ID,
@@ -247,7 +248,44 @@ test("the Review Queue lists the owner's pending Approvals most-recent first, in
 			actionKind: "memory_write",
 			approvalId: "approval_old",
 			proposedAt: new Date(1000),
+			proposedContent: "The user prefers Vendor A.",
 			proposedSummary: 'Proposed a durable Product Memory: "The user prefers Vendor A."',
+			thinkspaceGoal: "Decide between vendors",
+			thinkspaceId: OWNED_THINKSPACE_ID,
+		},
+	]);
+});
+
+test("the Review Queue carries a held GitHub-issue proposal's serialized payload for the issue card", async () => {
+	const db = createTestProductDb();
+	await seedOwnedThinkspace(db);
+	const proposedContent = JSON.stringify({
+		body: "The retry logic swallows the error.",
+		repo: "octocat/hello-world",
+		title: "Flaky test on CI",
+	});
+	await db.insert(thinkspaceApprovals).values({
+		actionKind: "github_create_issue",
+		approvalRequestId: "req_issue",
+		id: "approval_issue",
+		ownerUserId: authenticatedSession.user.id,
+		proposedContent,
+		proposedSummary: 'Create issue "Flaky test on CI" in octocat/hello-world',
+		thinkspaceId: OWNED_THINKSPACE_ID,
+		toolCallId: "tool_issue",
+	});
+
+	const queue = await call(approvalsRouter.list, undefined, {
+		context: createCallContext({ db }),
+	});
+
+	assert.deepEqual(queue, [
+		{
+			actionKind: "github_create_issue",
+			approvalId: "approval_issue",
+			proposedAt: queue[0]?.proposedAt,
+			proposedContent,
+			proposedSummary: 'Create issue "Flaky test on CI" in octocat/hello-world',
 			thinkspaceGoal: "Decide between vendors",
 			thinkspaceId: OWNED_THINKSPACE_ID,
 		},

--- a/packages/api/src/approvals/router.ts
+++ b/packages/api/src/approvals/router.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 import { protectedProcedure } from "../procedures";
 import {
-	decideOwnedThinkspaceMemoryApproval,
+	decideOwnedThinkspaceApproval,
 	ThinkspaceApprovalValidationError,
 } from "../thinkspaces/approval-decisions";
 import { listPendingThinkspaceApprovalsByOwner } from "../thinkspaces/approvals-repository";
@@ -29,10 +29,10 @@ const toNotFound = (): ORPCError<"NOT_FOUND", undefined> =>
  */
 export const approvalsRouter = {
 	decide: protectedProcedure.input(decideInput).handler(async ({ context, input }) => {
-		let result: Awaited<ReturnType<typeof decideOwnedThinkspaceMemoryApproval>>;
+		let result: Awaited<ReturnType<typeof decideOwnedThinkspaceApproval>>;
 
 		try {
-			result = await decideOwnedThinkspaceMemoryApproval({
+			result = await decideOwnedThinkspaceApproval({
 				approvalId: input.approvalId,
 				db: context.db,
 				decision: input.decision,
@@ -69,6 +69,7 @@ export const approvalsRouter = {
 			actionKind: approval.actionKind,
 			approvalId: approval.id,
 			proposedAt: approval.createdAt,
+			proposedContent: approval.proposedContent,
 			proposedSummary: approval.proposedSummary,
 			thinkspaceGoal,
 			thinkspaceId: approval.thinkspaceId,

--- a/packages/api/src/thinkspaces/approval-decisions.test.ts
+++ b/packages/api/src/thinkspaces/approval-decisions.test.ts
@@ -4,10 +4,10 @@ import test from "node:test";
 import type { ProductDb } from "@better-agent/db";
 
 import {
-	decideOwnedThinkspaceMemoryApproval,
+	decideOwnedThinkspaceApproval,
 	ThinkspaceApprovalValidationError,
 } from "./approval-decisions";
-import type { ThinkspaceMemoryApprovalDecisionRequest } from "./approval-decisions";
+import type { ThinkspaceApprovalDecisionRequest } from "./approval-decisions";
 
 const env = {
 	THINKSPACE_AGENT: {
@@ -18,9 +18,9 @@ const env = {
 const ownerFound = () => Promise.resolve({ id: "thinkspace_1" });
 
 test("deciding forwards the bound Thinkspace, owner, decision, and reason to the runtime", async () => {
-	const seen: ThinkspaceMemoryApprovalDecisionRequest[] = [];
+	const seen: ThinkspaceApprovalDecisionRequest[] = [];
 
-	const result = await decideOwnedThinkspaceMemoryApproval({
+	const result = await decideOwnedThinkspaceApproval({
 		approvalId: "  approval_1  ",
 		db: {} as ProductDb,
 		decideApproval: ({ request }) => {
@@ -56,7 +56,7 @@ test("deciding forwards the bound Thinkspace, owner, decision, and reason to the
 test("a non-owner's decide resolves to null without ever reaching the runtime", async () => {
 	let reachedRuntime = false;
 
-	const result = await decideOwnedThinkspaceMemoryApproval({
+	const result = await decideOwnedThinkspaceApproval({
 		approvalId: "approval_1",
 		db: {} as ProductDb,
 		decideApproval: () => {
@@ -82,7 +82,7 @@ test("a non-owner's decide resolves to null without ever reaching the runtime", 
 
 test("an empty Approval handle is rejected before any ownership or runtime work", async () => {
 	await assert.rejects(
-		decideOwnedThinkspaceMemoryApproval({
+		decideOwnedThinkspaceApproval({
 			approvalId: "   ",
 			db: {} as ProductDb,
 			decideApproval: () => Promise.reject(new Error("must not run")),

--- a/packages/api/src/thinkspaces/approval-decisions.ts
+++ b/packages/api/src/thinkspaces/approval-decisions.ts
@@ -9,12 +9,12 @@ import { resolveThinkspaceAgentRuntime, THINKSPACE_AGENT_BINDING_NAME } from "./
 export const THINKSPACE_APPROVAL_ID_MAX_LENGTH = 128;
 
 /**
- * The worker→runtime contract for deciding one pending Approval out-of-band.
- * Deciding drives the Durable Object (which owns the parked-turn state); the
- * Review Queue reads the D1 index. Mirrors the submit/inspect runtime contracts
- * in turns.ts and inspect.ts.
+ * The worker→runtime contract for deciding one pending Approval out-of-band,
+ * for any held action kind. Deciding drives the Durable Object (which owns the
+ * parked-turn state); the Review Queue reads the D1 index. Mirrors the
+ * submit/inspect runtime contracts in turns.ts and inspect.ts.
  */
-export interface ThinkspaceMemoryApprovalDecisionRequest {
+export interface ThinkspaceApprovalDecisionRequest {
 	approvalId: string;
 	decision: ThinkspaceApprovalDecision;
 	ownerUserId: string;
@@ -22,12 +22,12 @@ export interface ThinkspaceMemoryApprovalDecisionRequest {
 	thinkspaceId: string;
 }
 
-export type ThinkspaceMemoryApprovalDecisionStatus = "applied" | "not_found";
+export type ThinkspaceApprovalDecisionStatus = "applied" | "not_found";
 
-export interface ThinkspaceMemoryApprovalDecisionResult {
+export interface ThinkspaceApprovalDecisionResult {
 	approvalId: string;
 	decision: ThinkspaceApprovalDecision;
-	status: ThinkspaceMemoryApprovalDecisionStatus;
+	status: ThinkspaceApprovalDecisionStatus;
 	thinkspaceId: string;
 }
 
@@ -63,14 +63,14 @@ type GetThinkspaceByOwner = (
 
 type DecideApproval = (input: {
 	env: ThinkspaceApprovalDecisionEnv;
-	request: ThinkspaceMemoryApprovalDecisionRequest;
+	request: ThinkspaceApprovalDecisionRequest;
 	runtimeName: string;
-}) => Promise<ThinkspaceMemoryApprovalDecisionResult>;
+}) => Promise<ThinkspaceApprovalDecisionResult>;
 
 interface ThinkspaceAgentApprovalStub {
-	decideMemoryApproval: (
-		request: ThinkspaceMemoryApprovalDecisionRequest,
-	) => Promise<ThinkspaceMemoryApprovalDecisionResult>;
+	decideApproval: (
+		request: ThinkspaceApprovalDecisionRequest,
+	) => Promise<ThinkspaceApprovalDecisionResult>;
 	/**
 	 * PartyServer's initialization RPC. User-defined RPC methods do not pass
 	 * through the runtime's fetch/alarm entry points where `onStart()` would run,
@@ -87,10 +87,10 @@ const decideViaThinkspaceAgentRuntime: DecideApproval = async ({ env, request, r
 
 	await stub.setName(runtimeName);
 
-	return await stub.decideMemoryApproval(request);
+	return await stub.decideApproval(request);
 };
 
-export interface DecideOwnedThinkspaceMemoryApprovalInput {
+export interface DecideOwnedThinkspaceApprovalInput {
 	approvalId: string;
 	db: ProductDb;
 	decideApproval?: DecideApproval;
@@ -109,7 +109,7 @@ export interface DecideOwnedThinkspaceMemoryApprovalInput {
  * the runtime, which is authoritative over whether the specific Approval is
  * still pending.
  */
-export const decideOwnedThinkspaceMemoryApproval = async ({
+export const decideOwnedThinkspaceApproval = async ({
 	approvalId,
 	db,
 	decideApproval = decideViaThinkspaceAgentRuntime,
@@ -119,7 +119,7 @@ export const decideOwnedThinkspaceMemoryApproval = async ({
 	ownerUserId,
 	reason,
 	thinkspaceId,
-}: DecideOwnedThinkspaceMemoryApprovalInput): Promise<ThinkspaceMemoryApprovalDecisionResult | null> => {
+}: DecideOwnedThinkspaceApprovalInput): Promise<ThinkspaceApprovalDecisionResult | null> => {
 	const boundedApprovalId = validateThinkspaceApprovalId(approvalId);
 
 	const thinkspace = await getThinkspaceByOwner(db, { ownerUserId, thinkspaceId });

--- a/packages/api/src/thinkspaces/approval-surfaces.test.ts
+++ b/packages/api/src/thinkspaces/approval-surfaces.test.ts
@@ -7,8 +7,8 @@ import { thinkspaces } from "@better-agent/db/schema/thinkspaces";
 
 import { createTestProductDb } from "../testing/product-db";
 import {
-	extractResolvedMemoryApprovals,
-	flipMemoryApprovalInTranscript,
+	extractResolvedApprovals,
+	flipApprovalInTranscript,
 	MEMORY_WRITE_TOOL_PART_TYPE,
 } from "./approvals";
 import type { ThinkspaceApprovalDecision } from "./approvals";
@@ -25,11 +25,11 @@ import {
  * that convergence so the two surfaces can never drift into two mechanisms.
  *
  * - The Review Queue (control plane) flips the held part in place with
- *   `flipMemoryApprovalInTranscript` and resolves the index row directly — what
- *   the runtime's `decideMemoryApproval` does.
+ *   `flipApprovalInTranscript` and resolves the index row directly — what
+ *   the runtime's `decideApproval` does.
  * - An inline Sitting decision drives the agents/ai-chat native tool-approval
  *   transition over the live transcript, and the runtime's `onChatResponse`
- *   reconciliation reads the decided part back out (`extractResolvedMemoryApprovals`)
+ *   reconciliation reads the decided part back out (`extractResolvedApprovals`)
  *   and resolves the same index row.
  */
 
@@ -111,7 +111,7 @@ test("an inline Sitting decision reconciles to the same outcome the control-plan
 		const approved = decision === "approved";
 
 		// The Review Queue flips the held part in place.
-		const controlPlane = flipMemoryApprovalInTranscript({
+		const controlPlane = flipApprovalInTranscript({
 			decision,
 			messages: parkedTranscript(),
 			toolCallId: TOOL_CALL_ID,
@@ -124,8 +124,8 @@ test("an inline Sitting decision reconciles to the same outcome the control-plan
 		// The runtime's index reconciliation reads both surfaces to the identical
 		// resolution — even though an inline reject lands in `output-denied` while a
 		// control-plane reject lands in `approval-responded`.
-		const fromControlPlane = extractResolvedMemoryApprovals(controlPlane.messages);
-		const fromInline = extractResolvedMemoryApprovals(inline);
+		const fromControlPlane = extractResolvedApprovals(controlPlane.messages);
+		const fromInline = extractResolvedApprovals(inline);
 
 		assert.deepEqual(fromInline, fromControlPlane);
 		assert.deepEqual(fromInline, [{ status: decision, toolCallId: TOOL_CALL_ID }]);
@@ -138,7 +138,7 @@ test("either surface resolves the same pending Approval row out of the queue", a
 		const resolvedAt = new Date();
 
 		// The control plane resolves the row with the decision directly, the way
-		// `decideMemoryApproval` does after flipping the transcript.
+		// `decideApproval` does after flipping the transcript.
 		const controlPlaneDb = createTestProductDb();
 		await seed(controlPlaneDb);
 		const controlPlaneRow = await resolveThinkspaceApproval(controlPlaneDb, {
@@ -153,7 +153,7 @@ test("either surface resolves the same pending Approval row out of the queue", a
 		// through the same repository call.
 		const inlineDb = createTestProductDb();
 		await seed(inlineDb);
-		const [resolution] = extractResolvedMemoryApprovals(
+		const [resolution] = extractResolvedApprovals(
 			applyInlineNativeDecision(parkedTranscript(), approved),
 		);
 		assert.ok(resolution);

--- a/packages/api/src/thinkspaces/approvals.test.ts
+++ b/packages/api/src/thinkspaces/approvals.test.ts
@@ -2,9 +2,14 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-	extractPendingMemoryApprovals,
-	extractResolvedMemoryApprovals,
-	flipMemoryApprovalInTranscript,
+	CREATE_GITHUB_ISSUE_TOOL_PART_TYPE,
+	extractPendingApprovals,
+	extractResolvedApprovals,
+	flipApprovalInTranscript,
+	MEMORY_WRITE_TOOL_PART_TYPE,
+	parseProposedGitHubIssue,
+	readProposedGitHubIssue,
+	summarizeGitHubIssueProposal,
 	summarizeMemoryProposal,
 } from "./approvals";
 
@@ -13,30 +18,63 @@ const memoryPart = (overrides: Record<string, unknown> = {}) => ({
 	input: { content: "The user prefers Vendor A." },
 	state: "approval-requested",
 	toolCallId: "tool_call_1",
-	type: "tool-memory_write",
+	type: MEMORY_WRITE_TOOL_PART_TYPE,
+	...overrides,
+});
+
+const githubPart = (overrides: Record<string, unknown> = {}) => ({
+	approval: { id: "approval_req_gh" },
+	input: {
+		body: "Steps to reproduce the flake.",
+		repo: "octocat/hello-world",
+		title: "Fix the flaky test",
+	},
+	state: "approval-requested",
+	toolCallId: "tool_call_gh",
+	type: CREATE_GITHUB_ISSUE_TOOL_PART_TYPE,
 	...overrides,
 });
 
 const assistant = (parts: Record<string, unknown>[]) => ({ parts, role: "assistant" });
 
-test("a parked Memory proposal is extracted with the durable handles a decision needs", () => {
-	const pending = extractPendingMemoryApprovals([
+test("a parked Memory proposal is extracted with its kind and durable handles", () => {
+	const pending = extractPendingApprovals([
 		assistant([{ text: "Working on it.", type: "text" }, memoryPart()]),
 	]);
 
 	assert.deepEqual(pending, [
 		{
+			actionKind: "memory_write",
 			approvalRequestId: "approval_req_1",
-			content: "The user prefers Vendor A.",
+			proposedContent: "The user prefers Vendor A.",
+			proposedSummary: 'Proposed a durable Product Memory: "The user prefers Vendor A."',
 			toolCallId: "tool_call_1",
 		},
 	]);
 });
 
-test("malformed or non-Memory holds never surface as decidable Approvals", () => {
-	const pending = extractPendingMemoryApprovals([
+test("a parked GitHub-issue proposal is extracted with a serialized payload and a repo-bearing summary", () => {
+	const [pending, ...rest] = extractPendingApprovals([
+		assistant([{ text: "Drafting an issue.", type: "text" }, githubPart()]),
+	]);
+
+	assert.equal(rest.length, 0);
+	assert.ok(pending);
+	assert.equal(pending.actionKind, "github_create_issue");
+	assert.equal(pending.approvalRequestId, "approval_req_gh");
+	assert.equal(pending.toolCallId, "tool_call_gh");
+	assert.equal(pending.proposedSummary, 'Create issue "Fix the flaky test" in octocat/hello-world');
+	assert.deepEqual(parseProposedGitHubIssue(pending.proposedContent), {
+		body: "Steps to reproduce the flake.",
+		repo: "octocat/hello-world",
+		title: "Fix the flaky test",
+	});
+});
+
+test("malformed or unregistered holds never surface as decidable Approvals", () => {
+	const pending = extractPendingApprovals([
 		assistant([
-			// A different tool awaiting approval is not this index's concern.
+			// A different tool awaiting approval is not the index's concern.
 			{
 				approval: { id: "a" },
 				state: "approval-requested",
@@ -49,29 +87,31 @@ test("malformed or non-Memory holds never surface as decidable Approvals", () =>
 			memoryPart({ input: {}, toolCallId: "tool_call_2" }),
 			// Not in the requested state.
 			memoryPart({ state: "output-available", toolCallId: "tool_call_3" }),
+			// A GitHub hold missing its repo cannot name a target, so it is skipped.
+			githubPart({ input: { body: "b", title: "t" }, toolCallId: "tool_call_4" }),
 		]),
 	]);
 
 	assert.deepEqual(pending, []);
 });
 
-test("decided Memory holds are read back with their outcome for index reconciliation", () => {
-	const resolved = extractResolvedMemoryApprovals([
+test("decided holds of either kind are read back with their outcome for index reconciliation", () => {
+	const resolved = extractResolvedApprovals([
 		assistant([
 			memoryPart({
 				approval: { approved: true, id: "a" },
 				state: "output-available",
-				toolCallId: "approved_executed",
+				toolCallId: "memory_executed",
 			}),
-			memoryPart({
-				approval: { approved: false, id: "b" },
+			githubPart({
+				approval: { approved: true, id: "b" },
+				state: "output-available",
+				toolCallId: "issue_created",
+			}),
+			githubPart({
+				approval: { approved: false, id: "c" },
 				state: "output-denied",
-				toolCallId: "rejected",
-			}),
-			memoryPart({
-				approval: { approved: true, id: "c" },
-				state: "approval-responded",
-				toolCallId: "approved_pending",
+				toolCallId: "issue_rejected",
 			}),
 			// Still parked: not yet resolved.
 			memoryPart({ toolCallId: "still_pending" }),
@@ -79,16 +119,16 @@ test("decided Memory holds are read back with their outcome for index reconcilia
 	]);
 
 	assert.deepEqual(resolved, [
-		{ status: "approved", toolCallId: "approved_executed" },
-		{ status: "rejected", toolCallId: "rejected" },
-		{ status: "approved", toolCallId: "approved_pending" },
+		{ status: "approved", toolCallId: "memory_executed" },
+		{ status: "approved", toolCallId: "issue_created" },
+		{ status: "rejected", toolCallId: "issue_rejected" },
 	]);
 });
 
 test("approving flips exactly the matching parked hold to approval-responded, preserving the approval id", () => {
 	const messages = [assistant([{ text: "Note.", type: "text" }, memoryPart()])];
 
-	const result = flipMemoryApprovalInTranscript({
+	const result = flipApprovalInTranscript({
 		decision: "approved",
 		messages,
 		toolCallId: "tool_call_1",
@@ -107,10 +147,25 @@ test("approving flips exactly the matching parked hold to approval-responded, pr
 	assert.equal((inputMessage.parts[1] as Record<string, unknown>).state, "approval-requested");
 });
 
+test("the flip is action-kind-agnostic: a parked GitHub-issue hold flips the same way", () => {
+	const messages = [assistant([githubPart()])];
+
+	const result = flipApprovalInTranscript({
+		decision: "approved",
+		messages,
+		toolCallId: "tool_call_gh",
+	});
+
+	assert.equal(result.flipped, true);
+	const flippedPart = result.messages[0]?.parts?.[0] as Record<string, unknown>;
+	assert.equal(flippedPart.state, "approval-responded");
+	assert.deepEqual(flippedPart.approval, { approved: true, id: "approval_req_gh" });
+});
+
 test("rejecting flips the hold to a denial and carries an optional reason", () => {
 	const messages = [assistant([memoryPart()])];
 
-	const result = flipMemoryApprovalInTranscript({
+	const result = flipApprovalInTranscript({
 		decision: "rejected",
 		messages,
 		reason: "Not durable enough.",
@@ -129,7 +184,7 @@ test("rejecting flips the hold to a denial and carries an optional reason", () =
 test("a decision for a hold that is no longer parked reports no flip so the caller fails closed", () => {
 	const messages = [assistant([memoryPart({ state: "output-available" })])];
 
-	const result = flipMemoryApprovalInTranscript({
+	const result = flipApprovalInTranscript({
 		decision: "approved",
 		messages,
 		toolCallId: "tool_call_1",
@@ -146,4 +201,28 @@ test("a Memory proposal summary collapses whitespace and bounds length for the q
 	const long = summarizeMemoryProposal("x".repeat(500));
 	assert.ok(long.length < 500);
 	assert.match(long, /…"$/u);
+});
+
+test("a GitHub-issue summary names the repo prominently and bounds the title", () => {
+	assert.equal(
+		summarizeGitHubIssueProposal({ repo: "octocat/hello-world", title: "  Fix the   flake  " }),
+		'Create issue "Fix the flake" in octocat/hello-world',
+	);
+
+	const long = summarizeGitHubIssueProposal({
+		repo: "octocat/hello-world",
+		title: "x".repeat(500),
+	});
+	assert.ok(long.endsWith(" in octocat/hello-world"));
+	assert.match(long, /…" in /u);
+});
+
+test("a GitHub issue payload round-trips and rejects malformed input", () => {
+	const issue = { body: "b", repo: "octocat/hello-world", title: "t" };
+	assert.deepEqual(readProposedGitHubIssue(issue), issue);
+	assert.deepEqual(parseProposedGitHubIssue(JSON.stringify(issue)), issue);
+
+	assert.equal(readProposedGitHubIssue({ body: "b", title: "t" }), null);
+	assert.equal(readProposedGitHubIssue(null), null);
+	assert.equal(parseProposedGitHubIssue("not json"), null);
 });

--- a/packages/api/src/thinkspaces/approvals.ts
+++ b/packages/api/src/thinkspaces/approvals.ts
@@ -1,24 +1,33 @@
 /**
  * The Approval holdpoint, expressed as pure transcript logic.
  *
- * A held tool (the Memory-proposing tool) is defined to the runtime with
- * Project Think's `needsApproval` mechanism. When the agent calls it, the
- * AI SDK does not execute it; it records a tool part in the `approval-requested`
- * state and parks the turn. Better Agent maps that transport-level pause onto a
- * product-level **Approval**: the owner decides, and the decision flips the part
- * to `approval-responded`, which resumes the parked turn — on approval the
- * tool's `execute` finally runs and writes the Memory; on rejection it never
- * runs and nothing persists (ADR-0006: Think's tool approval is the transport,
- * the product Approval is the authority).
+ * A held tool (the Memory-proposing tool, the GitHub-issue-proposing tool) is
+ * defined to the runtime with Project Think's `needsApproval` mechanism. When
+ * the agent calls it, the AI SDK does not execute it; it records a tool part in
+ * the `approval-requested` state and parks the turn. Better Agent maps that
+ * transport-level pause onto a product-level **Approval**: the owner decides,
+ * and the decision flips the part to `approval-responded`, which resumes the
+ * parked turn — on approval the tool's `execute` finally runs and performs the
+ * action; on rejection it never runs and nothing happens (ADR-0006: Think's
+ * tool approval is the transport, the product Approval is the authority).
  *
  * This module owns the seam in pure functions so it is testable without a live
  * model or the runtime: reading which holds a transcript is carrying, and
- * flipping one hold to its decided state. It imports neither `ai` nor
- * `@cloudflare/think`; it works on the structural shape of a UI message part.
+ * flipping one hold to its decided state. The action-kind-specific bits — which
+ * tool-part type a kind produces, how to pull its proposed payload out of the
+ * part's input, and how to summarize it for the Review Queue — live in a small
+ * per-action-kind **descriptor registry**; the generic skeletons read every
+ * registered kind uniformly. It imports neither `ai` nor `@cloudflare/think`;
+ * it works on the structural shape of a UI message part.
  */
+import { THINKSPACE_APPROVAL_ACTION_KIND } from "@better-agent/db/schema/approvals";
+import type { ThinkspaceApprovalActionKind } from "@better-agent/db/schema/approvals";
 
 /** The runtime tool-part type the held Memory-proposing tool produces. */
 export const MEMORY_WRITE_TOOL_PART_TYPE = "tool-memory_write" as const;
+
+/** The runtime tool-part type the held GitHub-issue-proposing tool produces. */
+export const CREATE_GITHUB_ISSUE_TOOL_PART_TYPE = "tool-create_github_issue" as const;
 
 const APPROVAL_REQUESTED_STATE = "approval-requested";
 const APPROVAL_RESPONDED_STATE = "approval-responded";
@@ -26,21 +35,9 @@ const OUTPUT_AVAILABLE_STATE = "output-available";
 const OUTPUT_DENIED_STATE = "output-denied";
 
 export const MEMORY_PROPOSAL_SUMMARY_MAX_LENGTH = 200;
+export const GITHUB_ISSUE_SUMMARY_TITLE_MAX_LENGTH = 120;
 
 export type ThinkspaceApprovalDecision = "approved" | "rejected";
-
-/** A held Memory proposal awaiting the owner's decision. */
-export interface PendingMemoryApproval {
-	approvalRequestId: string;
-	content: string;
-	toolCallId: string;
-}
-
-/** A held Memory proposal the transcript already shows as decided. */
-export interface ResolvedMemoryApproval {
-	status: ThinkspaceApprovalDecision;
-	toolCallId: string;
-}
 
 interface ApprovalShape {
 	approved?: boolean;
@@ -61,13 +58,22 @@ interface TranscriptMessage {
 	role?: string;
 }
 
-const isMemoryWritePart = (part: TranscriptToolPart): boolean =>
-	part.type === MEMORY_WRITE_TOOL_PART_TYPE;
-
 const toNonEmptyString = (value: unknown): string | null =>
 	typeof value === "string" && value.length > 0 ? value : null;
 
-const proposedContent = (input: unknown): string | null => {
+const collapseWhitespace = (value: string): string => value.replaceAll(/\s+/gu, " ").trim();
+
+const bound = (value: string, maxLength: number): string =>
+	value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
+
+/** A short product-language summary of a proposed Memory for the Review Queue. */
+export const summarizeMemoryProposal = (content: string): string =>
+	`Proposed a durable Product Memory: "${bound(
+		collapseWhitespace(content),
+		MEMORY_PROPOSAL_SUMMARY_MAX_LENGTH,
+	)}"`;
+
+const readMemoryContent = (input: unknown): string | null => {
 	if (typeof input !== "object" || input === null) {
 		return null;
 	}
@@ -77,44 +83,173 @@ const proposedContent = (input: unknown): string | null => {
 	return toNonEmptyString(content);
 };
 
-/** A short product-language summary of a proposed Memory for the Review Queue. */
-export const summarizeMemoryProposal = (content: string): string => {
-	const collapsed = content.replaceAll(/\s+/gu, " ").trim();
-	const bounded =
-		collapsed.length > MEMORY_PROPOSAL_SUMMARY_MAX_LENGTH
-			? `${collapsed.slice(0, MEMORY_PROPOSAL_SUMMARY_MAX_LENGTH - 1)}…`
-			: collapsed;
-
-	return `Proposed a durable Product Memory: "${bounded}"`;
-};
+/** A proposed GitHub issue, the payload the held `create_github_issue` tool carries. */
+export interface ProposedGitHubIssue {
+	body: string;
+	repo: string;
+	title: string;
+}
 
 /**
- * Every held Memory proposal a transcript is currently parked on. A part counts
- * as pending only when it is a Memory-write part in the `approval-requested`
- * state with the durable handles a decision needs (tool call id, approval
- * request id) and a non-empty proposed content; anything malformed is skipped
- * and stays held, never surfacing as a decidable Approval.
+ * Pulls a proposed GitHub issue out of a held tool part's `input` (or any
+ * object shaped like one), requiring a non-empty repo, title, and body;
+ * anything malformed is null so the hold stays held and never surfaces a card
+ * with nothing to decide.
  */
-export const extractPendingMemoryApprovals = (
+export const readProposedGitHubIssue = (input: unknown): ProposedGitHubIssue | null => {
+	if (typeof input !== "object" || input === null) {
+		return null;
+	}
+
+	const { body, repo, title } = input as Record<string, unknown>;
+	const boundedBody = toNonEmptyString(body);
+	const boundedRepo = toNonEmptyString(repo);
+	const boundedTitle = toNonEmptyString(title);
+
+	if (!(boundedBody && boundedRepo && boundedTitle)) {
+		return null;
+	}
+
+	return { body: boundedBody, repo: boundedRepo, title: boundedTitle };
+};
+
+const serializeProposedGitHubIssue = (proposal: ProposedGitHubIssue): string =>
+	JSON.stringify({ body: proposal.body, repo: proposal.repo, title: proposal.title });
+
+/**
+ * Parses a serialized `proposed_content` GitHub issue payload back into its
+ * fields for the Review Queue. Null when the stored content is not a
+ * well-formed issue payload, so a malformed row renders nothing rather than
+ * throwing.
+ */
+export const parseProposedGitHubIssue = (proposedContent: string): ProposedGitHubIssue | null => {
+	try {
+		return readProposedGitHubIssue(JSON.parse(proposedContent) as unknown);
+	} catch {
+		return null;
+	}
+};
+
+/** A short product-language summary of a proposed GitHub issue for the Review Queue. */
+export const summarizeGitHubIssueProposal = ({
+	repo,
+	title,
+}: Pick<ProposedGitHubIssue, "repo" | "title">): string =>
+	`Create issue "${bound(
+		collapseWhitespace(title),
+		GITHUB_ISSUE_SUMMARY_TITLE_MAX_LENGTH,
+	)}" in ${collapseWhitespace(repo)}`;
+
+/**
+ * One held action kind's transcript shape: which tool-part type it produces and
+ * how to turn a parked part's `input` into the durable `proposed_content` (the
+ * serialized payload) plus a human `proposed_summary`. `describeProposal`
+ * returns null for a malformed input so the hold is skipped and never surfaces
+ * as a decidable Approval.
+ */
+interface ApprovalActionDescriptor {
+	actionKind: ThinkspaceApprovalActionKind;
+	describeProposal: (input: unknown) => { proposedContent: string; proposedSummary: string } | null;
+	partType: string;
+}
+
+const memoryWriteDescriptor: ApprovalActionDescriptor = {
+	actionKind: THINKSPACE_APPROVAL_ACTION_KIND.MEMORY_WRITE,
+	describeProposal: (input) => {
+		const content = readMemoryContent(input);
+
+		if (!content) {
+			return null;
+		}
+
+		return { proposedContent: content, proposedSummary: summarizeMemoryProposal(content) };
+	},
+	partType: MEMORY_WRITE_TOOL_PART_TYPE,
+};
+
+const githubCreateIssueDescriptor: ApprovalActionDescriptor = {
+	actionKind: THINKSPACE_APPROVAL_ACTION_KIND.GITHUB_CREATE_ISSUE,
+	describeProposal: (input) => {
+		const proposal = readProposedGitHubIssue(input);
+
+		if (!proposal) {
+			return null;
+		}
+
+		return {
+			proposedContent: serializeProposedGitHubIssue(proposal),
+			proposedSummary: summarizeGitHubIssueProposal(proposal),
+		};
+	},
+	partType: CREATE_GITHUB_ISSUE_TOOL_PART_TYPE,
+};
+
+const APPROVAL_ACTION_DESCRIPTORS: readonly ApprovalActionDescriptor[] = [
+	memoryWriteDescriptor,
+	githubCreateIssueDescriptor,
+];
+
+const descriptorByPartType = new Map<string, ApprovalActionDescriptor>(
+	APPROVAL_ACTION_DESCRIPTORS.map((descriptor) => [descriptor.partType, descriptor]),
+);
+
+const descriptorForPart = (part: TranscriptToolPart): ApprovalActionDescriptor | undefined =>
+	typeof part.type === "string" ? descriptorByPartType.get(part.type) : undefined;
+
+/** A held proposal awaiting the owner's decision, of any registered action kind. */
+export interface PendingApproval {
+	actionKind: ThinkspaceApprovalActionKind;
+	approvalRequestId: string;
+	proposedContent: string;
+	proposedSummary: string;
+	toolCallId: string;
+}
+
+/** A held proposal the transcript already shows as decided. */
+export interface ResolvedApproval {
+	status: ThinkspaceApprovalDecision;
+	toolCallId: string;
+}
+
+/**
+ * Every held proposal a transcript is currently parked on. A part counts as
+ * pending only when it is a registered held-action part in the
+ * `approval-requested` state with the durable handles a decision needs (tool
+ * call id, approval request id) and a well-formed proposed payload; anything
+ * malformed is skipped and stays held, never surfacing as a decidable Approval.
+ */
+export const extractPendingApprovals = (
 	messages: readonly TranscriptMessage[],
-): PendingMemoryApproval[] => {
-	const pending: PendingMemoryApproval[] = [];
+): PendingApproval[] => {
+	const pending: PendingApproval[] = [];
 
 	for (const message of messages) {
 		for (const part of message.parts ?? []) {
-			if (!(isMemoryWritePart(part) && part.state === APPROVAL_REQUESTED_STATE)) {
+			if (part.state !== APPROVAL_REQUESTED_STATE) {
+				continue;
+			}
+
+			const descriptor = descriptorForPart(part);
+
+			if (!descriptor) {
 				continue;
 			}
 
 			const toolCallId = toNonEmptyString(part.toolCallId);
 			const approvalRequestId = toNonEmptyString(part.approval?.id);
-			const content = proposedContent(part.input);
+			const proposal = descriptor.describeProposal(part.input);
 
-			if (!(toolCallId && approvalRequestId && content)) {
+			if (!(toolCallId && approvalRequestId && proposal)) {
 				continue;
 			}
 
-			pending.push({ approvalRequestId, content, toolCallId });
+			pending.push({
+				actionKind: descriptor.actionKind,
+				approvalRequestId,
+				proposedContent: proposal.proposedContent,
+				proposedSummary: proposal.proposedSummary,
+				toolCallId,
+			});
 		}
 	}
 
@@ -134,18 +269,18 @@ const resolvedStatus = (part: TranscriptToolPart): ThinkspaceApprovalDecision | 
 };
 
 /**
- * Every held Memory proposal the transcript already shows as decided. Lets the
- * index reconcile rows the owner decided through another surface (a later
- * inline Sitting decision) back out of the Review Queue.
+ * Every held proposal the transcript already shows as decided. Lets the index
+ * reconcile rows the owner decided through another surface (a later inline
+ * Sitting decision) back out of the Review Queue.
  */
-export const extractResolvedMemoryApprovals = (
+export const extractResolvedApprovals = (
 	messages: readonly TranscriptMessage[],
-): ResolvedMemoryApproval[] => {
-	const resolved: ResolvedMemoryApproval[] = [];
+): ResolvedApproval[] => {
+	const resolved: ResolvedApproval[] = [];
 
 	for (const message of messages) {
 		for (const part of message.parts ?? []) {
-			if (!isMemoryWritePart(part) || part.state === APPROVAL_REQUESTED_STATE) {
+			if (!descriptorForPart(part) || part.state === APPROVAL_REQUESTED_STATE) {
 				continue;
 			}
 
@@ -161,27 +296,20 @@ export const extractResolvedMemoryApprovals = (
 	return resolved;
 };
 
-export interface FlipMemoryApprovalInput {
-	decision: ThinkspaceApprovalDecision;
-	messages: readonly TranscriptMessage[];
-	reason?: string;
-	toolCallId: string;
-}
-
-export interface FlipMemoryApprovalResult<TMessage> {
+export interface FlipApprovalResult<TMessage> {
 	flipped: boolean;
 	messages: TMessage[];
 }
 
 /**
- * Records the owner's decision on one parked Memory proposal by flipping its
+ * Records the owner's decision on one parked proposal by flipping its
  * `approval-requested` part to `approval-responded`, preserving the part's
  * approval id (the AI SDK keys its continuation on it). Pure: it never mutates
- * the input, only flips the single part whose tool call id matches and that is
- * still awaiting a decision, and reports whether a flip happened so the caller
- * can fail closed when the hold is already gone.
+ * the input, only flips the single registered held part whose tool call id
+ * matches and that is still awaiting a decision, and reports whether a flip
+ * happened so the caller can fail closed when the hold is already gone.
  */
-export const flipMemoryApprovalInTranscript = <TMessage extends TranscriptMessage>({
+export const flipApprovalInTranscript = <TMessage extends TranscriptMessage>({
 	decision,
 	messages,
 	reason,
@@ -191,7 +319,7 @@ export const flipMemoryApprovalInTranscript = <TMessage extends TranscriptMessag
 	messages: readonly TMessage[];
 	reason?: string;
 	toolCallId: string;
-}): FlipMemoryApprovalResult<TMessage> => {
+}): FlipApprovalResult<TMessage> => {
 	let flipped = false;
 
 	const next = messages.map((message) => ({
@@ -199,7 +327,7 @@ export const flipMemoryApprovalInTranscript = <TMessage extends TranscriptMessag
 		parts: (message.parts ?? []).map((part) => {
 			if (
 				flipped ||
-				!isMemoryWritePart(part) ||
+				!descriptorForPart(part) ||
 				part.state !== APPROVAL_REQUESTED_STATE ||
 				part.toolCallId !== toolCallId
 			) {

--- a/packages/api/src/thinkspaces/connected-account-runtime-tools.ts
+++ b/packages/api/src/thinkspaces/connected-account-runtime-tools.ts
@@ -23,6 +23,12 @@ import { z } from "zod";
 
 import { GitHubIssueCreationError } from "../connected-accounts/github-issues";
 import type { ActiveAgentProfileRevision } from "./agent-profile";
+import {
+	CONNECTED_ACCOUNT_TOOL_IDS,
+	CREATE_GITHUB_ISSUE_TOOL_ID,
+	isConnectedAccountToolId,
+} from "./connected-account-tools";
+import type { ConnectedAccountToolId } from "./connected-account-tools";
 import type { ThinkspaceGitHubIssueCreator } from "./github-issue-creator";
 import { markThinkspaceTurnProductSafeError } from "./inspect";
 import type { ThinkspacePermissionPolicy } from "./permission-policy";
@@ -44,26 +50,26 @@ export const THINKSPACE_GITHUB_ISSUE_BODY_MAX_LENGTH = 60_000;
 const GITHUB_REPO_MAX_LENGTH = 200;
 
 /**
- * The held GitHub-issue tool. Its **runtime name** (the toolset key, the
+ * The held GitHub-issue tool's **runtime name** (the toolset key, the
  * `ctx.toolName` at the call boundary, and the `tool-create_github_issue`
- * transcript part) is `create_github_issue`; its **product tool id** (the
- * enablement id, the entry in `assembly.activeTools`, and the Permission keying)
- * is `github:create_issue` in the locked `${catalogId}:${toolName}` convention.
+ * transcript part). Its **product tool id** (the enablement id, the entry in
+ * `assembly.activeTools`, and the Permission keying) is `github:create_issue`,
+ * defined in the `ai`-free `connected-account-tools.ts` and re-exported here.
  */
 export const CREATE_GITHUB_ISSUE_TOOL_NAME = "create_github_issue";
-export const CREATE_GITHUB_ISSUE_TOOL_ID = "github:create_issue";
+export { CREATE_GITHUB_ISSUE_TOOL_ID };
 
 /**
- * The external-mutation product tool ids. `github:create_issue` is the only one
- * today; mirrors MCP's `serverId:tool` form and the connected-account
- * Permission/credential lookup.
+ * The external-mutation product tool ids — the connected-account tool catalog
+ * viewed as held external writes. The catalog is owned by
+ * `connected-account-tools.ts`; this is the same set under the runtime's name
+ * for it (mirrors MCP's `serverId:tool` form and the credential lookup).
  */
-export const EXTERNAL_MUTATION_TOOL_IDS = [CREATE_GITHUB_ISSUE_TOOL_ID] as const;
+export const EXTERNAL_MUTATION_TOOL_IDS = CONNECTED_ACCOUNT_TOOL_IDS;
 
-export type ExternalMutationToolId = (typeof EXTERNAL_MUTATION_TOOL_IDS)[number];
+export type ExternalMutationToolId = ConnectedAccountToolId;
 
-export const isExternalMutationToolId = (value: string): value is ExternalMutationToolId =>
-	EXTERNAL_MUTATION_TOOL_IDS.includes(value as ExternalMutationToolId);
+export const isExternalMutationToolId = isConnectedAccountToolId;
 
 const activeExternalMutationToolIds = (
 	activeProductToolIds: readonly string[],

--- a/packages/api/src/thinkspaces/connected-account-tools.test.ts
+++ b/packages/api/src/thinkspaces/connected-account-tools.test.ts
@@ -2,10 +2,22 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+	CONNECTED_ACCOUNT_TOOL_IDS,
 	connectedAccountCatalogIdFromToolId,
 	connectedAccountToolPermissionKind,
+	CREATE_GITHUB_ISSUE_TOOL_ID,
 	createConnectedAccountToolPermissionRequests,
+	isConnectedAccountToolId,
 } from "./connected-account-tools";
+
+test("the connected-account tool catalog is the source of truth for equippable tool ids", () => {
+	assert.equal(CREATE_GITHUB_ISSUE_TOOL_ID, "github:create_issue");
+	assert.deepEqual([...CONNECTED_ACCOUNT_TOOL_IDS], ["github:create_issue"]);
+	assert.equal(isConnectedAccountToolId("github:create_issue"), true);
+	assert.equal(isConnectedAccountToolId("memory_write"), false);
+	assert.equal(isConnectedAccountToolId("github"), false);
+	assert.equal(isConnectedAccountToolId(""), false);
+});
 
 test("derives the catalog id from a connected-account tool id", () => {
 	assert.equal(connectedAccountCatalogIdFromToolId("github:create_issue"), "github");

--- a/packages/api/src/thinkspaces/connected-account-tools.ts
+++ b/packages/api/src/thinkspaces/connected-account-tools.ts
@@ -13,6 +13,28 @@ import { THINKSPACE_PERMISSION_KINDS } from "@better-agent/db/schema/permissions
 
 import type { ConnectedAccountCredentialPermissionRequest } from "./agent-profile";
 
+/**
+ * The held GitHub-issue tool's **product tool id**, in the locked
+ * `${catalogId}:${toolName}` convention. The runtime tool factory's name for it
+ * (`create_github_issue`) and its `ai` dependency live in
+ * `connected-account-runtime-tools.ts`; this id lives here, in the `ai`-free
+ * catalog mapper, so the equip surface (the router's selection enum, the
+ * profile editor) can reference it without pulling the runtime tool in.
+ */
+export const CREATE_GITHUB_ISSUE_TOOL_ID = "github:create_issue" as const;
+
+/**
+ * The connected-account product tool ids a Thinkspace can equip — the source
+ * of truth mirrored by `EXTERNAL_MUTATION_TOOL_IDS` in the runtime tools, in
+ * the same role `BUILT_IN_TOOL_IDS` plays for built-ins.
+ */
+export const CONNECTED_ACCOUNT_TOOL_IDS = [CREATE_GITHUB_ISSUE_TOOL_ID] as const;
+
+export type ConnectedAccountToolId = (typeof CONNECTED_ACCOUNT_TOOL_IDS)[number];
+
+export const isConnectedAccountToolId = (value: string): value is ConnectedAccountToolId =>
+	CONNECTED_ACCOUNT_TOOL_IDS.includes(value as ConnectedAccountToolId);
+
 export type ConnectedAccountToolPermissionKind =
 	typeof THINKSPACE_PERMISSION_KINDS.CONNECTED_ACCOUNT_CREDENTIAL;
 

--- a/packages/api/src/thinkspaces/router.test.ts
+++ b/packages/api/src/thinkspaces/router.test.ts
@@ -516,6 +516,43 @@ test("enabling built-in tools writes built_in enablements and deduped Permission
 	);
 });
 
+test("enabling a connected-account tool writes a connected_account enablement and a credential request", async () => {
+	const { db, saved } = createDbForAgentProfileDraftUpdate(
+		ownedThinkspaceRow({ ...ownedAgentProfileColumns("draft"), status: "draft" }),
+	);
+	const context = createCallContext({ db });
+
+	const updated = await call(
+		thinkspacesRouter.updateToolSelections,
+		{
+			connectedAccountToolIds: ["github:create_issue"],
+			selections: [],
+			thinkspaceId: OWNED_THINKSPACE_ID,
+		},
+		{ context },
+	);
+
+	assert.ok(updated);
+	assert.deepEqual(JSON.parse(String(saved[0]?.toolEnablements)), [
+		{ source: "connected_account", toolId: "github:create_issue" },
+	]);
+
+	// One credential request per catalog id, keyed by the connected_account_catalog
+	// id, alongside the always-present model provider credential request.
+	const requests = JSON.parse(String(saved[0]?.requestedPermissions)) as {
+		catalogId?: string;
+		kind: string;
+	}[];
+	assert.deepEqual(
+		requests.map((request) => request.kind).toSorted((left, right) => left.localeCompare(right)),
+		["connected_account_credential", "model_provider_credential"],
+	);
+	assert.equal(
+		requests.find((request) => request.kind === "connected_account_credential")?.catalogId,
+		"github",
+	);
+});
+
 test("activating granted built-in requests creates the two Permission kinds with their resource identities", async () => {
 	const db = createTestProductDb();
 	await seedRealThinkspaceWithProfile({

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -45,6 +45,11 @@ import {
 } from "./permissions";
 import { BUILT_IN_TOOL_IDS, createBuiltInToolPermissionRequests } from "./built-in-tools";
 import type { BuiltInToolId } from "./built-in-tools";
+import {
+	CONNECTED_ACCOUNT_TOOL_IDS,
+	createConnectedAccountToolPermissionRequests,
+} from "./connected-account-tools";
+import type { ConnectedAccountToolId } from "./connected-account-tools";
 import { createMcpToolAccessPermissionRequest, serializeThinkspaceToolSelections } from "./policy";
 import {
 	createThinkspaceArchivePatch,
@@ -97,6 +102,7 @@ const toolSelectionSchema = z.object({
 
 const updateToolSelectionsInput = z.object({
 	builtInToolIds: z.array(z.enum(BUILT_IN_TOOL_IDS)).optional(),
+	connectedAccountToolIds: z.array(z.enum(CONNECTED_ACCOUNT_TOOL_IDS)).optional(),
 	selections: z.array(toolSelectionSchema),
 	thinkspaceId: z.string().min(1),
 });
@@ -122,8 +128,18 @@ const normalizeBuiltInToolIds = (toolIds: readonly BuiltInToolId[]): BuiltInTool
 	return BUILT_IN_TOOL_IDS.filter((toolId) => requested.has(toolId));
 };
 
+/** Deduped, in stable catalog order, mirroring `normalizeBuiltInToolIds`. */
+const normalizeConnectedAccountToolIds = (
+	toolIds: readonly ConnectedAccountToolId[],
+): ConnectedAccountToolId[] => {
+	const requested = new Set(toolIds);
+
+	return CONNECTED_ACCOUNT_TOOL_IDS.filter((toolId) => requested.has(toolId));
+};
+
 const toToolEnablements = (
 	builtInToolIds: readonly BuiltInToolId[],
+	connectedAccountToolIds: readonly ConnectedAccountToolId[],
 	selections: z.infer<typeof toolSelectionSchema>[],
 ): ToolEnablement[] => {
 	const normalized = JSON.parse(serializeThinkspaceToolSelections(selections)) as z.infer<
@@ -134,6 +150,12 @@ const toToolEnablements = (
 		...builtInToolIds.map(
 			(toolId): ToolEnablement => ({
 				source: "built_in",
+				toolId,
+			}),
+		),
+		...connectedAccountToolIds.map(
+			(toolId): ToolEnablement => ({
+				source: "connected_account",
 				toolId,
 			}),
 		),
@@ -153,8 +175,8 @@ const toToolEnablements = (
  * requests Permission to use the owner's saved credential for that model's
  * provider. The owner grants it at activation (the default grants all requests),
  * which is what makes model resolution potent — without this grant the runtime
- * fails closed with `permission_required`. Built-in and MCP tool requests are
- * added on top from the user's selections.
+ * fails closed with `permission_required`. Built-in, connected-account, and MCP
+ * tool requests are added on top from the user's selections.
  */
 const createModelProviderCredentialPermissionRequest = (modelId: string): RequestedPermission => ({
 	kind: "model_provider_credential",
@@ -165,10 +187,12 @@ const createModelProviderCredentialPermissionRequest = (modelId: string): Reques
 const toRequestedPermissions = (
 	modelId: string,
 	builtInToolIds: readonly BuiltInToolId[],
+	connectedAccountToolIds: readonly ConnectedAccountToolId[],
 	selections: z.infer<typeof toolSelectionSchema>[],
 ): RequestedPermission[] => [
 	createModelProviderCredentialPermissionRequest(modelId),
 	...createBuiltInToolPermissionRequests(builtInToolIds),
+	...createConnectedAccountToolPermissionRequests(connectedAccountToolIds),
 	...selections.map((selection) => createMcpToolAccessPermissionRequest(selection)),
 ];
 
@@ -395,7 +419,7 @@ export const thinkspacesRouter = {
 				id: createAgentProfileRevisionId(),
 				identity,
 				modelBehavior,
-				requestedPermissions: toRequestedPermissions(modelBehavior.modelId, [], []),
+				requestedPermissions: toRequestedPermissions(modelBehavior.modelId, [], [], []),
 				thinkspaceId: record.id,
 			});
 			const created = await createThinkspaceWithAgentProfileDraft(context.db, { draft, record });
@@ -645,15 +669,23 @@ export const thinkspacesRouter = {
 				}
 
 				const builtInToolIds = normalizeBuiltInToolIds(input.builtInToolIds ?? []);
+				const connectedAccountToolIds = normalizeConnectedAccountToolIds(
+					input.connectedAccountToolIds ?? [],
+				);
 				const updatedDraft = await saveAgentProfileDraft(context.db, {
 					draft: {
 						...draft,
 						requestedPermissions: toRequestedPermissions(
 							draft.modelBehavior.modelId,
 							builtInToolIds,
+							connectedAccountToolIds,
 							input.selections,
 						),
-						toolEnablements: toToolEnablements(builtInToolIds, input.selections),
+						toolEnablements: toToolEnablements(
+							builtInToolIds,
+							connectedAccountToolIds,
+							input.selections,
+						),
 						updatedAt: new Date(),
 					},
 				});

--- a/packages/db/src/schema/approvals.ts
+++ b/packages/db/src/schema/approvals.ts
@@ -21,15 +21,28 @@ export type ThinkspaceApprovalStatus =
 	(typeof THINKSPACE_APPROVAL_STATUS)[keyof typeof THINKSPACE_APPROVAL_STATUS];
 
 /**
- * The class of action a pending Approval holds. The first (and only) held
- * action in this slice is the agent proposing a durable Product Memory.
+ * The class of action a pending Approval holds. The first held action was the
+ * agent proposing a durable Product Memory; `github_create_issue` is the first
+ * held *external* mutation (PRD #108). Both reuse `proposed_content` /
+ * `proposed_summary`, so adding a kind needs no migration.
  */
 export const THINKSPACE_APPROVAL_ACTION_KIND = {
+	GITHUB_CREATE_ISSUE: "github_create_issue",
 	MEMORY_WRITE: "memory_write",
 } as const;
 
 export type ThinkspaceApprovalActionKind =
 	(typeof THINKSPACE_APPROVAL_ACTION_KIND)[keyof typeof THINKSPACE_APPROVAL_ACTION_KIND];
+
+/**
+ * Whether a stored `action_kind` string is one the product still understands.
+ * The decide path uses this to fail closed on an unknown kind rather than
+ * trusting an arbitrary row value.
+ */
+export const isThinkspaceApprovalActionKind = (
+	value: string,
+): value is ThinkspaceApprovalActionKind =>
+	(Object.values(THINKSPACE_APPROVAL_ACTION_KIND) as string[]).includes(value);
 
 /**
  * The D1 index half of a pending Approval (ADR-0002): the authoritative


### PR DESCRIPTION
## Parent
PRD #108. Closes #114.

Generalizes the memory-shaped Approval seam to be action-kind-agnostic, renders the held GitHub-issue Approval on both decision surfaces, and lands the connected-account **equip surface** deferred from #113 (so #115 can run end to end). No migration.

## Job 1 — approval seam → action kinds
- `approvals.ts` is driven by a per-action-kind **descriptor registry** (partType filter + payload extractor + summarizer). `memory_write` and `github_create_issue` are both registered; the generic skeletons (`extractPendingApprovals` / `extractResolvedApprovals` / `flipApprovalInTranscript`) read every kind uniformly.
- `GITHUB_CREATE_ISSUE` added to `THINKSPACE_APPROVAL_ACTION_KIND` + an `isThinkspaceApprovalActionKind` guard. The issue payload round-trips through `proposed_content` (JSON) / `proposed_summary` — **no schema change**.
- `decideMemoryApproval` → `decideApproval` (DO + `approval-decisions.ts`), guard generalized via `isThinkspaceApprovalActionKind`, reconcile loop kind-agnostic. The `approvals.decide` oRPC and `continueLastTurn()` resume path are unchanged in shape.
- Render the held GitHub-issue Approval inline in a Sitting and in the Review Queue with the **repo prominent** (the `approvals.list` row now carries `proposedContent`).

## Job 2 — connected-account equip surface (deferred from #113)
- Relocated the connected-account tool-id catalog into the `ai`-free `connected-account-tools.ts` (mirrors `BUILT_IN_TOOL_IDS`); `EXTERNAL_MUTATION_TOOL_IDS` re-derives from it.
- `updateToolSelections` accepts `connectedAccountToolIds`; `toToolEnablements` emits `source: "connected_account"` enablements and `toRequestedPermissions` wires in `createConnectedAccountToolPermissionRequests` (the grant side already exists from #111).
- Profile editor: a checkbox to enable `github:create_issue`, preserving connected-account selections across every toggle; the `connected_account_credential` requested/granted Permission now renders with a label.

## Acceptance criteria
- [x] `approvals.ts` is descriptor-driven; both kinds registered; generic skeletons unchanged
- [x] `GITHUB_CREATE_ISSUE` exists; payload round-trips through `proposedContent`/`proposedSummary`, no migration
- [x] `decideApproval` resolves both kinds; the memory round trip is unaffected
- [x] A held GitHub-issue proposal renders inline in a Sitting and in the Review Queue, repo prominent
- [x] Reconciliation (pending in / resolved out) works for issue Approvals the same as memory
- [x] Extractor/flip/decide tests cover both kinds
- [x] Equip surface: `updateToolSelections` writes `connected_account` enablement + `connected_account_credential` request; profile-editor checkbox
- [x] Type checks (api/server/ui), Ultracite, and `bun test packages/api` (314/314) pass

## Review
High-effort multi-agent code review run before merge (8 finder angles). It surfaced one real completeness gap — the new `connected_account_credential` request was unmodeled in the profile editor's permission view (also cleared two pre-existing web type errors) — fixed here; and a now-inaccurate idempotency comment in the decide path, corrected. Remaining findings were source-of-truth duplication that matches the file's existing `BUILT_IN_TOOLS` precedent.

## Not in scope
- Live end-to-end verification + smoke checklist (#115; needs a user-supplied fine-grained GitHub PAT).