### PR TITLE
Backend: eager draft lifecycle + thinkspaces.startCuration entry point (#126)

### DIFF
--- a/packages/api/src/thinkspaces/lifecycle.test.ts
+++ b/packages/api/src/thinkspaces/lifecycle.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+	createCurationDraftThinkspaceRecord,
 	createThinkspaceArchivePatch,
 	createThinkspaceCreationRecord,
 	THINKSPACE_CREATION_DEFAULTS,
@@ -43,6 +44,35 @@ test("builds a deterministic configuration summary when none is supplied", () =>
 	assert.match(
 		record.configurationSummary ?? "",
 		/Memory governance starts in user-reviewed mode/u,
+	);
+});
+
+test("mints an empty-Goal draft record for a curation conversation to open against", () => {
+	const record = createCurationDraftThinkspaceRecord({
+		id: "thinkspace_curation",
+		ownerUserId: "user_123",
+	});
+
+	assert.equal(record.id, "thinkspace_curation");
+	assert.equal(record.ownerUserId, "user_123");
+	assert.equal(record.goal, "");
+	assert.equal(record.configurationSummary, "");
+	assert.equal(record.status, "draft");
+	assert.equal(
+		record.memoryGovernance,
+		JSON.stringify(THINKSPACE_CREATION_DEFAULTS.memoryGovernance),
+	);
+});
+
+test("rejects a curation draft without an owner or identifier", () => {
+	assert.throws(
+		() => createCurationDraftThinkspaceRecord({ id: "thinkspace_curation", ownerUserId: "" }),
+		ThinkspaceLifecycleValidationError,
+	);
+
+	assert.throws(
+		() => createCurationDraftThinkspaceRecord({ id: "", ownerUserId: "user_123" }),
+		ThinkspaceLifecycleValidationError,
 	);
 });
 

--- a/packages/api/src/thinkspaces/lifecycle.ts
+++ b/packages/api/src/thinkspaces/lifecycle.ts
@@ -61,6 +61,44 @@ export const createThinkspaceArchivePatch = (
 	};
 };
 
+export interface CreateCurationDraftThinkspaceInput {
+	id: string;
+	ownerUserId: string;
+}
+
+/**
+ * Mints the empty-Goal DRAFT a curation conversation opens against. Unlike
+ * `createThinkspaceCreationRecord`, there is no user-authored Goal yet — the
+ * Curator's `set_*` tools (#127) fill the Goal and configuration as the
+ * conversation shapes the agent. The empty Goal is the signal `listThinkspaces`
+ * filters on to keep in-progress curations out of the main list; a draft that
+ * later gains a Goal reappears. An abandoned empty draft persists (no GC): the
+ * judgement already spent in the session is never silently discarded.
+ */
+export const createCurationDraftThinkspaceRecord = ({
+	id,
+	ownerUserId,
+}: CreateCurationDraftThinkspaceInput): NewThinkspace => {
+	if (!ownerUserId) {
+		throw new ThinkspaceLifecycleValidationError(
+			"A Thinkspace must belong to an authenticated owner.",
+		);
+	}
+
+	if (!id) {
+		throw new ThinkspaceLifecycleValidationError("A Thinkspace requires a stable identifier.");
+	}
+
+	return {
+		configurationSummary: "",
+		goal: "",
+		id,
+		memoryGovernance: JSON.stringify(THINKSPACE_CREATION_DEFAULTS.memoryGovernance),
+		ownerUserId,
+		status: THINKSPACE_STATUS.DRAFT,
+	};
+};
+
 export const createThinkspaceCreationRecord = ({
 	configurationSummary,
 	goal,

--- a/packages/api/src/thinkspaces/repository.ts
+++ b/packages/api/src/thinkspaces/repository.ts
@@ -2,7 +2,7 @@ import type { ProductDb } from "@better-agent/db";
 import { thinkspaceAgentProfiles } from "@better-agent/db/schema/agent-profiles";
 import { THINKSPACE_STATUS, thinkspaces } from "@better-agent/db/schema/thinkspaces";
 import type { Thinkspace, ThinkspaceStatus } from "@better-agent/db/schema/thinkspaces";
-import { and, desc, eq, ne } from "drizzle-orm";
+import { and, desc, eq, ne, or } from "drizzle-orm";
 
 import { parseAgentProfileRevision, serializeAgentProfileRevision } from "./agent-profile";
 import type { DraftAgentProfileRevision } from "./agent-profile";
@@ -97,6 +97,11 @@ export const listThinkspaces = async (
 				status
 					? eq(thinkspaces.status, status)
 					: ne(thinkspaces.status, THINKSPACE_STATUS.ARCHIVED),
+				// An empty-Goal draft is an in-progress curation: keep it out of the
+				// list until the Curator gives it a real Goal. The draft still
+				// persists and stays fetchable by id, it just does not clutter the
+				// list. A draft that has gained a Goal has goal != '' and reappears.
+				or(ne(thinkspaces.status, THINKSPACE_STATUS.DRAFT), ne(thinkspaces.goal, "")),
 			),
 		)
 		.orderBy(desc(thinkspaces.updatedAt));

--- a/packages/api/src/thinkspaces/router.test.ts
+++ b/packages/api/src/thinkspaces/router.test.ts
@@ -342,6 +342,94 @@ test("creating a Thinkspace rejects models outside the catalog before persistenc
 	assert.equal(inserted.length, 0);
 });
 
