### PR TITLE
Backend: Curator propose-only toolset (set_*/enable_tool; no activate/grant)

### DIFF
--- a/apps/server/src/agents/curator-agent.ts
+++ b/apps/server/src/agents/curator-agent.ts
@@ -8,11 +8,14 @@ import {
 import type { CurationForwardContext } from "@better-agent/api/curator/forward-context";
 import { CURATOR_RUNTIME_MAX_STEPS } from "@better-agent/api/curator/runtime";
 import { CURATOR_SYSTEM_PROMPT } from "@better-agent/api/curator/system-prompt";
+import { createProductModelCatalog } from "@better-agent/api/models/models-dev";
 import {
 	CuratorModelUnavailableError,
 	getUserCuratorModelSettings,
 	resolveCuratorModel,
 } from "@better-agent/api/models/curator";
+import { createCuratorRuntimeTools } from "@better-agent/api/thinkspaces/curator-runtime-tools";
+import type { CuratorRuntimeToolContext } from "@better-agent/api/thinkspaces/curator-runtime-tools";
 import { createDb } from "@better-agent/db";
 import type { ProductDb } from "@better-agent/db";
 import type { CloudflareEnv } from "@better-agent/env/types";
@@ -34,15 +37,17 @@ const CURATOR_MODEL_UNAVAILABLE_MESSAGE = "The Curator could not resolve a model
  * The Curator's creation runtime — a deliberate parallel of {@link ThinkspaceAgent},
  * for a different role (ADR-0010). Keyed on the **draft Thinkspace id** (one
  * Curator per draft), it reuses Project Think's durable session, streaming, and
- * recovery wholesale. This is the skeleton (#125): it runs and streams on the
- * ungated Curator model and carries the Curator system prompt, but assembles
- * **no mutation tools** — the propose-only `set_*`/`enable_tool` toolset lands in
- * #127. "Proposes, never grants" is therefore already structural here: there is
- * nothing for it to grant or activate with.
+ * recovery wholesale. It runs and streams on the ungated Curator model, carries
+ * the Curator system prompt, and assembles the propose-only `set_*`/`enable_tool`
+ * toolset (#127) that molds the bound draft Agent Profile. "Proposes, never
+ * grants" is structural: the toolset has no activate and no grant tool, so
+ * granting Permissions and activating the Thinkspace stay user-only acts.
  */
 export class CuratorAgent extends Think<CloudflareEnv> {
 	private readonly curatorSystemPrompt = CURATOR_SYSTEM_PROMPT;
-	private readonly curatorToolSet: ToolSet = {};
+	private readonly curatorToolSet: ToolSet = createCuratorRuntimeTools({
+		resolveContext: () => this.resolveCuratorToolContext(),
+	});
 	private readonly turnModelPlaceholder: LanguageModel = UNRESOLVED_CURATOR_MODEL;
 
 	override maxSteps = CURATOR_RUNTIME_MAX_STEPS;
@@ -98,6 +103,31 @@ export class CuratorAgent extends Think<CloudflareEnv> {
 
 	override getTools(): ToolSet {
 		return this.curatorToolSet;
+	}
+
+	/**
+	 * Resolves what the propose-only tools need at execute time: the (owner,
+	 * draft) the runtime is bound to, plus a product db and model catalog built
+	 * from this runtime's environment. Mirrors how `beforeTurn` reads the bound
+	 * context and builds the db. Returns null when the context is absent, so a
+	 * tool that somehow runs before admission fails product-safely rather than
+	 * touching another owner's data.
+	 */
+	private async resolveCuratorToolContext(): Promise<CuratorRuntimeToolContext | null> {
+		const context = await this.ctx.storage.get<CurationForwardContext>(
+			CURATION_CONTEXT_STORAGE_KEY,
+		);
+
+		if (!context) {
+			return null;
+		}
+
+		return {
+			db: createDb(this.env.DB),
+			draftThinkspaceId: context.draftThinkspaceId,
+			modelCatalog: createProductModelCatalog(this.env),
+			ownerUserId: context.ownerUserId,
+		};
 	}
 
 	override async beforeTurn() {

--- a/packages/api/src/thinkspaces/agent-profile.ts
+++ b/packages/api/src/thinkspaces/agent-profile.ts
@@ -237,6 +237,41 @@ export const isAgentProfileReasoningLevel = (value: unknown): value is AgentProf
 	AGENT_PROFILE_REASONING_LEVELS.includes(value as AgentProfileReasoningLevel);
 
 /**
+ * Derives an Agent Profile display name from a Goal, truncating with an
+ * ellipsis past the display-name limit. The Goal names the outcome; the name
+ * is its short label, so seeding the name from the Goal keeps the two aligned
+ * until a future slice lets the Curator name the agent independently.
+ */
+export const deriveAgentProfileDisplayName = (goal: string): string => {
+	const normalized = goal.trim();
+
+	if (normalized.length <= AGENT_PROFILE_DISPLAY_NAME_MAX_LENGTH) {
+		return normalized;
+	}
+
+	return `${normalized.slice(0, AGENT_PROFILE_DISPLAY_NAME_MAX_LENGTH - 1).trimEnd()}…`;
+};
+
+/**
+ * Picks the reasoning level to seed a revision with: non-reasoning models must
+ * be "none", otherwise the user's saved reasoning effort if it is a real level,
+ * falling back to "medium". Shared by Thinkspace creation and the Curator's
+ * `set_model` so both seed the same way.
+ */
+export const getSeedReasoningLevel = (input: {
+	catalogEntryReasoning: string;
+	reasoningEffort: string | null | undefined;
+}): AgentProfileReasoningLevel => {
+	if (input.catalogEntryReasoning === "none") {
+		return "none";
+	}
+
+	return isAgentProfileReasoningLevel(input.reasoningEffort) && input.reasoningEffort !== "none"
+		? input.reasoningEffort
+		: "medium";
+};
+
+/**
  * Validates the (model, reasoning level) pair against a catalog entry.
  * Non-reasoning models must use "none"; reasoning-capable models must pick
  * an actual level, so an Agent Profile can never hold an ambiguous pairing.

--- a/packages/api/src/thinkspaces/curator-runtime-tools.test.ts
+++ b/packages/api/src/thinkspaces/curator-runtime-tools.test.ts
@@ -1,0 +1,351 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+import { user } from "@better-agent/db/schema/auth";
+import { call } from "@orpc/server";
+import type { Tool, ToolCallOptions } from "ai";
+
+import type { Context } from "../context";
+import { DEFAULT_MODEL_ID, getModelCatalog } from "../models/catalog";
+import { createMemoryModelCatalog } from "../models/model-catalog";
+import type { ModelCatalog } from "../models/model-catalog";
+import { createTestProductDb } from "../testing/product-db";
+import {
+	getSeedReasoningLevel,
+	validateAgentProfileIdentity,
+	validateAgentProfileModelBehavior,
+} from "./agent-profile";
+import type { McpToolAccessPermissionRequest, RequestedPermission } from "./agent-profile";
+import { getDraftAgentProfileRevision } from "./agent-profile-repository";
+import { createInitialAgentProfileDraft } from "./agent-profile-lifecycle";
+import { createCuratorRuntimeTools } from "./curator-runtime-tools";
+import type {
+	CuratorRuntimeToolContext,
+	ResolveCuratorRuntimeToolContext,
+} from "./curator-runtime-tools";
+import { createCurationDraftThinkspaceRecord } from "./lifecycle";
+import {
+	createThinkspaceWithAgentProfileDraft,
+	getThinkspace,
+	listThinkspaces,
+} from "./repository";
+import { thinkspacesRouter } from "./router";
+import { toRequestedPermissions } from "./tool-selection";
+
+const OWNER_ID = "curator_owner";
+const DRAFT_ID = "thinkspace_curation_draft";
+const TOOL_CALL_OPTIONS = { messages: [], toolCallId: "tool_call_1" } as ToolCallOptions;
+const modelCatalog: ModelCatalog = createMemoryModelCatalog([...getModelCatalog()]);
+
+const executeTool = async (toolDefinition: Tool | undefined, input: unknown): Promise<string> => {
+	assert.ok(toolDefinition?.execute, "tool must be constructed with an execute handler");
+
+	return (await toolDefinition.execute(input as never, TOOL_CALL_OPTIONS)) as string;
+};
+
+/**
+ * Seeds the exact (DRAFT Thinkspace + initial empty-Goal Agent Profile draft)
+ * pair `startCuration` mints, so the Curator tools run against a faithful draft.
+ */
+const seedCurationDraft = async (
+	db: ProductDb,
+	{
+		ownerUserId = OWNER_ID,
+		thinkspaceId = DRAFT_ID,
+	}: { ownerUserId?: string; thinkspaceId?: string } = {},
+): Promise<void> => {
+	await db
+		.insert(user)
+		.values({ email: `${ownerUserId}@example.com`, id: ownerUserId, name: "Owner" });
+
+	const record = createCurationDraftThinkspaceRecord({ id: thinkspaceId, ownerUserId });
+	const identity = validateAgentProfileIdentity({
+		displayName: "Untitled Thinkspace",
+		instructions: "",
+	});
+	const entry = await modelCatalog.getModel(DEFAULT_MODEL_ID);
+	assert.ok(entry, "seed model must exist in the catalog");
+	const modelBehavior = validateAgentProfileModelBehavior({
+		catalogEntry: entry,
+		modelId: DEFAULT_MODEL_ID,
+		reasoningLevel: getSeedReasoningLevel({
+			catalogEntryReasoning: entry.reasoning,
+			reasoningEffort: "medium",
+		}),
+	});
+	const draft = createInitialAgentProfileDraft({
+		id: `agent_profile_revision_${crypto.randomUUID()}`,
+		identity,
+		modelBehavior,
+		requestedPermissions: toRequestedPermissions(modelBehavior.modelId, [], [], []),
+		thinkspaceId,
+	});
+	await createThinkspaceWithAgentProfileDraft(db, { draft, record });
+};
+
+const boundContext = (db: ProductDb): CuratorRuntimeToolContext => ({
+	db,
+	draftThinkspaceId: DRAFT_ID,
+	modelCatalog,
+	ownerUserId: OWNER_ID,
+});
+
+const toolsFor = (resolveContext: ResolveCuratorRuntimeToolContext) =>
+	createCuratorRuntimeTools({ resolveContext });
+
+const boundToolsFor = (db: ProductDb) => toolsFor(() => Promise.resolve(boundContext(db)));
+
+const readDraft = async (db: ProductDb) => {
+	const draft = await getDraftAgentProfileRevision(db, { thinkspaceId: DRAFT_ID });
+	assert.ok(draft, "the seeded draft must still exist");
+	return draft;
+};
+
+const updateToolSelectionsContext = (db: ProductDb): Context =>
+	({
+		db,
+		env: {},
+		executionCtx: undefined,
+		headers: new Headers(),
+		modelCatalog,
+		session: { session: { id: "session_1" }, user: { id: OWNER_ID } },
+	}) as unknown as Context;
+
+test("the Curator toolset is exactly the five propose-only tools — no activate, no grant", () => {
+	const tools = createCuratorRuntimeTools({ resolveContext: () => Promise.resolve(null) });
+
+	assert.equal("activate" in tools, false);
+	assert.equal("grant" in tools, false);
+	assert.deepEqual(Object.keys(tools).toSorted(), [
+		"enable_tool",
+		"set_configuration_summary",
+		"set_goal",
+		"set_instructions",
+		"set_model",
+	]);
+});
+
+test("a tool with no bound context changes nothing and returns a product-safe message", async () => {
+	const db = createTestProductDb();
+	await seedCurationDraft(db);
+	const tools = toolsFor(() => Promise.resolve(null));
+
+	const result = await executeTool(tools.set_goal, { goal: "Ship the curator slice" });
+
+	assert.match(result, /draft Thinkspace/u);
+	const thinkspace = await getThinkspace(db, { ownerUserId: OWNER_ID, thinkspaceId: DRAFT_ID });
+	assert.equal(thinkspace?.goal, "");
+});
+
+test("set_goal gives the empty-Goal draft a real Goal and returns it to the owner's list", async () => {
+	const db = createTestProductDb();
+	await seedCurationDraft(db);
+	const tools = boundToolsFor(db);
+
+	const before = await listThinkspaces(db, { ownerUserId: OWNER_ID });
+	assert.equal(before.length, 0);
+
+	const result = await executeTool(tools.set_goal, { goal: "  Monitor SDK releases weekly  " });
+
+	assert.match(result, /Monitor SDK releases weekly/u);
+	const thinkspace = await getThinkspace(db, { ownerUserId: OWNER_ID, thinkspaceId: DRAFT_ID });
+	assert.equal(thinkspace?.goal, "Monitor SDK releases weekly");
+	// The agent's name tracks the Goal, replacing the placeholder.
+	const draft = await readDraft(db);
+	assert.equal(draft.identity.displayName, "Monitor SDK releases weekly");
+	const after = await listThinkspaces(db, { ownerUserId: OWNER_ID });
+	assert.equal(after.length, 1);
+});
+
+test("set_goal rejects an empty Goal without touching the draft", async () => {
+	const db = createTestProductDb();
+	await seedCurationDraft(db);
+	const tools = boundToolsFor(db);
+
+	const result = await executeTool(tools.set_goal, { goal: "   " });
+
+	assert.match(result, /Goal is required/u);
+	const thinkspace = await getThinkspace(db, { ownerUserId: OWNER_ID, thinkspaceId: DRAFT_ID });
+	assert.equal(thinkspace?.goal, "");
+	const draft = await readDraft(db);
+	assert.equal(draft.identity.displayName, "Untitled Thinkspace");
+});
+
+test("set_configuration_summary writes the summary to the bound draft Thinkspace", async () => {
+	const db = createTestProductDb();
+	await seedCurationDraft(db);
+	const tools = boundToolsFor(db);
+
+	await executeTool(tools.set_configuration_summary, {
+		summary: "Reads release notes, drafts a handoff.",
+	});
+
+	const thinkspace = await getThinkspace(db, { ownerUserId: OWNER_ID, thinkspaceId: DRAFT_ID });
+	assert.equal(thinkspace?.configurationSummary, "Reads release notes, drafts a handoff.");
+});
+
+test("set_instructions updates the draft revision's instructions, leaving the name untouched", async () => {
+	const db = createTestProductDb();
+	await seedCurationDraft(db);
+	const tools = boundToolsFor(db);
+
+	await executeTool(tools.set_instructions, { instructions: "Always cite the source release." });
+
+	const draft = await readDraft(db);
+	assert.equal(draft.identity.instructions, "Always cite the source release.");
+	assert.equal(draft.identity.displayName, "Untitled Thinkspace");
+});
+
+test("set_model rewrites the model and re-derives the model-provider credential request", async () => {
+	const db = createTestProductDb();
+	await seedCurationDraft(db);
+	const tools = boundToolsFor(db);
+
+	const result = await executeTool(tools.set_model, { modelId: "openai:gpt-4o-mini" });
+
+	assert.match(result, /gpt-4o-mini/u);
+	const draft = await readDraft(db);
+	assert.deepEqual(draft.modelBehavior, { modelId: "openai:gpt-4o-mini", reasoningLevel: "none" });
+	const credential = draft.requestedPermissions.find(
+		(permission) => permission.kind === "model_provider_credential",
+	);
+	assert.equal(
+		credential?.kind === "model_provider_credential" ? credential.providerId : null,
+		"openai",
+	);
+});
+
+test("set_model rejects a model id outside the catalog and leaves the draft model unchanged", async () => {
+	const db = createTestProductDb();
+	await seedCurationDraft(db);
+	const tools = boundToolsFor(db);
+
+	const result = await executeTool(tools.set_model, { modelId: "google:not-real" });
+
+	assert.match(result, /not in the supported model catalog/u);
+	const draft = await readDraft(db);
+	assert.equal(draft.modelBehavior.modelId, DEFAULT_MODEL_ID);
+});
+
+test("set_model preserves enabled-tool Permissions while switching providers", async () => {
+	const db = createTestProductDb();
+	await seedCurationDraft(db);
+	const tools = boundToolsFor(db);
+
+	await executeTool(tools.enable_tool, { toolId: "web_search" });
+	await executeTool(tools.set_model, { modelId: "openai:gpt-4o-mini" });
+
+	const draft = await readDraft(db);
+	const kinds = draft.requestedPermissions.map((permission) => permission.kind).toSorted();
+	assert.deepEqual(kinds, ["built_in_web_read", "model_provider_credential"]);
+	const credential = draft.requestedPermissions.find(
+		(permission) => permission.kind === "model_provider_credential",
+	);
+	assert.equal(
+		credential?.kind === "model_provider_credential" ? credential.providerId : null,
+		"openai",
+	);
+});
+
+test("set_model recovers an MCP tool's risk when re-deriving its Permission", async () => {
+	const db = createTestProductDb();
+	await seedCurationDraft(db);
+	const tools = boundToolsFor(db);
+
+	await executeTool(tools.enable_tool, { risk: "mutating", toolId: "github-mcp:open_pr" });
+	await executeTool(tools.set_model, { modelId: "openai:gpt-4o-mini" });
+
+	const draft = await readDraft(db);
+	const mcpRequest = draft.requestedPermissions.find(
+		(permission): permission is McpToolAccessPermissionRequest =>
+			permission.kind === "mcp_tool_access",
+	);
+	assert.equal(mcpRequest?.risk, "mutating");
+	assert.equal(mcpRequest?.serverId, "github-mcp");
+});
+
+test("enable_tool is idempotent: re-enabling a tool reports it and writes nothing new", async () => {
+	const db = createTestProductDb();
+	await seedCurationDraft(db);
+	const tools = boundToolsFor(db);
+
+	await executeTool(tools.enable_tool, { toolId: "web_search" });
+	const before = await readDraft(db);
+
+	const result = await executeTool(tools.enable_tool, { toolId: "web_search" });
+
+	assert.match(result, /already enabled/u);
+	const after = await readDraft(db);
+	assert.deepEqual(after.toolEnablements, before.toolEnablements);
+	assert.deepEqual(after.requestedPermissions, before.requestedPermissions);
+});
+
+test("enable_tool fails product-safely on a malformed MCP id and writes nothing", async () => {
+	const db = createTestProductDb();
+	await seedCurationDraft(db);
+	const tools = boundToolsFor(db);
+	const before = await readDraft(db);
+
+	const result = await executeTool(tools.enable_tool, { toolId: ":missing-server" });
+
+	assert.match(result, /server ID/u);
+	const after = await readDraft(db);
+	assert.deepEqual(after.toolEnablements, before.toolEnablements);
+	assert.deepEqual(after.requestedPermissions, before.requestedPermissions);
+});
+
+/**
+ * The core acceptance: enabling a tool through the Curator derives the exact
+ * same enablement + requested Permission the owner UI's `updateToolSelections`
+ * derives, because both route through the shared `tool-selection` seam.
+ */
+const assertEnableToolMatchesUpdateToolSelections = async ({
+	enableInput,
+	updateInput,
+}: {
+	enableInput: { risk?: "read_only" | "mutating" | "unknown"; toolId: string };
+	updateInput: Record<string, unknown>;
+}): Promise<void> => {
+	const curatorDb = createTestProductDb();
+	await seedCurationDraft(curatorDb);
+	await executeTool(boundToolsFor(curatorDb).enable_tool, enableInput);
+	const curatorDraft = await readDraft(curatorDb);
+
+	const ownerDb = createTestProductDb();
+	await seedCurationDraft(ownerDb);
+	await call(
+		thinkspacesRouter.updateToolSelections,
+		{ selections: [], thinkspaceId: DRAFT_ID, ...updateInput },
+		{ context: updateToolSelectionsContext(ownerDb) },
+	);
+	const ownerDraft = await getDraftAgentProfileRevision(ownerDb, { thinkspaceId: DRAFT_ID });
+	assert.ok(ownerDraft);
+
+	assert.deepEqual(curatorDraft.toolEnablements, ownerDraft.toolEnablements);
+	assert.deepEqual(
+		curatorDraft.requestedPermissions as RequestedPermission[],
+		ownerDraft.requestedPermissions as RequestedPermission[],
+	);
+};
+
+test("enable_tool derives a built-in tool exactly as updateToolSelections does", async () => {
+	await assertEnableToolMatchesUpdateToolSelections({
+		enableInput: { toolId: "web_search" },
+		updateInput: { builtInToolIds: ["web_search"] },
+	});
+});
+
+test("enable_tool derives a connected-account tool exactly as updateToolSelections does", async () => {
+	await assertEnableToolMatchesUpdateToolSelections({
+		enableInput: { toolId: "github:create_issue" },
+		updateInput: { connectedAccountToolIds: ["github:create_issue"] },
+	});
+});
+
+test("enable_tool derives an MCP tool exactly as updateToolSelections does", async () => {
+	await assertEnableToolMatchesUpdateToolSelections({
+		enableInput: { risk: "read_only", toolId: "cloudflare-docs" },
+		updateInput: { selections: [{ risk: "read_only", serverId: "cloudflare-docs" }] },
+	});
+});

--- a/packages/api/src/thinkspaces/curator-runtime-tools.ts
+++ b/packages/api/src/thinkspaces/curator-runtime-tools.ts
@@ -1,0 +1,450 @@
+/**
+ * The Curator's propose-only toolset (#127) — the tools that let the creation
+ * conversation mold a draft Agent Profile live, the heart of the refinement
+ * engine. Each tool is owner-scoped to the one draft the `CuratorAgent` is bound
+ * to (it resolves the draft from the runtime's stored context, never from a tool
+ * argument) and writes through the same Agent-Profile-draft and tool-selection
+ * seams the owner UI uses, so the Curator's proposals and the owner's edits can
+ * never derive Permissions differently.
+ *
+ * The invariant "proposes, never grants" is structural here: there is no
+ * `activate` tool and no `grant` tool to hand out. Enabling a tool only records
+ * the requested Permission on the draft; the owner grants it, and activates the
+ * Thinkspace, as a separate act outside this runtime (ADR-0010). Every execution
+ * failure resolves to a product-safe string (never a thrown error and never a
+ * fabricated success) so the bounded Curator loop keeps running.
+ */
+import type { ProductDb } from "@better-agent/db";
+import { tool } from "ai";
+import type { ToolSet } from "ai";
+import { z } from "zod";
+
+import { ModelCatalogError, validateCatalogModelId } from "../models/model-catalog";
+import type { ModelCatalog } from "../models/model-catalog";
+import {
+	AGENT_PROFILE_INSTRUCTIONS_MAX_LENGTH,
+	AGENT_PROFILE_REASONING_LEVELS,
+	AgentProfileValidationError,
+	deriveAgentProfileDisplayName,
+	getSeedReasoningLevel,
+	MCP_TOOL_ACCESS_REQUEST_RISKS,
+	validateAgentProfileIdentity,
+	validateAgentProfileModelBehavior,
+} from "./agent-profile";
+import type { DraftAgentProfileRevision, McpToolAccessRequestRisk } from "./agent-profile";
+import { getDraftAgentProfileRevision, saveAgentProfileDraft } from "./agent-profile-repository";
+import { isBuiltInToolId } from "./built-in-tools";
+import { isConnectedAccountToolId } from "./connected-account-tools";
+import {
+	MAX_CONFIGURATION_SUMMARY_LENGTH,
+	MAX_GOAL_LENGTH,
+	ThinkspaceLifecycleValidationError,
+	validateCurationConfigurationSummary,
+	validateCurationGoal,
+} from "./lifecycle";
+import { PermissionPolicyError } from "./policy";
+import { applyCurationGoal, updateCurationDraftThinkspace } from "./repository";
+import {
+	normalizeBuiltInToolIds,
+	normalizeConnectedAccountToolIds,
+	parseMcpEnablementToolId,
+	toRequestedPermissions,
+	toToolEnablements,
+	toToolSelectionSet,
+} from "./tool-selection";
+import type { ThinkspaceToolSelectionSet } from "./tool-selection";
+
+/**
+ * Everything a Curator tool needs at execute time, resolved together: the draft
+ * the runtime is bound to ({@link CurationForwardContext}), plus the product db
+ * and model catalog built from the runtime's environment. Resolving it lazily
+ * (the draft id lives in async DO storage, `getTools()` is sync) keeps the tools
+ * free of the runtime substrate.
+ */
+export interface CuratorRuntimeToolContext {
+	db: ProductDb;
+	draftThinkspaceId: string;
+	modelCatalog: ModelCatalog;
+	ownerUserId: string;
+}
+
+export type ResolveCuratorRuntimeToolContext = () => Promise<CuratorRuntimeToolContext | null>;
+
+export interface CreateCuratorRuntimeToolsInput {
+	resolveContext: ResolveCuratorRuntimeToolContext;
+}
+
+const MISSING_CONTEXT_MESSAGE =
+	"This curation conversation has lost its draft Thinkspace, so nothing was changed.";
+const DRAFT_UNAVAILABLE_MESSAGE =
+	"This curation draft is no longer available, so nothing was changed.";
+const CATALOG_UNAVAILABLE_MESSAGE =
+	"The model catalog is temporarily unavailable, so the model could not be changed. Try again shortly.";
+const UNEXPECTED_FAILURE_MESSAGE =
+	"That change could not be applied, so nothing was changed. Mention the limitation rather than describing it as done.";
+
+/**
+ * Validation and lookup failures become honest product-safe results, not
+ * exceptions or fabricated successes. Typed domain errors already carry
+ * owner-facing guidance; anything else collapses to a generic no-change message.
+ */
+const toProductSafeToolFailure = (error: unknown): string => {
+	if (
+		error instanceof ThinkspaceLifecycleValidationError ||
+		error instanceof AgentProfileValidationError ||
+		error instanceof PermissionPolicyError
+	) {
+		return error.message;
+	}
+
+	if (error instanceof ModelCatalogError) {
+		return error.kind === "catalog_unavailable" ? CATALOG_UNAVAILABLE_MESSAGE : error.message;
+	}
+
+	return UNEXPECTED_FAILURE_MESSAGE;
+};
+
+type BoundDraftResult =
+	| { context: CuratorRuntimeToolContext; draft: DraftAgentProfileRevision; ok: true }
+	| { message: string; ok: false };
+
+/**
+ * Resolves the bound context and the draft's single revision together — the
+ * common preamble for every tool that reads or writes the draft revision. A
+ * missing context or absent draft fails product-safely.
+ */
+const loadBoundDraft = async (
+	resolveContext: ResolveCuratorRuntimeToolContext,
+): Promise<BoundDraftResult> => {
+	const context = await resolveContext();
+
+	if (!context) {
+		return { message: MISSING_CONTEXT_MESSAGE, ok: false };
+	}
+
+	const draft = await getDraftAgentProfileRevision(context.db, {
+		thinkspaceId: context.draftThinkspaceId,
+	});
+
+	if (!draft) {
+		return { message: DRAFT_UNAVAILABLE_MESSAGE, ok: false };
+	}
+
+	return { context, draft, ok: true };
+};
+
+interface ToolEnablementAddition {
+	alreadyEnabled: boolean;
+	set: ThinkspaceToolSelectionSet;
+}
+
+/**
+ * Adds one tool to a reconstructed selection set, routed by catalog: a built-in
+ * id, a connected-account id, or otherwise an MCP `serverId`/`serverId:toolName`
+ * reference (the `risk` argument applies only to MCP). Enabling an
+ * already-enabled tool is a no-op the caller reports rather than a duplicate.
+ */
+const addToolToSelectionSet = (
+	current: ThinkspaceToolSelectionSet,
+	toolId: string,
+	risk: McpToolAccessRequestRisk | undefined,
+): ToolEnablementAddition => {
+	if (isBuiltInToolId(toolId)) {
+		if (current.builtInToolIds.includes(toolId)) {
+			return { alreadyEnabled: true, set: current };
+		}
+
+		return {
+			alreadyEnabled: false,
+			set: { ...current, builtInToolIds: [...current.builtInToolIds, toolId] },
+		};
+	}
+
+	if (isConnectedAccountToolId(toolId)) {
+		if (current.connectedAccountToolIds.includes(toolId)) {
+			return { alreadyEnabled: true, set: current };
+		}
+
+		return {
+			alreadyEnabled: false,
+			set: {
+				...current,
+				connectedAccountToolIds: [...current.connectedAccountToolIds, toolId],
+			},
+		};
+	}
+
+	const { serverId, toolName } = parseMcpEnablementToolId(toolId);
+	const alreadyEnabled = current.selections.some(
+		(selection) => selection.serverId === serverId && selection.toolName === toolName,
+	);
+
+	if (alreadyEnabled) {
+		return { alreadyEnabled: true, set: current };
+	}
+
+	return {
+		alreadyEnabled: false,
+		set: {
+			...current,
+			selections: [...current.selections, { risk: risk ?? "unknown", serverId, toolName }],
+		},
+	};
+};
+
+const createSetGoalTool = (resolveContext: ResolveCuratorRuntimeToolContext) =>
+	tool({
+		description:
+			"Set this Thinkspace's Goal — the single bounded, checkable outcome the Agent Profile is shaped around. Giving the draft a real Goal returns it to the owner's Thinkspace list. Proposes only; nothing is activated.",
+		execute: async ({ goal }) => {
+			const bound = await loadBoundDraft(resolveContext);
+
+			if (!bound.ok) {
+				return bound.message;
+			}
+
+			const { context, draft } = bound;
+
+			try {
+				const validatedGoal = validateCurationGoal(goal);
+				// With no separate naming tool, the agent's name tracks the Goal — the
+				// same Goal -> display-name seed Thinkspace creation uses — so the agent
+				// card stops reading "Untitled Thinkspace" as soon as the Goal is real.
+				// Validate everything before the single atomic write so a failure leaves
+				// the draft untouched and the result message honest.
+				const identity = validateAgentProfileIdentity({
+					displayName: deriveAgentProfileDisplayName(validatedGoal),
+					instructions: draft.identity.instructions,
+				});
+				const updatedThinkspace = await applyCurationGoal(context.db, {
+					displayName: identity.displayName,
+					goal: validatedGoal,
+					ownerUserId: context.ownerUserId,
+					revisionId: draft.id,
+					thinkspaceId: context.draftThinkspaceId,
+					updatedAt: new Date(),
+				});
+
+				if (!updatedThinkspace) {
+					return DRAFT_UNAVAILABLE_MESSAGE;
+				}
+
+				return `Set the Goal to: ${validatedGoal}`;
+			} catch (error) {
+				return toProductSafeToolFailure(error);
+			}
+		},
+		inputSchema: z.object({
+			goal: z
+				.string()
+				.min(1)
+				.max(MAX_GOAL_LENGTH)
+				.describe("The single bounded, checkable outcome this Thinkspace exists to reach."),
+		}),
+	});
+
+const createSetConfigurationSummaryTool = (resolveContext: ResolveCuratorRuntimeToolContext) =>
+	tool({
+		description:
+			"Set this Thinkspace's configuration summary — a short plain-language description of how it is set up. Pass an empty string to clear it. Proposes only.",
+		execute: async ({ summary }) => {
+			const context = await resolveContext();
+
+			if (!context) {
+				return MISSING_CONTEXT_MESSAGE;
+			}
+
+			try {
+				const validatedSummary = validateCurationConfigurationSummary(summary);
+				const updatedThinkspace = await updateCurationDraftThinkspace(context.db, {
+					ownerUserId: context.ownerUserId,
+					patch: { configurationSummary: validatedSummary, updatedAt: new Date() },
+					thinkspaceId: context.draftThinkspaceId,
+				});
+
+				if (!updatedThinkspace) {
+					return DRAFT_UNAVAILABLE_MESSAGE;
+				}
+
+				return validatedSummary
+					? "Updated the configuration summary."
+					: "Cleared the configuration summary.";
+			} catch (error) {
+				return toProductSafeToolFailure(error);
+			}
+		},
+		inputSchema: z.object({
+			summary: z
+				.string()
+				.max(MAX_CONFIGURATION_SUMMARY_LENGTH)
+				.describe("A short plain-language description of how this Thinkspace is configured."),
+		}),
+	});
+
+const createSetInstructionsTool = (resolveContext: ResolveCuratorRuntimeToolContext) =>
+	tool({
+		description:
+			"Set the Agent Profile instructions — the standing guidance the future Thinkspace Agent runs under. Proposes only.",
+		execute: async ({ instructions }) => {
+			const bound = await loadBoundDraft(resolveContext);
+
+			if (!bound.ok) {
+				return bound.message;
+			}
+
+			const { context, draft } = bound;
+
+			try {
+				const identity = validateAgentProfileIdentity({
+					displayName: draft.identity.displayName,
+					instructions,
+				});
+				await saveAgentProfileDraft(context.db, {
+					draft: { ...draft, identity, updatedAt: new Date() },
+				});
+
+				return "Updated the Agent Profile instructions.";
+			} catch (error) {
+				return toProductSafeToolFailure(error);
+			}
+		},
+		inputSchema: z.object({
+			instructions: z
+				.string()
+				.max(AGENT_PROFILE_INSTRUCTIONS_MAX_LENGTH)
+				.describe("The standing guidance the future Thinkspace Agent runs under."),
+		}),
+	});
+
+const createSetModelTool = (resolveContext: ResolveCuratorRuntimeToolContext) =>
+	tool({
+		description:
+			"Set the model the future Thinkspace Agent runs on, validated against the supported catalog. Optionally set its reasoning level. Proposes only.",
+		execute: async ({ modelId, reasoningLevel }) => {
+			const bound = await loadBoundDraft(resolveContext);
+
+			if (!bound.ok) {
+				return bound.message;
+			}
+
+			const { context, draft } = bound;
+
+			try {
+				const { entry } = await validateCatalogModelId(context.modelCatalog, modelId);
+				const modelBehavior = validateAgentProfileModelBehavior({
+					catalogEntry: entry,
+					modelId: entry.id,
+					reasoningLevel: getSeedReasoningLevel({
+						catalogEntryReasoning: entry.reasoning,
+						reasoningEffort: reasoningLevel,
+					}),
+				});
+				// Changing the model changes its provider, so the model-provider
+				// credential request must be re-derived; re-running the shared
+				// derivation over the draft's existing tools keeps every other request
+				// identical to what the owner UI would have written.
+				const selectionSet = toToolSelectionSet(draft.toolEnablements, draft.requestedPermissions);
+				await saveAgentProfileDraft(context.db, {
+					draft: {
+						...draft,
+						modelBehavior,
+						requestedPermissions: toRequestedPermissions(
+							modelBehavior.modelId,
+							selectionSet.builtInToolIds,
+							selectionSet.connectedAccountToolIds,
+							selectionSet.selections,
+						),
+						updatedAt: new Date(),
+					},
+				});
+
+				return `Set the model to ${entry.name} (${modelBehavior.modelId}) at ${modelBehavior.reasoningLevel} reasoning.`;
+			} catch (error) {
+				return toProductSafeToolFailure(error);
+			}
+		},
+		inputSchema: z.object({
+			modelId: z.string().min(1).describe("A catalog model id, e.g. anthropic:claude-sonnet-4-5."),
+			reasoningLevel: z
+				.enum(AGENT_PROFILE_REASONING_LEVELS)
+				.optional()
+				.describe("Reasoning level; ignored for non-reasoning models. Defaults sensibly."),
+		}),
+	});
+
+const createEnableToolTool = (resolveContext: ResolveCuratorRuntimeToolContext) =>
+	tool({
+		description:
+			"Enable one tool for the future Thinkspace Agent and request the Permission it needs. Accepts a built-in tool id, a connected-account tool id, or an MCP server reference (serverId or serverId:toolName). This only requests the Permission; the owner grants it at activation. Proposes only.",
+		execute: async ({ risk, toolId }) => {
+			const bound = await loadBoundDraft(resolveContext);
+
+			if (!bound.ok) {
+				return bound.message;
+			}
+
+			const { context, draft } = bound;
+
+			try {
+				const current = toToolSelectionSet(draft.toolEnablements, draft.requestedPermissions);
+				const addition = addToolToSelectionSet(current, toolId, risk);
+
+				if (addition.alreadyEnabled) {
+					return `${toolId} is already enabled for this Agent Profile.`;
+				}
+
+				const builtInToolIds = normalizeBuiltInToolIds(addition.set.builtInToolIds);
+				const connectedAccountToolIds = normalizeConnectedAccountToolIds(
+					addition.set.connectedAccountToolIds,
+				);
+				await saveAgentProfileDraft(context.db, {
+					draft: {
+						...draft,
+						requestedPermissions: toRequestedPermissions(
+							draft.modelBehavior.modelId,
+							builtInToolIds,
+							connectedAccountToolIds,
+							addition.set.selections,
+						),
+						toolEnablements: toToolEnablements(
+							builtInToolIds,
+							connectedAccountToolIds,
+							addition.set.selections,
+						),
+						updatedAt: new Date(),
+					},
+				});
+
+				return `Enabled ${toolId} and requested the Permission it needs. You grant it when you activate the Thinkspace.`;
+			} catch (error) {
+				return toProductSafeToolFailure(error);
+			}
+		},
+		inputSchema: z.object({
+			risk: z
+				.enum(MCP_TOOL_ACCESS_REQUEST_RISKS)
+				.optional()
+				.describe("For an MCP server tool, its access risk. Ignored for other tool sources."),
+			toolId: z
+				.string()
+				.min(1)
+				.describe(
+					"A built-in tool id, a connected-account tool id, or an MCP serverId[:toolName].",
+				),
+		}),
+	});
+
+/**
+ * Assembles the Curator's complete propose-only toolset. There is deliberately
+ * no `activate` and no `grant` tool — "proposes, never grants" is a structural
+ * property of this set, not a runtime check the Curator could forget.
+ */
+export const createCuratorRuntimeTools = ({
+	resolveContext,
+}: CreateCuratorRuntimeToolsInput): ToolSet => ({
+	enable_tool: createEnableToolTool(resolveContext),
+	set_configuration_summary: createSetConfigurationSummaryTool(resolveContext),
+	set_goal: createSetGoalTool(resolveContext),
+	set_instructions: createSetInstructionsTool(resolveContext),
+	set_model: createSetModelTool(resolveContext),
+});

--- a/packages/api/src/thinkspaces/lifecycle.ts
+++ b/packages/api/src/thinkspaces/lifecycle.ts
@@ -1,8 +1,8 @@
 import { THINKSPACE_STATUS } from "@better-agent/db/schema/thinkspaces";
 import type { NewThinkspace } from "@better-agent/db/schema/thinkspaces";
 
-const MAX_GOAL_LENGTH = 280;
-const MAX_CONFIGURATION_SUMMARY_LENGTH = 1600;
+export const MAX_GOAL_LENGTH = 280;
+export const MAX_CONFIGURATION_SUMMARY_LENGTH = 1600;
 
 export const THINKSPACE_CREATION_DEFAULTS = {
 	memoryGovernance: {
@@ -97,6 +97,36 @@ export const createCurationDraftThinkspaceRecord = ({
 		ownerUserId,
 		status: THINKSPACE_STATUS.DRAFT,
 	};
+};
+
+/**
+ * Validates a Goal the Curator proposes for a draft Thinkspace: a non-empty,
+ * length-bounded string. A real Goal is what flips an in-progress curation
+ * draft back into the owner's list (#126), so an empty Goal is rejected here
+ * just as it is at form-based creation.
+ */
+export const validateCurationGoal = (goal: string): string => {
+	const normalized = normalizeText(goal);
+
+	if (!normalized) {
+		throw new ThinkspaceLifecycleValidationError("Goal is required to shape a Thinkspace.");
+	}
+
+	assertMaxLength("Goal", normalized, MAX_GOAL_LENGTH);
+
+	return normalized;
+};
+
+/**
+ * Validates a configuration summary the Curator proposes: length-bounded, and
+ * allowed to be cleared back to empty.
+ */
+export const validateCurationConfigurationSummary = (summary: string): string => {
+	const normalized = normalizeText(summary);
+
+	assertMaxLength("Configuration summary", normalized, MAX_CONFIGURATION_SUMMARY_LENGTH);
+
+	return normalized;
 };
 
 export const createThinkspaceCreationRecord = ({

--- a/packages/api/src/thinkspaces/repository.ts
+++ b/packages/api/src/thinkspaces/repository.ts
@@ -84,6 +84,72 @@ export const archiveThinkspace = async (
 	return archived ?? null;
 };
 
+export interface UpdateCurationDraftThinkspaceInput {
+	ownerUserId: string;
+	patch: Partial<Pick<typeof thinkspaces.$inferInsert, "configurationSummary" | "goal">> & {
+		updatedAt: Date;
+	};
+	thinkspaceId: string;
+}
+
+/**
+ * Applies a Curator-proposed change to a draft Thinkspace's own fields (Goal,
+ * configuration summary). Owner-scoped as defense in depth even though the
+ * Curator runtime is already bound to one owner+draft: the patch can only land
+ * on a Thinkspace the caller owns, and a miss returns null so the tool fails
+ * product-safely. Giving an empty-Goal draft a real Goal is what returns it to
+ * the owner's list (see `listThinkspaces`).
+ */
+export const updateCurationDraftThinkspace = async (
+	db: ProductDb,
+	{ ownerUserId, patch, thinkspaceId }: UpdateCurationDraftThinkspaceInput,
+): Promise<Thinkspace | null> => {
+	const [updated] = await db
+		.update(thinkspaces)
+		.set(patch)
+		.where(and(eq(thinkspaces.id, thinkspaceId), eq(thinkspaces.ownerUserId, ownerUserId)))
+		.returning();
+
+	return updated ?? null;
+};
+
+export interface ApplyCurationGoalInput {
+	displayName: string;
+	goal: string;
+	ownerUserId: string;
+	revisionId: string;
+	thinkspaceId: string;
+	updatedAt: Date;
+}
+
+/**
+ * Atomically gives a curation draft a real Goal and the matching display name:
+ * the Thinkspace row's Goal (which returns the draft to the owner's list) and
+ * the draft revision's display name move together in one D1 batch, so a failure
+ * can never leave the Goal set while the agent card still reads "Untitled
+ * Thinkspace". Owner-scoped on the Thinkspace; returns null (no Thinkspace
+ * updated) so the caller fails product-safely without having written anything.
+ */
+export const applyCurationGoal = async (
+	db: ProductDb,
+	{ displayName, goal, ownerUserId, revisionId, thinkspaceId, updatedAt }: ApplyCurationGoalInput,
+): Promise<Thinkspace | null> => {
+	const [thinkspaceRows] = await db.batch([
+		db
+			.update(thinkspaces)
+			.set({ goal, updatedAt })
+			.where(and(eq(thinkspaces.id, thinkspaceId), eq(thinkspaces.ownerUserId, ownerUserId)))
+			.returning(),
+		db
+			.update(thinkspaceAgentProfiles)
+			.set({ displayName, updatedAt })
+			.where(eq(thinkspaceAgentProfiles.id, revisionId)),
+	]);
+	const [updated] = thinkspaceRows;
+
+	return updated ?? null;
+};
+
 export const listThinkspaces = async (
 	db: ProductDb,
 	{ ownerUserId, status }: ListThinkspacesInput,

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -2,7 +2,7 @@ import type { ProductDb } from "@better-agent/db";
 import { ORPCError } from "@orpc/server";
 import { z } from "zod";
 
-import { DEFAULT_MODEL_ID, parseModelId } from "../models/catalog";
+import { DEFAULT_MODEL_ID } from "../models/catalog";
 import { ModelCatalogError, validateCatalogModelId } from "../models/model-catalog";
 import {
 	getOwnedThinkspaceModelReadiness,
@@ -12,8 +12,8 @@ import {
 import { protectedProcedure } from "../procedures";
 import {
 	AgentProfileValidationError,
-	AGENT_PROFILE_DISPLAY_NAME_MAX_LENGTH,
-	isAgentProfileReasoningLevel,
+	deriveAgentProfileDisplayName,
+	getSeedReasoningLevel,
 	validateAgentProfileIdentity,
 	validateAgentProfileModelBehavior,
 } from "./agent-profile";
@@ -43,14 +43,14 @@ import {
 	saveThinkspacePermissionGrants,
 	ThinkspacePermissionGrantError,
 } from "./permissions";
-import { BUILT_IN_TOOL_IDS, createBuiltInToolPermissionRequests } from "./built-in-tools";
-import type { BuiltInToolId } from "./built-in-tools";
+import { BUILT_IN_TOOL_IDS } from "./built-in-tools";
+import { CONNECTED_ACCOUNT_TOOL_IDS } from "./connected-account-tools";
 import {
-	CONNECTED_ACCOUNT_TOOL_IDS,
-	createConnectedAccountToolPermissionRequests,
-} from "./connected-account-tools";
-import type { ConnectedAccountToolId } from "./connected-account-tools";
-import { createMcpToolAccessPermissionRequest, serializeThinkspaceToolSelections } from "./policy";
+	normalizeBuiltInToolIds,
+	normalizeConnectedAccountToolIds,
+	toRequestedPermissions,
+	toToolEnablements,
+} from "./tool-selection";
 import {
 	createCurationDraftThinkspaceRecord,
 	createThinkspaceArchivePatch,
@@ -131,81 +131,6 @@ const createAgentProfileRevisionId = (): string => `agent_profile_revision_${cry
  */
 const CURATION_DRAFT_DISPLAY_NAME = "Untitled Thinkspace";
 
-/** Deduped, in stable catalog order, however the caller ordered them. */
-const normalizeBuiltInToolIds = (toolIds: readonly BuiltInToolId[]): BuiltInToolId[] => {
-	const requested = new Set(toolIds);
-
-	return BUILT_IN_TOOL_IDS.filter((toolId) => requested.has(toolId));
-};
-
-/** Deduped, in stable catalog order, mirroring `normalizeBuiltInToolIds`. */
-const normalizeConnectedAccountToolIds = (
-	toolIds: readonly ConnectedAccountToolId[],
-): ConnectedAccountToolId[] => {
-	const requested = new Set(toolIds);
-
-	return CONNECTED_ACCOUNT_TOOL_IDS.filter((toolId) => requested.has(toolId));
-};
-
-const toToolEnablements = (
-	builtInToolIds: readonly BuiltInToolId[],
-	connectedAccountToolIds: readonly ConnectedAccountToolId[],
-	selections: z.infer<typeof toolSelectionSchema>[],
-): ToolEnablement[] => {
-	const normalized = JSON.parse(serializeThinkspaceToolSelections(selections)) as z.infer<
-		typeof toolSelectionSchema
-	>[];
-
-	return [
-		...builtInToolIds.map(
-			(toolId): ToolEnablement => ({
-				source: "built_in",
-				toolId,
-			}),
-		),
-		...connectedAccountToolIds.map(
-			(toolId): ToolEnablement => ({
-				source: "connected_account",
-				toolId,
-			}),
-		),
-		...normalized.map(
-			(selection): ToolEnablement => ({
-				source: "mcp_server",
-				toolId: selection.toolName
-					? `${selection.serverId}:${selection.toolName}`
-					: selection.serverId,
-			}),
-		),
-	];
-};
-
-/**
- * Every Agent Profile revision needs its model to run, so the draft always
- * requests Permission to use the owner's saved credential for that model's
- * provider. The owner grants it at activation (the default grants all requests),
- * which is what makes model resolution potent — without this grant the runtime
- * fails closed with `permission_required`. Built-in, connected-account, and MCP
- * tool requests are added on top from the user's selections.
- */
-const createModelProviderCredentialPermissionRequest = (modelId: string): RequestedPermission => ({
-	kind: "model_provider_credential",
-	providerId: parseModelId(modelId).providerId,
-	reason: "Use your saved provider credential to run this Thinkspace Agent's model.",
-});
-
-const toRequestedPermissions = (
-	modelId: string,
-	builtInToolIds: readonly BuiltInToolId[],
-	connectedAccountToolIds: readonly ConnectedAccountToolId[],
-	selections: z.infer<typeof toolSelectionSchema>[],
-): RequestedPermission[] => [
-	createModelProviderCredentialPermissionRequest(modelId),
-	...createBuiltInToolPermissionRequests(builtInToolIds),
-	...createConnectedAccountToolPermissionRequests(connectedAccountToolIds),
-	...selections.map((selection) => createMcpToolAccessPermissionRequest(selection)),
-];
-
 export interface EnabledToolPotencyInspection {
 	potency: ToolPotency;
 	source: ToolEnablement["source"];
@@ -233,29 +158,6 @@ const inspectEnabledToolPotencies = async (
 		source: enablement.source,
 		toolId: enablement.toolId,
 	}));
-};
-
-const deriveAgentProfileDisplayName = (goal: string): string => {
-	const normalized = goal.trim();
-
-	if (normalized.length <= AGENT_PROFILE_DISPLAY_NAME_MAX_LENGTH) {
-		return normalized;
-	}
-
-	return `${normalized.slice(0, AGENT_PROFILE_DISPLAY_NAME_MAX_LENGTH - 1).trimEnd()}…`;
-};
-
-const getSeedReasoningLevel = (input: {
-	catalogEntryReasoning: string;
-	reasoningEffort: string | null | undefined;
-}) => {
-	if (input.catalogEntryReasoning === "none") {
-		return "none";
-	}
-
-	return isAgentProfileReasoningLevel(input.reasoningEffort) && input.reasoningEffort !== "none"
-		? input.reasoningEffort
-		: "medium";
 };
 
 /**

--- a/packages/api/src/thinkspaces/tool-selection.ts
+++ b/packages/api/src/thinkspaces/tool-selection.ts
@@ -1,0 +1,204 @@
+/**
+ * Tool-selection normalization shared by every surface that shapes a draft
+ * Agent Profile's enabled tools: the owner-driven `updateToolSelections`
+ * procedure (router) and the Curator's propose-only `enable_tool` / `set_model`
+ * tools (#127). Enabling a tool derives both its `ToolEnablement` (what makes it
+ * present) and its requested `Permission` (what the owner grants at activation
+ * to make it potent); this module owns that derivation once so the two callers
+ * cannot drift. "Profile proposes, Permission disposes" — these functions only
+ * shape draft requests; only the user grants them.
+ *
+ * The forward direction (selections -> enablements + requested Permissions)
+ * mirrors what the owner UI sends. The inverse (`toToolSelectionSet`) recovers
+ * the selection set from a draft so an incremental edit (add one tool, change
+ * the model) can re-run the same forward derivation over the full set rather
+ * than hand-patching the arrays. The MCP risk a `ToolEnablement` cannot carry
+ * is recovered from the matching `mcp_tool_access` request, the only place it
+ * survives.
+ */
+import { parseModelId } from "../models/catalog";
+import type {
+	McpToolAccessPermissionRequest,
+	McpToolAccessRequestRisk,
+	RequestedPermission,
+	ToolEnablement,
+} from "./agent-profile";
+import {
+	BUILT_IN_TOOL_IDS,
+	createBuiltInToolPermissionRequests,
+	isBuiltInToolId,
+} from "./built-in-tools";
+import type { BuiltInToolId } from "./built-in-tools";
+import {
+	CONNECTED_ACCOUNT_TOOL_IDS,
+	createConnectedAccountToolPermissionRequests,
+	isConnectedAccountToolId,
+} from "./connected-account-tools";
+import type { ConnectedAccountToolId } from "./connected-account-tools";
+import { createMcpToolAccessPermissionRequest, serializeThinkspaceToolSelections } from "./policy";
+import type { ThinkspaceToolSelection } from "./policy";
+
+/** Deduped, in stable catalog order, however the caller ordered them. */
+export const normalizeBuiltInToolIds = (toolIds: readonly BuiltInToolId[]): BuiltInToolId[] => {
+	const requested = new Set(toolIds);
+
+	return BUILT_IN_TOOL_IDS.filter((toolId) => requested.has(toolId));
+};
+
+/** Deduped, in stable catalog order, mirroring `normalizeBuiltInToolIds`. */
+export const normalizeConnectedAccountToolIds = (
+	toolIds: readonly ConnectedAccountToolId[],
+): ConnectedAccountToolId[] => {
+	const requested = new Set(toolIds);
+
+	return CONNECTED_ACCOUNT_TOOL_IDS.filter((toolId) => requested.has(toolId));
+};
+
+export const toToolEnablements = (
+	builtInToolIds: readonly BuiltInToolId[],
+	connectedAccountToolIds: readonly ConnectedAccountToolId[],
+	selections: ThinkspaceToolSelection[],
+): ToolEnablement[] => {
+	const normalized = JSON.parse(
+		serializeThinkspaceToolSelections(selections),
+	) as ThinkspaceToolSelection[];
+
+	return [
+		...builtInToolIds.map(
+			(toolId): ToolEnablement => ({
+				source: "built_in",
+				toolId,
+			}),
+		),
+		...connectedAccountToolIds.map(
+			(toolId): ToolEnablement => ({
+				source: "connected_account",
+				toolId,
+			}),
+		),
+		...normalized.map(
+			(selection): ToolEnablement => ({
+				source: "mcp_server",
+				toolId: selection.toolName
+					? `${selection.serverId}:${selection.toolName}`
+					: selection.serverId,
+			}),
+		),
+	];
+};
+
+/**
+ * Every Agent Profile revision needs its model to run, so the draft always
+ * requests Permission to use the owner's saved credential for that model's
+ * provider. The owner grants it at activation (the default grants all requests),
+ * which is what makes model resolution potent — without this grant the runtime
+ * fails closed with `permission_required`. Built-in, connected-account, and MCP
+ * tool requests are added on top from the user's selections.
+ */
+const createModelProviderCredentialPermissionRequest = (modelId: string): RequestedPermission => ({
+	kind: "model_provider_credential",
+	providerId: parseModelId(modelId).providerId,
+	reason: "Use your saved provider credential to run this Thinkspace Agent's model.",
+});
+
+export const toRequestedPermissions = (
+	modelId: string,
+	builtInToolIds: readonly BuiltInToolId[],
+	connectedAccountToolIds: readonly ConnectedAccountToolId[],
+	selections: ThinkspaceToolSelection[],
+): RequestedPermission[] => [
+	createModelProviderCredentialPermissionRequest(modelId),
+	...createBuiltInToolPermissionRequests(builtInToolIds),
+	...createConnectedAccountToolPermissionRequests(connectedAccountToolIds),
+	...selections.map((selection) => createMcpToolAccessPermissionRequest(selection)),
+];
+
+/**
+ * The raw selection inputs an Agent Profile draft's tool enablement is derived
+ * from — the shape `updateToolSelections` accepts and the shape
+ * `toToolEnablements` / `toRequestedPermissions` consume.
+ */
+export interface ThinkspaceToolSelectionSet {
+	builtInToolIds: BuiltInToolId[];
+	connectedAccountToolIds: ConnectedAccountToolId[];
+	selections: ThinkspaceToolSelection[];
+}
+
+/** Splits a `${serverId}:${toolName}` MCP enablement id; bare ids are server-scoped. */
+export const parseMcpEnablementToolId = (
+	toolId: string,
+): { serverId: string; toolName?: string } => {
+	const separatorIndex = toolId.indexOf(":");
+
+	if (separatorIndex === -1) {
+		return { serverId: toolId };
+	}
+
+	const toolName = toolId.slice(separatorIndex + 1);
+
+	return { serverId: toolId.slice(0, separatorIndex), toolName: toolName || undefined };
+};
+
+const isMcpToolAccessRequest = (
+	permission: RequestedPermission,
+): permission is McpToolAccessPermissionRequest => permission.kind === "mcp_tool_access";
+
+/**
+ * An MCP `ToolEnablement` carries only the tool id; its risk lives on the
+ * matching `mcp_tool_access` request. Recover it by serverId + scope, falling
+ * back to the conservative `unknown` if no request matches.
+ */
+const recoverMcpRisk = (
+	requestedPermissions: readonly RequestedPermission[],
+	serverId: string,
+	toolName: string | undefined,
+): McpToolAccessRequestRisk => {
+	const match = requestedPermissions.filter(isMcpToolAccessRequest).find((request) => {
+		if (request.serverId !== serverId) {
+			return false;
+		}
+
+		return toolName
+			? request.scope.type === "tool" && request.scope.toolName === toolName
+			: request.scope.type === "server";
+	});
+
+	return match?.risk ?? "unknown";
+};
+
+/**
+ * Recovers the selection set a draft's enablements were derived from, so an
+ * incremental edit can re-run the forward derivation over the full set. The
+ * enablements are the source of truth for which tools are present; the requested
+ * Permissions are read only to recover each MCP tool's risk. Enablement sources
+ * outside the three the Curator shapes (e.g. `local_node`) are ignored.
+ */
+export const toToolSelectionSet = (
+	enablements: readonly ToolEnablement[],
+	requestedPermissions: readonly RequestedPermission[],
+): ThinkspaceToolSelectionSet => {
+	const builtInToolIds: BuiltInToolId[] = [];
+	const connectedAccountToolIds: ConnectedAccountToolId[] = [];
+	const selections: ThinkspaceToolSelection[] = [];
+
+	for (const enablement of enablements) {
+		if (enablement.source === "built_in" && isBuiltInToolId(enablement.toolId)) {
+			builtInToolIds.push(enablement.toolId);
+		} else if (
+			enablement.source === "connected_account" &&
+			isConnectedAccountToolId(enablement.toolId)
+		) {
+			connectedAccountToolIds.push(enablement.toolId);
+		} else if (enablement.source === "mcp_server") {
+			const { serverId, toolName } = parseMcpEnablementToolId(enablement.toolId);
+
+			selections.push({
+				risk: recoverMcpRisk(requestedPermissions, serverId, toolName),
+				serverId,
+				toolName,
+			});
+		}
+	}
+
+	return { builtInToolIds, connectedAccountToolIds, selections };
+};


### PR DESCRIPTION
Closes #127.

The Curator's **propose-only** toolset — the tools that mold a draft Agent Profile live during creation. "Proposes, never grants" is **structural**: the toolset has no `activate` and no `grant` tool, so granting Permissions and activating the Thinkspace stay user-only acts.

## What's here
- **`thinkspaces/curator-runtime-tools.ts`** (new) — `set_goal`, `set_configuration_summary`, `set_instructions`, `set_model`, `enable_tool`, assembled into the `CuratorAgent` DO via a lazy context resolver. Each tool is owner-scoped to the bound draft (it resolves the draft from the runtime's stored context, **never** from a tool argument) and resolves every failure to a product-safe string.
- **`thinkspaces/tool-selection.ts`** (new) — the Permission/enablement normalization extracted out of `router.ts` so `updateToolSelections` and the Curator's `enable_tool`/`set_model` derive Permissions through **one** seam (no hand-rolled shaping). Adds `toToolSelectionSet`, the inverse that recovers the selection set from a draft so an incremental edit re-runs the same forward derivation; the MCP risk a `ToolEnablement` can't carry is recovered from the matching `mcp_tool_access` request.
- `set_model` re-derives the model-provider credential request when the model (and thus provider) changes.
- `set_goal` atomically writes the Thinkspace Goal **and** the draft's Goal-derived display name in one D1 batch (`applyCurationGoal`).
- Moved `deriveAgentProfileDisplayName` / `getSeedReasoningLevel` into `agent-profile.ts`; added curation field validators to `lifecycle.ts`.

## Acceptance
- [x] `set_goal`/`set_configuration_summary`/`set_instructions`/`set_model`/`enable_tool` write through the existing Agent-Profile-draft + `updateToolSelections` seams
- [x] `enable_tool` auto-derives the matching requested Permission(s) **exactly** as `updateToolSelections` (built-in / connected-account / MCP) — asserted byte-identical in tests
- [x] **No `activate` and no `grant` tool** — asserted in a test
- [x] `set_model` rejects an out-of-catalog id; tools owner-scoped to the bound draft
- [x] `bun run check-types`, `bun x ultracite check`, `bun test packages/api` (359 pass) all green

## Review
`/code-review high` (PRD-required): fixed one real bug (`set_goal` two-write race → atomic batch) and one polish (`PermissionPolicyError` → clean message); two further candidates verified as non-defects. No schema change → no migration.
