### PR TITLE
Backend: CuratorAgent Durable Object skeleton (fail-closed curation runtime)

### DIFF
--- a/apps/server/src/agents/curator-agent.ts
+++ b/apps/server/src/agents/curator-agent.ts
@@ -1,0 +1,146 @@
+import type { LanguageModelV3 } from "@ai-sdk/provider";
+import {
+	CURATION_CONTEXT_STORAGE_KEY,
+	CURATION_FORWARD_CONTEXT_HEADER,
+	decodeCurationForwardContext,
+	matchesCurationForwardContext,
+} from "@better-agent/api/curator/forward-context";
+import type { CurationForwardContext } from "@better-agent/api/curator/forward-context";
+import { CURATOR_RUNTIME_MAX_STEPS } from "@better-agent/api/curator/runtime";
+import { CURATOR_SYSTEM_PROMPT } from "@better-agent/api/curator/system-prompt";
+import {
+	CuratorModelUnavailableError,
+	getUserCuratorModelSettings,
+	resolveCuratorModel,
+} from "@better-agent/api/models/curator";
+import { createDb } from "@better-agent/db";
+import type { ProductDb } from "@better-agent/db";
+import type { CloudflareEnv } from "@better-agent/env/types";
+import { Think } from "@cloudflare/think";
+import type { LanguageModel, ToolSet } from "ai";
+
+/**
+ * Placeholder returned by getModel(). Never used for inference: beforeTurn
+ * always resolves the ungated Curator model from the user's product credential
+ * and overrides it, or fails the turn with a product-safe error first.
+ */
+const UNRESOLVED_CURATOR_MODEL = "better-agent:curator-model-resolved-in-before-turn";
+
+const MISSING_CURATION_CONTEXT_MESSAGE =
+	"This curation conversation is missing its draft Thinkspace context.";
+const CURATOR_MODEL_UNAVAILABLE_MESSAGE = "The Curator could not resolve a model to run on.";
+
+/**
+ * The Curator's creation runtime — a deliberate parallel of {@link ThinkspaceAgent},
+ * for a different role (ADR-0010). Keyed on the **draft Thinkspace id** (one
+ * Curator per draft), it reuses Project Think's durable session, streaming, and
+ * recovery wholesale. This is the skeleton (#125): it runs and streams on the
+ * ungated Curator model and carries the Curator system prompt, but assembles
+ * **no mutation tools** — the propose-only `set_*`/`enable_tool` toolset lands in
+ * #127. "Proposes, never grants" is therefore already structural here: there is
+ * nothing for it to grant or activate with.
+ */
+export class CuratorAgent extends Think<CloudflareEnv> {
+	private readonly curatorSystemPrompt = CURATOR_SYSTEM_PROMPT;
+	private readonly curatorToolSet: ToolSet = {};
+	private readonly turnModelPlaceholder: LanguageModel = UNRESOLVED_CURATOR_MODEL;
+
+	override maxSteps = CURATOR_RUNTIME_MAX_STEPS;
+	override workspaceBash = false;
+
+	/**
+	 * Fail-closed by default, mirroring the Thinkspace Agent. Project Think serves
+	 * some unauthenticated routes once a request reaches the Durable Object, so
+	 * this override admits exactly one thing: a curation request the worker has
+	 * already authenticated and stamped with a forward context matching this
+	 * runtime's bound (owner, draft Thinkspace). Everything else — direct hits,
+	 * absent or mismatched context — stays 404, with no signal about whether the
+	 * draft exists.
+	 */
+	override async fetch(request: Request): Promise<Response> {
+		const forwardContext = decodeCurationForwardContext(
+			request.headers.get(CURATION_FORWARD_CONTEXT_HEADER),
+		);
+
+		if (!forwardContext) {
+			return CuratorAgent.runtimeClosedResponse();
+		}
+
+		const existingContext = await this.ctx.storage.get<CurationForwardContext>(
+			CURATION_CONTEXT_STORAGE_KEY,
+		);
+
+		if (existingContext && !matchesCurationForwardContext(forwardContext, existingContext)) {
+			return CuratorAgent.runtimeClosedResponse();
+		}
+
+		await this.ctx.storage.put<CurationForwardContext>(CURATION_CONTEXT_STORAGE_KEY, {
+			draftThinkspaceId: forwardContext.draftThinkspaceId,
+			ownerUserId: forwardContext.ownerUserId,
+		});
+
+		return super.fetch(request);
+	}
+
+	private static runtimeClosedResponse(): Response {
+		return new Response("This Curator runtime is not directly accessible.", {
+			status: 404,
+		});
+	}
+
+	override getModel(): LanguageModel {
+		return this.turnModelPlaceholder;
+	}
+
+	override getSystemPrompt(): string {
+		return this.curatorSystemPrompt;
+	}
+
+	override getTools(): ToolSet {
+		return this.curatorToolSet;
+	}
+
+	override async beforeTurn() {
+		const context = await this.ctx.storage.get<CurationForwardContext>(
+			CURATION_CONTEXT_STORAGE_KEY,
+		);
+
+		if (!context) {
+			throw new Error(MISSING_CURATION_CONTEXT_MESSAGE);
+		}
+
+		const db = createDb(this.env.DB);
+		const model = await this.resolveCuratorTurnModel(db, context);
+
+		return { model };
+	}
+
+	/**
+	 * Resolves the ungated Curator model (#124) from the user's own product
+	 * credential. On any failure — no credential, an unresolvable model — the turn
+	 * fails with the already product-safe connect-first message rather than a raw
+	 * error.
+	 */
+	private async resolveCuratorTurnModel(
+		db: ProductDb,
+		context: CurationForwardContext,
+	): Promise<LanguageModelV3> {
+		try {
+			const settings = await getUserCuratorModelSettings(db, context.ownerUserId);
+			const resolved = await resolveCuratorModel({
+				db,
+				env: this.env,
+				settings,
+				userId: context.ownerUserId,
+			});
+
+			return resolved.model;
+		} catch (error) {
+			const message =
+				error instanceof CuratorModelUnavailableError
+					? error.message
+					: CURATOR_MODEL_UNAVAILABLE_MESSAGE;
+			throw new Error(message, { cause: error });
+		}
+	}
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,4 +1,10 @@
 import { appRouter, createContext } from "@better-agent/api";
+import {
+	CURATION_FORWARD_CONTEXT_HEADER,
+	encodeCurationForwardContext,
+	parseCurationDraftThinkspaceId,
+} from "@better-agent/api/curator/forward-context";
+import { getOwnedCuratorAgentRuntimeReadiness } from "@better-agent/api/curator/runtime";
 import { getOwnedThinkspaceAgentRuntimeReadiness } from "@better-agent/api/thinkspaces/runtime";
 import {
 	encodeSittingForwardContext,
@@ -21,6 +27,7 @@ import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import { logger } from "hono/logger";
 
+export { CuratorAgent } from "./agents/curator-agent";
 export { ThinkspaceAgent } from "./agents/thinkspace-agent";
 
 const app = new Hono<{ Bindings: CloudflareEnv }>();
@@ -150,6 +157,57 @@ app.use("/api/sittings/*", async (c) => {
 
 	const runtime = await getAgentByName(
 		c.env.THINKSPACE_AGENT as unknown as Parameters<typeof getAgentByName>[0],
+		readiness.runtimeName,
+	);
+
+	return runtime.fetch(new Request(c.req.raw, { headers: forwardHeaders }));
+});
+
+/**
+ * The one authenticated seam by which browser traffic reaches a Curator runtime:
+ * the creation conversation over a draft Thinkspace. Mirrors the Sitting seam
+ * exactly — the worker verifies the Better Auth session and draft ownership, then
+ * strips any client-supplied forward header and stamps its own authenticated
+ * (owner, draft) context before handing the request to the runtime resolved by
+ * draft id. Every other outcome — bad path, unauthenticated, non-owner, missing
+ * draft — returns the same 404, so ownership stays the only signal.
+ */
+app.use("/api/curator/*", async (c) => {
+	const draftThinkspaceId = parseCurationDraftThinkspaceId(new URL(c.req.url).pathname);
+
+	if (!draftThinkspaceId) {
+		return c.notFound();
+	}
+
+	const db = createDb(c.env.DB);
+	const session = await createAuth({ db, env: c.env }).api.getSession({
+		headers: c.req.raw.headers,
+	});
+
+	if (!session?.user) {
+		return c.notFound();
+	}
+
+	const readiness = await getOwnedCuratorAgentRuntimeReadiness({
+		db,
+		draftThinkspaceId,
+		env: c.env,
+		ownerUserId: session.user.id,
+	});
+
+	if (!readiness) {
+		return c.notFound();
+	}
+
+	const forwardHeaders = new Headers(c.req.raw.headers);
+	forwardHeaders.delete(CURATION_FORWARD_CONTEXT_HEADER);
+	forwardHeaders.set(
+		CURATION_FORWARD_CONTEXT_HEADER,
+		encodeCurationForwardContext({ draftThinkspaceId, ownerUserId: session.user.id }),
+	);
+
+	const runtime = await getAgentByName(
+		c.env.CURATOR_AGENT as unknown as Parameters<typeof getAgentByName>[0],
 		readiness.runtimeName,
 	);
 

--- a/apps/server/src/worker-routes.test.ts
+++ b/apps/server/src/worker-routes.test.ts
@@ -21,6 +21,10 @@ const agentSource = readFileSync(
 	new URL("agents/thinkspace-agent.ts", sourceRoot).pathname,
 	"utf-8",
 );
+const curatorAgentSource = readFileSync(
+	new URL("agents/curator-agent.ts", sourceRoot).pathname,
+	"utf-8",
+);
 
 test("the worker never mounts raw Project Think agent routes", () => {
 	assert.doesNotMatch(workerSource, /routeAgentRequest/u);
@@ -44,6 +48,7 @@ test("the worker only exposes known app-owned route prefixes", () => {
 		"/api/rpc/*",
 		"/api/openapi/*",
 		"/api/sittings/*",
+		"/api/curator/*",
 		"/",
 		"/api/health",
 	]);
@@ -62,6 +67,40 @@ test("the worker authenticates and owner-gates the Sitting route before forwardi
 	assert.match(workerSource, /encodeSittingForwardContext\(/u);
 	// Resolution is by Thinkspace id via the agents helper, never a raw router.
 	assert.match(workerSource, /getAgentByName\(/u);
+});
+
+test("the worker authenticates and owner-gates the curation route before forwarding", () => {
+	// The Curator creation seam mirrors the Sitting gate exactly: session check,
+	// then draft-ownership check, then forward. A non-owner or unauthenticated
+	// caller gets the same 404 as a missing draft, so ownership is the only signal.
+	assert.match(workerSource, /"\/api\/curator\/\*"/u);
+	assert.match(workerSource, /getOwnedCuratorAgentRuntimeReadiness\(/u);
+	// The worker strips any client-supplied forward header, then stamps its own.
+	assert.match(workerSource, /forwardHeaders\.delete\(CURATION_FORWARD_CONTEXT_HEADER\)/u);
+	assert.match(workerSource, /encodeCurationForwardContext\(/u);
+	assert.match(workerSource, /c\.env\.CURATOR_AGENT/u);
+});
+
+test("the Curator runtime keeps direct HTTP access fail-closed", () => {
+	// The override defaults to 404; it admits only a worker-stamped curation
+	// forward whose (owner, draft) matches the runtime's bound context, then hands
+	// off to Project Think's chat protocol via super.fetch.
+	assert.match(curatorAgentSource, /override async fetch\(/u);
+	assert.match(curatorAgentSource, /status: 404/u);
+	assert.match(curatorAgentSource, /decodeCurationForwardContext\(/u);
+	assert.match(curatorAgentSource, /matchesCurationForwardContext\(/u);
+	assert.match(curatorAgentSource, /return super\.fetch\(request\)/u);
+});
+
+test("the Curator runtime runs the ungated Curator model and assembles no mutation tools", () => {
+	// The DO resolves the ungated Curator model (#124) in beforeTurn and ships no
+	// mutation tools yet — "proposes, never grants" is structural from the start.
+	assert.match(curatorAgentSource, /resolveCuratorModel\(/u);
+	assert.match(curatorAgentSource, /override async beforeTurn\(/u);
+	// The toolset is structurally empty in this skeleton — there is no activate or
+	// grant tool to assemble, so "proposes, never grants" cannot regress here.
+	assert.match(curatorAgentSource, /private readonly curatorToolSet: ToolSet = \{\}/u);
+	assert.match(curatorAgentSource, /getTools\(\): ToolSet \{\s*return this\.curatorToolSet;/u);
 });
 
 test("the Thinkspace Agent runtime keeps direct HTTP access fail-closed", () => {

--- a/packages/api/src/curator/forward-context.test.ts
+++ b/packages/api/src/curator/forward-context.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	decodeCurationForwardContext,
+	encodeCurationForwardContext,
+	matchesCurationForwardContext,
+	parseCurationDraftThinkspaceId,
+} from "./forward-context";
+
+test("parses the draft Thinkspace id out of a curation route path", () => {
+	assert.equal(parseCurationDraftThinkspaceId("/api/curator/thinkspace_123"), "thinkspace_123");
+	assert.equal(
+		parseCurationDraftThinkspaceId("/api/curator/thinkspace_123/get-messages"),
+		"thinkspace_123",
+	);
+});
+
+test("fails closed for non-curation or id-less paths", () => {
+	assert.equal(parseCurationDraftThinkspaceId("/api/curator/"), null);
+	assert.equal(parseCurationDraftThinkspaceId("/api/sittings/thinkspace_123"), null);
+	assert.equal(parseCurationDraftThinkspaceId("/api/curator"), null);
+});
+
+test("round-trips an authenticated forward context through the header value", () => {
+	const context = { draftThinkspaceId: "thinkspace_abc", ownerUserId: "user_1" };
+	const decoded = decodeCurationForwardContext(encodeCurationForwardContext(context));
+
+	assert.deepEqual(decoded, context);
+});
+
+test("decoding fails closed for missing, malformed, or wrong-shaped values", () => {
+	assert.equal(decodeCurationForwardContext(null), null);
+	assert.equal(decodeCurationForwardContext(""), null);
+	assert.equal(decodeCurationForwardContext("not-json"), null);
+	assert.equal(
+		decodeCurationForwardContext(encodeURIComponent(JSON.stringify({ ownerUserId: "user_1" }))),
+		null,
+	);
+	assert.equal(
+		decodeCurationForwardContext(
+			encodeURIComponent(JSON.stringify({ draftThinkspaceId: 42, ownerUserId: "user_1" })),
+		),
+		null,
+	);
+	assert.equal(
+		decodeCurationForwardContext(
+			encodeURIComponent(JSON.stringify({ draftThinkspaceId: "  ", ownerUserId: "user_1" })),
+		),
+		null,
+	);
+});
+
+test("admits only a forward context whose owner and draft both match the runtime's bound", () => {
+	const bound = { draftThinkspaceId: "thinkspace_abc", ownerUserId: "user_1" };
+
+	assert.equal(matchesCurationForwardContext({ ...bound }, bound), true);
+	// Wrong owner — another user's stamped context cannot reach this draft's runtime.
+	assert.equal(
+		matchesCurationForwardContext(
+			{ draftThinkspaceId: "thinkspace_abc", ownerUserId: "user_2" },
+			bound,
+		),
+		false,
+	);
+	// Wrong draft — the right owner against the wrong draft's runtime is rejected.
+	assert.equal(
+		matchesCurationForwardContext(
+			{ draftThinkspaceId: "thinkspace_other", ownerUserId: "user_1" },
+			bound,
+		),
+		false,
+	);
+	// No context at all matches nothing.
+	assert.equal(matchesCurationForwardContext(null, bound), false);
+});

--- a/packages/api/src/curator/forward-context.test.ts
+++ b/packages/api/src/curator/forward-context.test.ts
@@ -22,6 +22,13 @@ test("fails closed for non-curation or id-less paths", () => {
 	assert.equal(parseCurationDraftThinkspaceId("/api/curator"), null);
 });
 
+test("fails closed (not a URIError) on a malformed percent-escape in the id", () => {
+	// `new URL(...).pathname` keeps percent-escapes raw, so a malformed one reaches
+	// the parser. It must return null → the worker's sealed 404, never a 500.
+	assert.equal(parseCurationDraftThinkspaceId("/api/curator/%E0%A4%A"), null);
+	assert.equal(parseCurationDraftThinkspaceId("/api/curator/%"), null);
+});
+
 test("round-trips an authenticated forward context through the header value", () => {
 	const context = { draftThinkspaceId: "thinkspace_abc", ownerUserId: "user_1" };
 	const decoded = decodeCurationForwardContext(encodeCurationForwardContext(context));

--- a/packages/api/src/curator/forward-context.ts
+++ b/packages/api/src/curator/forward-context.ts
@@ -56,7 +56,17 @@ export const parseCurationDraftThinkspaceId = (pathname: string): string | null 
 		return null;
 	}
 
-	const draftThinkspaceId = decodeURIComponent(segment).trim();
+	let decodedSegment: string;
+	try {
+		decodedSegment = decodeURIComponent(segment);
+	} catch {
+		// A malformed percent-escape must fail closed to the worker's sealed 404,
+		// not let a URIError escape to a 500 that would distinguish a bad-id probe
+		// from a clean miss.
+		return null;
+	}
+
+	const draftThinkspaceId = decodedSegment.trim();
 
 	return draftThinkspaceId.length > 0 ? draftThinkspaceId : null;
 };

--- a/packages/api/src/curator/forward-context.ts
+++ b/packages/api/src/curator/forward-context.ts
@@ -1,0 +1,125 @@
+/**
+ * The Curator's creation runtime is a deliberate parallel of the Sitting
+ * transport (`thinkspaces/sittings.ts`): the same one-narrow-opening contract,
+ * for a different role. A **Sitting** is owner ↔ Thinkspace Agent over an active
+ * Thinkspace; Curator-led creation is owner ↔ Curator over a *draft* Thinkspace,
+ * before any Thinkspace Agent exists. This module owns how the worker stamps an
+ * authenticated forward onto a curation request, and how the `CuratorAgent`
+ * runtime verifies it before admitting the request into Project Think's chat
+ * protocol. The runtime stays fail-closed (404) to everything else.
+ */
+
+/** Path prefix for the single authenticated curation route the worker exposes. */
+export const CURATION_ROUTE_PREFIX = "/api/curator/" as const;
+
+/**
+ * Header the worker attaches to a forwarded curation request after it has
+ * verified the session and draft ownership. The runtime treats this as the
+ * authority for who is connecting, because the Durable Object is only reachable
+ * through the worker binding. The worker strips any client-supplied value before
+ * stamping its own, so a browser can never smuggle this header through.
+ */
+export const CURATION_FORWARD_CONTEXT_HEADER = "x-better-agent-curation-forward" as const;
+
+/** DO storage key for the (owner, draft) pair this runtime is bound to. */
+export const CURATION_CONTEXT_STORAGE_KEY = "better-agent:curation-context" as const;
+
+/**
+ * The owner/draft pair the worker authenticated for a forwarded curation
+ * request. Keyed on the *draft Thinkspace id* — one Curator per draft — which
+ * survives activation so a future reconfiguration slice can re-enter the same
+ * runtime.
+ */
+export interface CurationForwardContext {
+	draftThinkspaceId: string;
+	ownerUserId: string;
+}
+
+/**
+ * Pulls the draft Thinkspace id out of a curation route pathname. Returns null
+ * when the path is not a curation route or carries no id, so callers fail closed.
+ *
+ * Examples:
+ * - `/api/curator/thinkspace_123` → `"thinkspace_123"`
+ * - `/api/curator/thinkspace_123/get-messages` → `"thinkspace_123"`
+ * - `/api/curator/` → `null`
+ */
+export const parseCurationDraftThinkspaceId = (pathname: string): string | null => {
+	if (!pathname.startsWith(CURATION_ROUTE_PREFIX)) {
+		return null;
+	}
+
+	const remainder = pathname.slice(CURATION_ROUTE_PREFIX.length);
+	const [segment] = remainder.split("/", 1);
+
+	if (!segment) {
+		return null;
+	}
+
+	const draftThinkspaceId = decodeURIComponent(segment).trim();
+
+	return draftThinkspaceId.length > 0 ? draftThinkspaceId : null;
+};
+
+/**
+ * Encodes an authenticated forward context into a header-safe value. The value
+ * is opaque to the client and only meaningful to the runtime, which re-verifies
+ * it against the context the Durable Object is bound to.
+ */
+export const encodeCurationForwardContext = (context: CurationForwardContext): string =>
+	encodeURIComponent(
+		JSON.stringify({
+			draftThinkspaceId: context.draftThinkspaceId,
+			ownerUserId: context.ownerUserId,
+		}),
+	);
+
+/**
+ * Decodes a forward context header value, returning null on any malformed,
+ * missing, or wrong-shaped input so the runtime fails closed.
+ */
+export const decodeCurationForwardContext = (
+	value: string | null | undefined,
+): CurationForwardContext | null => {
+	if (!value) {
+		return null;
+	}
+
+	try {
+		const parsed = JSON.parse(decodeURIComponent(value)) as unknown;
+
+		if (typeof parsed !== "object" || parsed === null) {
+			return null;
+		}
+
+		const { draftThinkspaceId, ownerUserId } = parsed as Record<string, unknown>;
+
+		if (typeof draftThinkspaceId !== "string" || typeof ownerUserId !== "string") {
+			return null;
+		}
+
+		const boundedDraft = draftThinkspaceId.trim();
+		const boundedOwner = ownerUserId.trim();
+
+		if (!boundedDraft || !boundedOwner) {
+			return null;
+		}
+
+		return { draftThinkspaceId: boundedDraft, ownerUserId: boundedOwner };
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * Fail-closed admission check: a decoded forward context only matches when both
+ * the owner and the draft Thinkspace agree with what the runtime expects. A
+ * missing context matches nothing.
+ */
+export const matchesCurationForwardContext = (
+	context: CurationForwardContext | null,
+	expected: CurationForwardContext,
+): boolean =>
+	context !== null &&
+	context.ownerUserId === expected.ownerUserId &&
+	context.draftThinkspaceId === expected.draftThinkspaceId;

--- a/packages/api/src/curator/runtime.test.ts
+++ b/packages/api/src/curator/runtime.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+import type { CloudflareEnv } from "@better-agent/env/types";
+
+import {
+	CURATOR_AGENT_BINDING_NAME,
+	CURATOR_AGENT_CLASS_NAME,
+	CuratorRuntimeResolutionError,
+	getCuratorAgentRuntimeName,
+	getOwnedCuratorAgentRuntimeReadiness,
+	resolveCuratorAgentRuntime,
+} from "./runtime";
+
+const db = {} as ProductDb;
+
+/** A binding stub whose id is a deterministic function of the runtime name. */
+const createEnv = (): Pick<CloudflareEnv, typeof CURATOR_AGENT_BINDING_NAME> =>
+	({
+		CURATOR_AGENT: {
+			idFromName: (name: string) => ({ toString: () => `do_${name}` }),
+		},
+	}) as unknown as Pick<CloudflareEnv, typeof CURATOR_AGENT_BINDING_NAME>;
+
+test("the runtime is keyed on the draft Thinkspace id", () => {
+	assert.equal(getCuratorAgentRuntimeName("  thinkspace_123  "), "thinkspace_123");
+	assert.throws(() => getCuratorAgentRuntimeName("   "), CuratorRuntimeResolutionError);
+});
+
+test("resolves a Curator runtime identity bound to the draft id", () => {
+	const readiness = resolveCuratorAgentRuntime({
+		draftThinkspaceId: "thinkspace_123",
+		env: createEnv(),
+	});
+
+	assert.equal(readiness.bindingName, CURATOR_AGENT_BINDING_NAME);
+	assert.equal(readiness.className, CURATOR_AGENT_CLASS_NAME);
+	assert.equal(readiness.runtimeName, "thinkspace_123");
+	assert.equal(readiness.runtimeId, "do_thinkspace_123");
+	assert.equal(readiness.status, "ready");
+});
+
+test("owner-gated readiness resolves for a draft the caller owns", async () => {
+	const readiness = await getOwnedCuratorAgentRuntimeReadiness({
+		db,
+		draftThinkspaceId: "thinkspace_owned",
+		env: createEnv(),
+		getThinkspaceByOwner: (_db, input) => {
+			assert.equal(input.ownerUserId, "owner_user");
+			assert.equal(input.thinkspaceId, "thinkspace_owned");
+			return Promise.resolve({ id: "thinkspace_owned" });
+		},
+		ownerUserId: "owner_user",
+	});
+
+	assert.equal(readiness?.runtimeName, "thinkspace_owned");
+	assert.equal(readiness?.status, "ready");
+});
+
+test("owner-gated readiness is null for a non-owner or missing draft", async () => {
+	const readiness = await getOwnedCuratorAgentRuntimeReadiness({
+		db,
+		draftThinkspaceId: "thinkspace_owned",
+		env: createEnv(),
+		// A non-owner and a non-existent draft are indistinguishable — both null.
+		getThinkspaceByOwner: () => Promise.resolve(null),
+		ownerUserId: "other_user",
+	});
+
+	assert.equal(readiness, null);
+});

--- a/packages/api/src/curator/runtime.ts
+++ b/packages/api/src/curator/runtime.ts
@@ -1,0 +1,108 @@
+import type { ProductDb } from "@better-agent/db";
+import type { Thinkspace } from "@better-agent/db/schema/thinkspaces";
+import type { CloudflareEnv } from "@better-agent/env/types";
+
+import { getThinkspace } from "../thinkspaces/repository";
+
+export const CURATOR_AGENT_BINDING_NAME = "CURATOR_AGENT" as const;
+export const CURATOR_AGENT_CLASS_NAME = "CuratorAgent" as const;
+
+/**
+ * Conservative ceiling on the Curator's per-turn agentic loop. The creation
+ * conversation is propose-only; this slice ships no mutation tools (#127 adds
+ * `set_*`/`enable_tool`), so the bound stays small and the loop never runs away.
+ */
+export const CURATOR_RUNTIME_MAX_STEPS = 8 as const;
+
+export interface CuratorAgentRuntimeReadiness {
+	bindingName: typeof CURATOR_AGENT_BINDING_NAME;
+	className: typeof CURATOR_AGENT_CLASS_NAME;
+	draftThinkspaceId: string;
+	runtimeId: string;
+	runtimeName: string;
+	status: "ready";
+}
+
+export interface ResolveCuratorAgentRuntimeInput {
+	draftThinkspaceId: string;
+	env: Pick<CloudflareEnv, typeof CURATOR_AGENT_BINDING_NAME>;
+}
+
+export interface GetOwnedCuratorAgentRuntimeReadinessInput extends ResolveCuratorAgentRuntimeInput {
+	db: ProductDb;
+	getThinkspaceByOwner?: GetThinkspaceByOwner;
+	ownerUserId: string;
+}
+
+type GetThinkspaceByOwner = (
+	db: ProductDb,
+	input: { ownerUserId: string; thinkspaceId: string },
+) => Promise<Pick<Thinkspace, "id"> | null>;
+
+export class CuratorRuntimeResolutionError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CuratorRuntimeResolutionError";
+	}
+}
+
+export const getCuratorAgentRuntimeName = (draftThinkspaceId: string): string => {
+	const runtimeName = draftThinkspaceId.trim();
+
+	if (!runtimeName) {
+		throw new CuratorRuntimeResolutionError(
+			"Curator runtime identity requires a draft Thinkspace id.",
+		);
+	}
+
+	return runtimeName;
+};
+
+export const resolveCuratorAgentRuntime = ({
+	draftThinkspaceId,
+	env,
+}: ResolveCuratorAgentRuntimeInput): CuratorAgentRuntimeReadiness => {
+	const namespace = env[CURATOR_AGENT_BINDING_NAME];
+
+	if (!namespace) {
+		throw new CuratorRuntimeResolutionError("Curator runtime binding is not available.");
+	}
+
+	const runtimeName = getCuratorAgentRuntimeName(draftThinkspaceId);
+	const runtimeId = namespace.idFromName(runtimeName).toString();
+
+	return {
+		bindingName: CURATOR_AGENT_BINDING_NAME,
+		className: CURATOR_AGENT_CLASS_NAME,
+		draftThinkspaceId,
+		runtimeId,
+		runtimeName,
+		status: "ready",
+	};
+};
+
+/**
+ * The worker's ownership gate for the curation route: the draft Thinkspace must
+ * exist and be owned by the caller, or the worker fails closed before any agent
+ * code runs. Ownership is the only signal — a non-owner and a non-existent draft
+ * are indistinguishable (both null → the worker's sealed 404). The draft id
+ * keys the runtime, so the Curator survives the draft's later activation.
+ */
+export const getOwnedCuratorAgentRuntimeReadiness = async ({
+	db,
+	draftThinkspaceId,
+	env,
+	getThinkspaceByOwner = getThinkspace,
+	ownerUserId,
+}: GetOwnedCuratorAgentRuntimeReadinessInput): Promise<CuratorAgentRuntimeReadiness | null> => {
+	const thinkspace = await getThinkspaceByOwner(db, {
+		ownerUserId,
+		thinkspaceId: draftThinkspaceId,
+	});
+
+	if (!thinkspace) {
+		return null;
+	}
+
+	return resolveCuratorAgentRuntime({ draftThinkspaceId: thinkspace.id, env });
+};

--- a/packages/api/src/curator/system-prompt.ts
+++ b/packages/api/src/curator/system-prompt.ts
@@ -1,0 +1,13 @@
+/**
+ * The Curator's system prompt for the creation conversation. This skeleton
+ * (#125) establishes the role and the propose-never-grant invariant; the
+ * propose-only toolset and its usage instructions land in #127, which extends
+ * this prompt rather than replacing the role it sets.
+ */
+export const CURATOR_SYSTEM_PROMPT = [
+	"You are the Curator for Better Agent — the product's setup role, and the sole way a user creates a Thinkspace.",
+	"You help the user shape a new Thinkspace through a live conversation: you turn a vague intent into a bounded, assessable Goal, and you propose the Agent Profile that a dedicated Thinkspace Agent will run under — its name, instructions, model, and the tools it will need with the Permissions those tools require.",
+	"Sharpen the Goal until it names a real, checkable outcome rather than a wish. Ask at most a question or two when intent is genuinely ambiguous; otherwise propose and let the user push back.",
+	"You propose; the user decides. You never grant a Permission and you never activate a Thinkspace — granting and activation are always the user's act, performed by the user in the creation surface, never by you.",
+	"Be concise and concrete. Speak in the product's terms: Thinkspace, Goal, Agent Profile, Permission. Never claim to have taken an action you have not taken.",
+].join("\n\n");

--- a/packages/env/src/types.ts
+++ b/packages/env/src/types.ts
@@ -2,6 +2,7 @@ export interface CloudflareEnv {
 	BETTER_AUTH_SECRET: string;
 	BETTER_AUTH_URL: string;
 	CORS_ORIGIN: string;
+	CURATOR_AGENT: DurableObjectNamespace;
 	DB: D1Database;
 	THINKSPACE_AGENT: DurableObjectNamespace;
 	SESSION_KV?: KVNamespace;

--- a/packages/infra/alchemy.run.ts
+++ b/packages/infra/alchemy.run.ts
@@ -77,6 +77,11 @@ const thinkspaceAgents = DurableObjectNamespace("thinkspace-agent", {
 	sqlite: true,
 });
 
+const curatorAgents = DurableObjectNamespace("curator-agent", {
+	className: "CuratorAgent",
+	sqlite: true,
+});
+
 const commonBindings = {
 	API_ENCRYPTION_KEY: requiredSecretEnv("API_ENCRYPTION_KEY"),
 	BETTER_AUTH_SECRET: requiredSecretEnv("BETTER_AUTH_SECRET"),
@@ -90,6 +95,7 @@ const commonBindings = {
 
 const serverBindings = {
 	...commonBindings,
+	CURATOR_AGENT: curatorAgents,
 	THINKSPACE_AGENT: thinkspaceAgents,
 };
 


### PR DESCRIPTION
## Parent
PRD: #123 (`curator_creation_v1`) — second child. Blocked by #124 (merged).

## What this builds
A new `CuratorAgent` Durable Object on Project Think — a deliberate **parallel of `ThinkspaceAgent`**, for the Curator role (ADR-0010). Skeleton only: it runs and streams on the ungated Curator model; **no mutation tools yet** (those land in #127).

- **`CuratorAgent`** (`apps/server/src/agents/curator-agent.ts`) extends `Think`, keyed on the **draft Thinkspace id** (one Curator per draft). Curator system prompt, conservative `maxSteps`, `workspaceBash` off. Resolves the ungated Curator model (#124) in `beforeTurn`; `getTools()` returns an **empty toolset**, so "proposes, never grants" is structural from the start.
- **Curation forward-context** (`packages/api/src/curator/forward-context.ts`), mirroring the Sitting seam: the worker stamps an authenticated `(owner, draft)` header; the DO's `fetch` override admits only a matching context and stays **404-first** to everything else (direct hits, absent/mismatched context).
- **Ownership-gated runtime resolution** (`packages/api/src/curator/runtime.ts`): binding-name constant exported; `getOwnedCuratorAgentRuntimeReadiness` fails closed — a non-owner and a missing draft are **indistinguishable** (both → null).
- **Worker route** `/api/curator/*` (`apps/server/src/index.ts`): Better Auth session + draft-ownership gate **before** the request reaches the DO; strips any client-supplied forward header, then stamps its own; resolves the runtime via `getAgentByName`.
- **Binding wiring**: `CURATOR_AGENT` `DurableObjectNamespace` in Alchemy + `CloudflareEnv`. Alchemy owns the DO migration from the namespace declaration (no hand-managed wrangler migration list exists).

## Acceptance criteria (#125)
- [x] `CuratorAgent` DO on Think, keyed on the draft id, Curator system prompt, `workspaceBash` off, conservative `maxSteps`.
- [x] DO binding + migration wired through Alchemy; binding-name constant exported.
- [x] `fetch` fail-closed: only a worker-stamped `(owner, draft)` forward is admitted; everything else 404.
- [x] Worker authenticates the session and verifies draft ownership before forwarding; non-owner/unauthenticated get 404-first.
- [x] DO resolves the ungated Curator model (#124) and runs a streamed turn; no mutation tools assembled.
- [x] Adversarial forward-context test (wrong owner / wrong draft / no context / malformed) confirms the seal.
- [x] `bun run check-types`, `bun x ultracite check`, `bun test packages/api` (338 pass) green.

## Notes
- `apps/web/src/routeTree.gen.ts` deliberately excluded (pre-existing generated noise).
- The web client surface (`useAgent` against `/api/curator/${draftThinkspaceId}`) and the `startCuration` eager-draft mint land in later children (#126/#129).

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)