+test("startCuration mints an empty-Goal draft Thinkspace and its initial draft Agent Profile owned by the caller", async () => {
+	const db = createTestProductDb();
+	await db.insert(user).values({
+		email: "owner@example.com",
+		id: authenticatedSession.user.id,
+		name: "Owner",
+	});
+	const context = createCallContext({ db });
+
+	const started = await call(thinkspacesRouter.startCuration, undefined, { context });
+
+	assert.ok(started);
+	assert.equal(started.status, "draft");
+	assert.equal(started.goal, "");
+	assert.equal(started.ownerUserId, authenticatedSession.user.id);
+	assert.ok(started.id.startsWith("thinkspace_"));
+	assert.equal(started.agentProfileRevision.status, "draft");
+	assert.equal(started.agentProfileRevision.identity.displayName, "Untitled Thinkspace");
+	assert.equal(started.agentProfileRevision.identity.instructions, "");
+	// The model provider credential is requested up front so activation can grant it.
+	assert.deepEqual(
+		started.agentProfileRevision.requestedPermissions.map((request) => request.kind),
+		["model_provider_credential"],
+	);
+
+	// An in-progress (empty-Goal) draft stays fetchable/resumable by id, owner-scoped.
+	const resumed = await call(thinkspacesRouter.get, { thinkspaceId: started.id }, { context });
+
+	assert.equal(resumed.id, started.id);
+	assert.equal(resumed.agentProfileRevision?.status, "draft");
+	assert.equal(resumed.agentProfileRevision?.identity.displayName, "Untitled Thinkspace");
+});
+
+test("list hides empty-Goal curation drafts while a draft that gains a Goal appears", async () => {
+	const db = createTestProductDb();
+	await db.insert(user).values({
+		email: "owner@example.com",
+		id: authenticatedSession.user.id,
+		name: "Owner",
+	});
+	const context = createCallContext({ db });
+
+	const inProgress = await call(thinkspacesRouter.startCuration, undefined, { context });
+	const withGoal = await call(
+		thinkspacesRouter.create,
+		{ goal: "Monitor model catalog releases" },
+		{ context },
+	);
+
+	assert.ok(inProgress);
+	assert.ok(withGoal);
+
+	const listed = await call(thinkspacesRouter.list, undefined, { context });
+	const listedIds = new Set(listed.map((thinkspace) => thinkspace.id));
+
+	assert.equal(listedIds.has(inProgress.id), false);
+	assert.equal(listedIds.has(withGoal.id), true);
+});
+
+test("a non-owner cannot fetch or resume another user's in-progress curation draft", async () => {
+	const db = createTestProductDb();
+	await db.insert(user).values({
+		email: "owner@example.com",
+		id: authenticatedSession.user.id,
+		name: "Owner",
+	});
+
+	const started = await call(thinkspacesRouter.startCuration, undefined, {
+		context: createCallContext({ db }),
+	});
+
+	assert.ok(started);
+
+	await assert.rejects(
+		call(
+			thinkspacesRouter.get,
+			{ thinkspaceId: started.id },
+			{
+				context: createCallContext({
+					db,
+					session: { session: { id: "session_other" }, user: { id: "other_user" } },
+				}),
+			},
+		),
+		expectCode("NOT_FOUND"),
+	);
+});
+
 test("owners can activate the draft Agent Profile revision and draft Thinkspace together", async () => {
 	const { db, patches } = createDbForAgentProfileActivation(
 		ownedThinkspaceRow({ ...ownedAgentProfileColumns("draft"), status: "draft" }),

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -52,6 +52,7 @@ import {
 import type { ConnectedAccountToolId } from "./connected-account-tools";
 import { createMcpToolAccessPermissionRequest, serializeThinkspaceToolSelections } from "./policy";
 import {
+	createCurationDraftThinkspaceRecord,
 	createThinkspaceArchivePatch,
 	createThinkspaceCreationRecord,
 	ThinkspaceLifecycleValidationError,
@@ -120,6 +121,15 @@ const submitTurnInput = z.object({
 
 const createThinkspaceId = (): string => `thinkspace_${crypto.randomUUID()}`;
 const createAgentProfileRevisionId = (): string => `agent_profile_revision_${crypto.randomUUID()}`;
+
+/**
+ * Placeholder display name a curation draft's first Agent Profile revision
+ * carries until the Curator names the agent. There is no user-authored name at
+ * `startCuration` — the Goal and identity emerge through the conversation — but
+ * `validateAgentProfileIdentity` rejects an empty display name, so the draft
+ * holds this until the Curator's `set_*` tools (#127) overwrite it.
+ */
+const CURATION_DRAFT_DISPLAY_NAME = "Untitled Thinkspace";
 
 /** Deduped, in stable catalog order, however the caller ordered them. */
 const normalizeBuiltInToolIds = (toolIds: readonly BuiltInToolId[]): BuiltInToolId[] => {
@@ -595,6 +605,47 @@ export const thinkspacesRouter = {
 				throw error;
 			}
 		}),
+	// Conversational entry point: minting a Thinkspace now begins a curation
+	// session, not a form submission. A DRAFT with an empty Goal plus its initial
+	// Agent Profile draft is created up front — the draft id is also the
+	// `CuratorAgent` key, so the front end opens the runtime against it. Empty-Goal
+	// drafts are hidden from `list` and resumable by id via `get` (owner-scoped),
+	// so an abandoned curation persists without cluttering the list.
+	startCuration: protectedProcedure.handler(async ({ context }) => {
+		try {
+			const record = createCurationDraftThinkspaceRecord({
+				id: createThinkspaceId(),
+				ownerUserId: context.session.user.id,
+			});
+			const identity = validateAgentProfileIdentity({
+				displayName: CURATION_DRAFT_DISPLAY_NAME,
+				instructions: "",
+			});
+			const settings = await getUserProductModelSettings(context.db, context.session.user.id);
+			const requestedModelId = settings?.defaultModel?.trim() || DEFAULT_MODEL_ID;
+			const { entry } = await validateCatalogModelId(context.modelCatalog, requestedModelId);
+			const modelBehavior = validateAgentProfileModelBehavior({
+				catalogEntry: entry,
+				modelId: requestedModelId,
+				reasoningLevel: getSeedReasoningLevel({
+					catalogEntryReasoning: entry.reasoning,
+					reasoningEffort: settings?.reasoningEffort,
+				}),
+			});
+			const draft = createInitialAgentProfileDraft({
+				id: createAgentProfileRevisionId(),
+				identity,
+				modelBehavior,
+				requestedPermissions: toRequestedPermissions(modelBehavior.modelId, [], [], []),
+				thinkspaceId: record.id,
+			});
+			const created = await createThinkspaceWithAgentProfileDraft(context.db, { draft, record });
+
+			return { ...created.thinkspace, agentProfileRevision: created.draft };
+		} catch (error) {
+			throwProductSafeProfileError(error);
+		}
+	}),
 	submitTurn: protectedProcedure.input(submitTurnInput).handler(async ({ context, input }) => {
 		try {
 			const acceptance = await submitOwnedThinkspaceTurn({


### PR DESCRIPTION
## Parent
PRD #123 (`curator_creation_v1`), child #126. Builds on #124 (curator model resolution) and #125 (`CuratorAgent` DO).

## What changed
Minting a Thinkspace now begins a curation conversation rather than submitting a form. A new `thinkspaces.startCuration` oRPC procedure mints a DRAFT with an **empty Goal** plus its initial Agent Profile draft, owned by the caller, and returns the draft — whose id is also the `CuratorAgent` key the front end opens the runtime against (via the existing `/api/curator/*` route).

- **`createCurationDraftThinkspaceRecord`** (`lifecycle.ts`) — sibling to `createThinkspaceCreationRecord` (which throws on an empty Goal). Mints an empty-Goal `status: draft` record, reusing `THINKSPACE_CREATION_DEFAULTS`, guarding owner + id.
- **`startCuration`** (`router.ts`) — mirrors the `create` mint sequence (settings → default model → catalog validation → model behavior → initial draft → batched persist). The first Agent Profile draft carries a `"Untitled Thinkspace"` placeholder display name because `validateAgentProfileIdentity` rejects an empty one; the Curator's `set_*` tools (#127) overwrite it.
- **`listThinkspaces`** (`repository.ts`) — SQL-level exclusion of `status='draft' AND goal=''`, so in-progress curations stay out of the main list. A draft that gains a real Goal (`goal != ''`) reappears.
- **Resume** — the existing owner-scoped `get` already returns an empty-Goal draft + its `draftRevision` with no goal/status filter, so it satisfies "fetchable/resumable by id" without a redundant procedure. Non-owners get 404-first.
- **Preserve, don't auto-delete** — abandoned empty drafts persist; no GC in this child.

`thinkspaces.create` is left callable (the static form is removed in #129).

## Acceptance criteria
- [x] `startCuration` mints a DRAFT Thinkspace (empty Goal) + initial draft Agent Profile, owned by the caller, returns the draft id
- [x] `thinkspaces.list` excludes empty-Goal drafts; a draft that gains a Goal appears
- [x] An in-progress (empty-Goal) draft is fetchable/resumable by id, owner-scoped
- [x] Ownership enforced: a non-owner cannot fetch/resume another user's draft (404-first); `startCuration` only ever acts for the caller
- [x] `bun run check-types`, `bun x ultracite check`, and `bun test packages/api` pass

## Tests
- `lifecycle.test.ts` — empty-Goal draft record shape; rejects missing owner/id
- `router.test.ts` — `startCuration` mint shape + owner-scoped resume via `get`; `list` hides empty-Goal drafts while a goal-bearing draft appears; non-owner 404-first on fetch/resume

344 `bun test packages/api` (339 baseline + 5 new). `check-types` + `ultracite` green.

Closes #126