### PR TITLE
Curator: live agent-card synced-state projection (#128)

### DIFF
--- a/apps/server/src/agents/curator-agent.ts
+++ b/apps/server/src/agents/curator-agent.ts
@@ -8,14 +8,21 @@ import {
 import type { CurationForwardContext } from "@better-agent/api/curator/forward-context";
 import { CURATOR_RUNTIME_MAX_STEPS } from "@better-agent/api/curator/runtime";
 import { CURATOR_SYSTEM_PROMPT } from "@better-agent/api/curator/system-prompt";
+import { listConnectedAccounts } from "@better-agent/api/connected-accounts/repository";
+import { DEFAULT_MODEL_ID } from "@better-agent/api/models/catalog";
 import { createProductModelCatalog } from "@better-agent/api/models/models-dev";
 import {
 	CuratorModelUnavailableError,
 	getUserCuratorModelSettings,
 	resolveCuratorModel,
 } from "@better-agent/api/models/curator";
+import { getUserProductModelSettings } from "@better-agent/api/models/readiness";
+import { getDraftAgentProfileRevision } from "@better-agent/api/thinkspaces/agent-profile-repository";
+import { buildCuratorCardProjection } from "@better-agent/api/thinkspaces/curator-card";
+import type { CuratorCardProjection } from "@better-agent/api/thinkspaces/curator-card";
 import { createCuratorRuntimeTools } from "@better-agent/api/thinkspaces/curator-runtime-tools";
 import type { CuratorRuntimeToolContext } from "@better-agent/api/thinkspaces/curator-runtime-tools";
+import { getThinkspace } from "@better-agent/api/thinkspaces/repository";
 import { createDb } from "@better-agent/db";
 import type { ProductDb } from "@better-agent/db";
 import type { CloudflareEnv } from "@better-agent/env/types";
@@ -43,12 +50,22 @@ const CURATOR_MODEL_UNAVAILABLE_MESSAGE = "The Curator could not resolve a model
  * grants" is structural: the toolset has no activate and no grant tool, so
  * granting Permissions and activating the Thinkspace stay user-only acts.
  */
-export class CuratorAgent extends Think<CloudflareEnv> {
+export class CuratorAgent extends Think<CloudflareEnv, CuratorCardProjection | null> {
 	private readonly curatorSystemPrompt = CURATOR_SYSTEM_PROMPT;
 	private readonly curatorToolSet: ToolSet = createCuratorRuntimeTools({
 		resolveContext: () => this.resolveCuratorToolContext(),
 	});
 	private readonly turnModelPlaceholder: LanguageModel = UNRESOLVED_CURATOR_MODEL;
+
+	/**
+	 * The live agent card is a Think synced-state projection (`setState` ->
+	 * `onStateUpdate`), refreshed after each propose-only tool writes the draft.
+	 * It starts null: a freshly minted draft has no card yet, so the web client
+	 * seeds the initial view from its draft query and applies this projection as a
+	 * live delta once the first tool runs. **D1 stays the source of truth; this
+	 * state is only a projection of it.**
+	 */
+	override initialState: CuratorCardProjection | null = null;
 
 	override maxSteps = CURATOR_RUNTIME_MAX_STEPS;
 	override workspaceBash = false;
@@ -143,6 +160,62 @@ export class CuratorAgent extends Think<CloudflareEnv> {
 		const model = await this.resolveCuratorTurnModel(db, context);
 
 		return { model };
+	}
+
+	/**
+	 * Every Curator tool is a propose-only write to the bound draft (#127), so the
+	 * card is re-projected after each one. Reads the draft back from D1 (the source
+	 * of truth) and broadcasts the derived projection to connected clients via
+	 * `setState`. Observation-only and best-effort: a projection failure must not
+	 * fail the turn the tool already completed, so it is swallowed and the card
+	 * simply refreshes on the next write.
+	 */
+	override async afterToolCall(): Promise<void> {
+		try {
+			await this.projectCard();
+		} catch {
+			// Intentionally ignored: the card is a derived view, not the turn's work.
+		}
+	}
+
+	/**
+	 * Reads the bound draft from D1 and pushes the {@link buildCuratorCardProjection}
+	 * view into synced state. Pure projection lives in `packages/api` (Think-free);
+	 * the DO only resolves the inputs and calls `setState`. A missing context or an
+	 * absent draft leaves the card untouched.
+	 */
+	private async projectCard(): Promise<void> {
+		const context = await this.ctx.storage.get<CurationForwardContext>(
+			CURATION_CONTEXT_STORAGE_KEY,
+		);
+
+		if (!context) {
+			return;
+		}
+
+		const db = createDb(this.env.DB);
+		const [thinkspace, draft, connectedAccounts, settings] = await Promise.all([
+			getThinkspace(db, {
+				ownerUserId: context.ownerUserId,
+				thinkspaceId: context.draftThinkspaceId,
+			}),
+			getDraftAgentProfileRevision(db, { thinkspaceId: context.draftThinkspaceId }),
+			listConnectedAccounts(db, context.ownerUserId),
+			getUserProductModelSettings(db, context.ownerUserId),
+		]);
+
+		if (!(thinkspace && draft)) {
+			return;
+		}
+
+		this.setState(
+			buildCuratorCardProjection({
+				connectedAccounts,
+				defaultModelId: settings?.defaultModel?.trim() || DEFAULT_MODEL_ID,
+				draft,
+				thinkspace,
+			}),
+		);
 	}
 
 	/**

--- a/apps/web/src/components/curator-agent-card.tsx
+++ b/apps/web/src/components/curator-agent-card.tsx
@@ -1,0 +1,264 @@
+import { buildCuratorCardProjection } from "@better-agent/api/thinkspaces/curator-card";
+import type {
+	CuratorCardConnectedAccountView,
+	CuratorCardModelProvenance,
+	CuratorCardProjection,
+	CuratorCardRequestedPermissionView,
+	CuratorCardToolBadge,
+	CuratorCardToolView,
+} from "@better-agent/api/thinkspaces/curator-card";
+import { env } from "@better-agent/env/web";
+import { Badge } from "@better-agent/ui/components/badge";
+import { Button } from "@better-agent/ui/components/button";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { useAgent } from "agents/react";
+import { CpuIcon, KeyRoundIcon, PlugIcon, TargetIcon, WrenchIcon } from "lucide-react";
+import { useMemo } from "react";
+
+import { orpc } from "@/utils/orpc";
+
+/**
+ * Kebab-cased Durable Object class name. With `basePath` set, the client
+ * connects to the worker's authenticated Curator route directly and the worker
+ * resolves the runtime by draft Thinkspace id, so this value only labels the
+ * connection; it does not build the URL. Mirrors the Sitting transport.
+ */
+const CURATOR_AGENT_RUNTIME = "curator-agent";
+
+const MODEL_PROVENANCE_LABEL: Record<CuratorCardModelProvenance, string> = {
+	curator_set: "Curator-set",
+	inherited_default: "Inherited default",
+};
+
+const TOOL_SOURCE_LABEL: Record<CuratorCardToolView["source"], string> = {
+	built_in: "Built-in tool",
+	connected_account: "Connected Account tool",
+	local_node: "Local Node tool",
+	mcp_server: "External information source",
+};
+
+const TOOL_BADGE: Record<CuratorCardToolBadge, { label: string; variant: "outline" | "sage" }> = {
+	// No tool is potent on enablement alone today, so this reads "Read-only"
+	// forward-looking; the live axis the card surfaces is "Needs Permission".
+	enablement_only: { label: "Read-only", variant: "sage" },
+	needs_permission: { label: "Needs Permission", variant: "outline" },
+};
+
+const CardField = ({ children, label }: { children: React.ReactNode; label: string }) => (
+	<div className="grid gap-1 border-border border-t pt-4">
+		<p className="text-muted-foreground text-xs font-medium">{label}</p>
+		{children}
+	</div>
+);
+
+const ToolRow = ({ tool }: { tool: CuratorCardToolView }) => {
+	const badge = TOOL_BADGE[tool.badge];
+
+	return (
+		<div className="flex items-center justify-between gap-4 p-4">
+			<div className="grid gap-0.5">
+				<p className="break-all text-sm font-medium">{tool.toolId}</p>
+				<p className="text-muted-foreground text-xs">{TOOL_SOURCE_LABEL[tool.source]}</p>
+			</div>
+			<Badge variant={badge.variant}>{badge.label}</Badge>
+		</div>
+	);
+};
+
+const PermissionRow = ({ permission }: { permission: CuratorCardRequestedPermissionView }) => (
+	<div className="grid gap-0.5 p-4">
+		<p className="text-sm font-medium">{permission.label}</p>
+		<p className="text-muted-foreground text-xs">{permission.reason}</p>
+	</div>
+);
+
+const ConnectedAccountRow = ({ account }: { account: CuratorCardConnectedAccountView }) => (
+	<div className="flex items-center justify-between gap-4 p-4">
+		<div className="grid gap-0.5">
+			<p className="text-sm font-medium capitalize">{account.catalogId}</p>
+			<p className="text-muted-foreground text-xs">
+				{account.connected
+					? `Connected as ${account.accountLabel ?? account.catalogId}`
+					: "Not connected — the tool stays inert until you connect an account."}
+			</p>
+		</div>
+		{account.connected ? (
+			<Badge variant="sage">Connected</Badge>
+		) : (
+			<Button render={<Link to="/settings/product" />} size="sm" variant="outline">
+				<PlugIcon />
+				Connect
+			</Button>
+		)}
+	</div>
+);
+
+const ListPanel = ({
+	children,
+	count,
+	emptyMessage,
+}: {
+	children: React.ReactNode;
+	count: number;
+	emptyMessage: string;
+}) =>
+	count === 0 ? (
+		<p className="rounded-lg p-4 ring-1 ring-foreground/10 text-muted-foreground text-sm">
+			{emptyMessage}
+		</p>
+	) : (
+		<div className="divide-y divide-border overflow-hidden rounded-lg ring-1 ring-foreground/10">
+			{children}
+		</div>
+	);
+
+const CuratorCardBody = ({ card }: { card: CuratorCardProjection }) => (
+	<div className="grid gap-4 rounded-lg p-5 ring-1 ring-foreground/10">
+		<div className="flex items-start justify-between gap-4">
+			<div className="grid gap-1">
+				<p className="text-muted-foreground text-xs font-medium">Agent</p>
+				<p className="text-balance text-lg font-semibold tracking-tight">{card.displayName}</p>
+			</div>
+			<Badge variant={card.ready ? "sage" : "outline"}>
+				{card.ready ? "Ready to activate" : "Shaping…"}
+			</Badge>
+		</div>
+
+		<CardField label="Goal">
+			{card.goal ? (
+				<div className="flex items-start gap-2">
+					<TargetIcon aria-hidden className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+					<p className="text-sm leading-relaxed">{card.goal}</p>
+				</div>
+			) : (
+				<p className="text-muted-foreground text-sm">
+					No Goal yet — describe what this agent should achieve.
+				</p>
+			)}
+		</CardField>
+
+		{card.configurationSummary ? (
+			<CardField label="Configuration summary">
+				<p className="text-sm leading-relaxed">{card.configurationSummary}</p>
+			</CardField>
+		) : null}
+
+		<CardField label="Instructions">
+			<p className="whitespace-pre-wrap text-sm leading-relaxed">
+				{card.instructions || "No instructions yet."}
+			</p>
+		</CardField>
+
+		<CardField label="Model">
+			<div className="flex flex-wrap items-center gap-2">
+				<CpuIcon aria-hidden className="size-4 text-muted-foreground" />
+				<span className="break-all text-sm">{card.model.modelId}</span>
+				<Badge variant="outline">{MODEL_PROVENANCE_LABEL[card.model.provenance]}</Badge>
+				<span className="text-muted-foreground text-xs">
+					Reasoning: {card.model.reasoningLevel}
+				</span>
+			</div>
+		</CardField>
+
+		<CardField label="Enabled tools">
+			<div className="flex items-center gap-2 pb-1">
+				<WrenchIcon aria-hidden className="size-4 text-muted-foreground" />
+				<span className="text-muted-foreground text-xs">
+					Enablement makes a tool present; a Permission makes it potent.
+				</span>
+			</div>
+			<ListPanel count={card.tools.length} emptyMessage="No tools enabled yet.">
+				{card.tools.map((tool) => (
+					<ToolRow key={`${tool.source}:${tool.toolId}`} tool={tool} />
+				))}
+			</ListPanel>
+		</CardField>
+
+		<CardField label="Requested Permissions">
+			<div className="flex items-center gap-2 pb-1">
+				<KeyRoundIcon aria-hidden className="size-4 text-muted-foreground" />
+				<span className="text-muted-foreground text-xs">
+					You grant these when you activate the Thinkspace.
+				</span>
+			</div>
+			<ListPanel
+				count={card.requestedPermissions.length}
+				emptyMessage="No Permissions requested yet."
+			>
+				{card.requestedPermissions.map((permission) => (
+					<PermissionRow key={`${permission.kind}:${permission.label}`} permission={permission} />
+				))}
+			</ListPanel>
+		</CardField>
+
+		{card.connectedAccounts.length > 0 ? (
+			<CardField label="Connected Accounts">
+				<ListPanel count={card.connectedAccounts.length} emptyMessage="">
+					{card.connectedAccounts.map((account) => (
+						<ConnectedAccountRow account={account} key={account.toolId} />
+					))}
+				</ListPanel>
+			</CardField>
+		) : null}
+	</div>
+);
+
+/**
+ * The live agent card (#128) — the surface the creation conversation converges
+ * on. It reads the Curator runtime's synced state (`useAgent` `state`, kept in
+ * sync via `onStateUpdate`), which the DO re-projects after each propose-only
+ * tool writes the draft. On load — and for a freshly minted draft that has had
+ * no tool calls yet, so the runtime has not projected — it seeds the same view
+ * from the draft query through the shared pure builder, then lets live synced
+ * deltas take over. **D1 is the source of truth; synced state is a projection.**
+ *
+ * The page that places this beside the chat pane plus the Activate step is #129;
+ * this is the standalone card.
+ */
+export const CuratorAgentCard = ({ draftThinkspaceId }: { draftThinkspaceId: string }) => {
+	const thinkspaceQuery = useQuery(
+		orpc.thinkspaces.get.queryOptions({ input: { thinkspaceId: draftThinkspaceId } }),
+	);
+	const connectedAccountsQuery = useQuery(orpc.connectedAccounts.list.queryOptions());
+	const modelDefaultsQuery = useQuery(orpc.models.getDefaults.queryOptions());
+
+	const agent = useAgent<CuratorCardProjection | null>({
+		agent: CURATOR_AGENT_RUNTIME,
+		basePath: `api/curator/${draftThinkspaceId}`,
+		host: env.VITE_SERVER_URL,
+		name: draftThinkspaceId,
+	});
+
+	// The initial-load reconciliation: build the same projection from the draft
+	// query so the card has content before the first synced delta arrives.
+	const seed = useMemo<CuratorCardProjection | null>(() => {
+		const thinkspace = thinkspaceQuery.data;
+		const draft = thinkspace?.agentProfileRevision;
+
+		if (!(thinkspace && draft) || draft.status !== "draft") {
+			return null;
+		}
+
+		return buildCuratorCardProjection({
+			connectedAccounts: connectedAccountsQuery.data ?? [],
+			defaultModelId: modelDefaultsQuery.data?.defaultModel ?? draft.modelBehavior.modelId,
+			draft,
+			thinkspace,
+		});
+	}, [thinkspaceQuery.data, connectedAccountsQuery.data, modelDefaultsQuery.data]);
+
+	// Synced state wins once the runtime has projected; the seed covers the first
+	// load and a fresh, never-curated draft (whose synced state is still null).
+	const card = agent.state ?? seed;
+
+	if (!card) {
+		return (
+			<p className="rounded-lg p-5 ring-1 ring-foreground/10 text-muted-foreground text-sm">
+				Starting the curation conversation…
+			</p>
+		);
+	}
+
+	return <CuratorCardBody card={card} />;
+};

--- a/packages/api/src/thinkspaces/curator-card.test.ts
+++ b/packages/api/src/thinkspaces/curator-card.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ProductDb } from "@better-agent/db";
+import { user } from "@better-agent/db/schema/auth";
+import type { Tool, ToolCallOptions } from "ai";
+
+import { DEFAULT_MODEL_ID, getModelCatalog } from "../models/catalog";
+import { createMemoryModelCatalog } from "../models/model-catalog";
+import type { ModelCatalog } from "../models/model-catalog";
+import { createTestProductDb } from "../testing/product-db";
+import {
+	getSeedReasoningLevel,
+	validateAgentProfileIdentity,
+	validateAgentProfileModelBehavior,
+} from "./agent-profile";
+import { createInitialAgentProfileDraft } from "./agent-profile-lifecycle";
+import { getDraftAgentProfileRevision } from "./agent-profile-repository";
+import { buildCuratorCardProjection } from "./curator-card";
+import type { CuratorCardConnectedAccountRecord } from "./curator-card";
+import { createCuratorRuntimeTools } from "./curator-runtime-tools";
+import { createCurationDraftThinkspaceRecord } from "./lifecycle";
+import { createThinkspaceWithAgentProfileDraft, getThinkspace } from "./repository";
+import { toRequestedPermissions } from "./tool-selection";
+
+const OWNER_ID = "curator_card_owner";
+const DRAFT_ID = "thinkspace_curator_card_draft";
+const TOOL_CALL_OPTIONS = { messages: [], toolCallId: "tool_call_1" } as ToolCallOptions;
+const modelCatalog: ModelCatalog = createMemoryModelCatalog([...getModelCatalog()]);
+
+const executeTool = async (toolDefinition: Tool | undefined, input: unknown): Promise<string> => {
+	assert.ok(toolDefinition?.execute, "tool must be constructed with an execute handler");
+
+	return (await toolDefinition.execute(input as never, TOOL_CALL_OPTIONS)) as string;
+};
+
+/**
+ * Seeds the (DRAFT Thinkspace + initial empty-Goal Agent Profile draft) pair
+ * `startCuration` mints, so the Curator tools — and the projection they drive —
+ * run against a faithful draft.
+ */
+const seedCurationDraft = async (db: ProductDb): Promise<void> => {
+	await db.insert(user).values({ email: `${OWNER_ID}@example.com`, id: OWNER_ID, name: "Owner" });
+
+	const record = createCurationDraftThinkspaceRecord({ id: DRAFT_ID, ownerUserId: OWNER_ID });
+	const identity = validateAgentProfileIdentity({
+		displayName: "Untitled Thinkspace",
+		instructions: "",
+	});
+	const entry = await modelCatalog.getModel(DEFAULT_MODEL_ID);
+	assert.ok(entry, "seed model must exist in the catalog");
+	const modelBehavior = validateAgentProfileModelBehavior({
+		catalogEntry: entry,
+		modelId: DEFAULT_MODEL_ID,
+		reasoningLevel: getSeedReasoningLevel({
+			catalogEntryReasoning: entry.reasoning,
+			reasoningEffort: "medium",
+		}),
+	});
+	const draft = createInitialAgentProfileDraft({
+		id: `agent_profile_revision_${crypto.randomUUID()}`,
+		identity,
+		modelBehavior,
+		requestedPermissions: toRequestedPermissions(modelBehavior.modelId, [], [], []),
+		thinkspaceId: DRAFT_ID,
+	});
+	await createThinkspaceWithAgentProfileDraft(db, { draft, record });
+};
+
+const boundTools = (db: ProductDb) =>
+	createCuratorRuntimeTools({
+		resolveContext: () =>
+			Promise.resolve({ db, draftThinkspaceId: DRAFT_ID, modelCatalog, ownerUserId: OWNER_ID }),
+	});
+
+const projectCard = async (
+	db: ProductDb,
+	connectedAccounts: readonly CuratorCardConnectedAccountRecord[] = [],
+) => {
+	const draft = await getDraftAgentProfileRevision(db, { thinkspaceId: DRAFT_ID });
+	assert.ok(draft, "the seeded draft must still exist");
+	const thinkspace = await getThinkspace(db, { ownerUserId: OWNER_ID, thinkspaceId: DRAFT_ID });
+	assert.ok(thinkspace, "the seeded Thinkspace must still exist");
+
+	return buildCuratorCardProjection({
+		connectedAccounts,
+		defaultModelId: DEFAULT_MODEL_ID,
+		draft,
+		thinkspace,
+	});
+};
+
+test("projects a set_goal + enable_tool sequence including a not-connected connected-account tool", async () => {
+	const db = createTestProductDb();
+	await seedCurationDraft(db);
+	const tools = boundTools(db);
+
+	await executeTool(tools.set_goal, { goal: "Triage GitHub issues weekly" });
+	await executeTool(tools.enable_tool, { toolId: "web_search" });
+	await executeTool(tools.enable_tool, { toolId: "github:create_issue" });
+
+	// No Connected Account exists for the owner, so the proposed GitHub tool is
+	// surfaced as not-connected.
+	const card = await projectCard(db, []);
+
+	// The Goal flows to the card, and the display name tracks it (no naming tool).
+	assert.equal(card.goal, "Triage GitHub issues weekly");
+	assert.equal(card.displayName, "Triage GitHub issues weekly");
+
+	// The model is still the inherited default — the Curator never ran set_model.
+	assert.equal(card.model.modelId, DEFAULT_MODEL_ID);
+	assert.equal(card.model.provenance, "inherited_default");
+
+	// Both enabled tools need a Permission (no tool is potent on enablement alone).
+	assert.deepEqual(
+		card.tools.toSorted((a, b) => a.toolId.localeCompare(b.toolId)),
+		[
+			{ badge: "needs_permission", source: "connected_account", toolId: "github:create_issue" },
+			{ badge: "needs_permission", source: "built_in", toolId: "web_search" },
+		],
+	);
+
+	// The requested Permissions mirror what activation will ask the owner to grant.
+	assert.deepEqual(card.requestedPermissions.map((permission) => permission.kind).toSorted(), [
+		"built_in_web_read",
+		"connected_account_credential",
+		"model_provider_credential",
+	]);
+
+	// The Connected Accounts section shows GitHub as backing the proposed tool and
+	// not yet connected.
+	assert.deepEqual(card.connectedAccounts, [
+		{ accountLabel: null, catalogId: "github", connected: false, toolId: "github:create_issue" },
+	]);
+
+	// A real Goal plus the always-seeded model-credential request makes it ready.
+	assert.equal(card.ready, true);
+});
+
+test("a fresh draft projects an unready empty card on the inherited default model", async () => {
+	const db = createTestProductDb();
+	await seedCurationDraft(db);
+
+	const card = await projectCard(db, []);
+
+	assert.equal(card.goal, "");
+	assert.equal(card.displayName, "Untitled Thinkspace");
+	assert.equal(card.ready, false);
+	assert.deepEqual(card.tools, []);
+	assert.deepEqual(card.connectedAccounts, []);
+	// Even an empty draft carries the model-credential request, so readiness turns
+	// solely on the Goal here.
+	assert.deepEqual(
+		card.requestedPermissions.map((permission) => permission.kind),
+		["model_provider_credential"],
+	);
+});
+
+test("a connected backing account is surfaced as connected with its label", async () => {
+	const db = createTestProductDb();
+	await seedCurationDraft(db);
+	const tools = boundTools(db);
+
+	await executeTool(tools.set_goal, { goal: "Open issues from triage notes" });
+	await executeTool(tools.enable_tool, { toolId: "github:create_issue" });
+
+	const card = await projectCard(db, [
+		{ catalogId: "github", externalAccountId: "octocat", label: "Octocat (PAT)" },
+	]);
+
+	assert.deepEqual(card.connectedAccounts, [
+		{
+			accountLabel: "Octocat (PAT)",
+			catalogId: "github",
+			connected: true,
+			toolId: "github:create_issue",
+		},
+	]);
+});
+
+test("set_model flips model provenance to curator-set and reasoning level follows", async () => {
+	const db = createTestProductDb();
+	await seedCurationDraft(db);
+	const tools = boundTools(db);
+
+	await executeTool(tools.set_model, { modelId: "openai:gpt-4o-mini" });
+
+	const card = await projectCard(db, []);
+
+	assert.equal(card.model.modelId, "openai:gpt-4o-mini");
+	assert.equal(card.model.provenance, "curator_set");
+	assert.equal(card.model.reasoningLevel, "none");
+});

--- a/packages/api/src/thinkspaces/curator-card.ts
+++ b/packages/api/src/thinkspaces/curator-card.ts
@@ -1,0 +1,201 @@
+/**
+ * The Curator agent-card projection (#128) — a pure view of a curation draft.
+ *
+ * The card is the live surface the creation conversation converges on: after
+ * each Curator tool writes the draft (#127), the `CuratorAgent` re-reads it from
+ * D1 and pushes the projection this builder produces into Project Think's synced
+ * agent state, and the web card re-renders. **D1 stays the source of truth; this
+ * projection is only a derived view, never an independent source.**
+ *
+ * The builder is deliberately pure and substrate-free so it is the testable seam
+ * (the projection-shape gate lives against it) and so both sides of the wire can
+ * share one shape: the DO calls it to broadcast live deltas, and the web client
+ * calls it to seed the initial card from the draft query before the first synced
+ * delta arrives. It takes a draft revision, the Thinkspace's Goal/summary, the
+ * owner's Connected Accounts, and the owner's default model id; it reaches no db.
+ */
+import type {
+	AgentProfileReasoningLevel,
+	DraftAgentProfileRevision,
+	RequestedPermission,
+	ToolEnablementSource,
+} from "./agent-profile";
+import { connectedAccountCatalogIdFromToolId } from "./connected-account-tools";
+import { evaluateEnablementOnlyToolPotency } from "./permission-policy";
+
+/**
+ * Whether the draft's model was chosen by the Curator (`set_model`) or is still
+ * the user's inherited default. The draft does not record which tool last wrote
+ * the model, so this is a heuristic: a model equal to the owner's default reads
+ * as inherited. The imperfect case — the Curator re-picking the default — reads
+ * as inherited too, which is the honest, non-alarming default.
+ */
+export type CuratorCardModelProvenance = "curator_set" | "inherited_default";
+
+/**
+ * Read-only (potent on enablement alone) vs needs-Permission (inert until the
+ * owner grants the governing Permission at activation). Derived from the
+ * fail-closed potency rule under no grants, not hand-classified.
+ */
+export type CuratorCardToolBadge = "enablement_only" | "needs_permission";
+
+export interface CuratorCardToolView {
+	badge: CuratorCardToolBadge;
+	source: ToolEnablementSource;
+	toolId: string;
+}
+
+export interface CuratorCardModelView {
+	modelId: string;
+	provenance: CuratorCardModelProvenance;
+	reasoningLevel: AgentProfileReasoningLevel;
+}
+
+export interface CuratorCardRequestedPermissionView {
+	kind: RequestedPermission["kind"];
+	label: string;
+	reason: string;
+}
+
+export interface CuratorCardConnectedAccountView {
+	accountLabel: string | null;
+	catalogId: string;
+	connected: boolean;
+	toolId: string;
+}
+
+export interface CuratorCardProjection {
+	configurationSummary: string;
+	connectedAccounts: CuratorCardConnectedAccountView[];
+	displayName: string;
+	goal: string;
+	instructions: string;
+	model: CuratorCardModelView;
+	ready: boolean;
+	requestedPermissions: CuratorCardRequestedPermissionView[];
+	tools: CuratorCardToolView[];
+}
+
+/**
+ * The minimal Connected Account fields the projection needs — a structural
+ * subset of a `listConnectedAccounts` row, so callers pass the rows straight
+ * through without the builder depending on the db schema.
+ */
+export interface CuratorCardConnectedAccountRecord {
+	catalogId: string | null;
+	externalAccountId: string | null;
+	label: string | null;
+}
+
+/** The Goal and configuration summary live on the Thinkspace row, not the draft. */
+export interface CuratorCardThinkspaceFields {
+	configurationSummary: string;
+	goal: string;
+}
+
+export interface BuildCuratorCardProjectionInput {
+	connectedAccounts: readonly CuratorCardConnectedAccountRecord[];
+	defaultModelId: string;
+	draft: DraftAgentProfileRevision;
+	thinkspace: CuratorCardThinkspaceFields;
+}
+
+const toRequestedPermissionView = (
+	permission: RequestedPermission,
+): CuratorCardRequestedPermissionView => {
+	switch (permission.kind) {
+		case "built_in_memory_write": {
+			return { kind: permission.kind, label: "Memory writing", reason: permission.reason };
+		}
+		case "built_in_source_read": {
+			return { kind: permission.kind, label: "Source reading", reason: permission.reason };
+		}
+		case "built_in_web_read": {
+			return { kind: permission.kind, label: "Web reading", reason: permission.reason };
+		}
+		case "connected_account_credential": {
+			return {
+				kind: permission.kind,
+				label: `Connected Account: ${permission.catalogId}`,
+				reason: permission.reason,
+			};
+		}
+		case "model_provider_credential": {
+			return {
+				kind: permission.kind,
+				label: `Model credential: ${permission.providerId}`,
+				reason: permission.reason,
+			};
+		}
+		default: {
+			return {
+				kind: permission.kind,
+				label: `External tool access: ${permission.serverId}`,
+				reason: permission.reason,
+			};
+		}
+	}
+};
+
+/**
+ * Builds the agent card from a curation draft. Pure and idempotent: the same
+ * inputs always yield the same projection, so it is safe to re-run after every
+ * tool write and to share between the DO and the web seed.
+ */
+export const buildCuratorCardProjection = ({
+	connectedAccounts,
+	defaultModelId,
+	draft,
+	thinkspace,
+}: BuildCuratorCardProjectionInput): CuratorCardProjection => {
+	const potencyByToolId = new Map(
+		evaluateEnablementOnlyToolPotency(draft.toolEnablements).map(
+			(verdict) => [verdict.toolId, verdict.potency] as const,
+		),
+	);
+
+	const tools: CuratorCardToolView[] = draft.toolEnablements.map((enablement) => ({
+		badge:
+			potencyByToolId.get(enablement.toolId) === "potent" ? "enablement_only" : "needs_permission",
+		source: enablement.source,
+		toolId: enablement.toolId,
+	}));
+
+	const connectedAccountViews: CuratorCardConnectedAccountView[] = draft.toolEnablements
+		.filter((enablement) => enablement.source === "connected_account")
+		.map((enablement) => {
+			const catalogId = connectedAccountCatalogIdFromToolId(enablement.toolId);
+			const account = connectedAccounts.find((candidate) => candidate.catalogId === catalogId);
+
+			return {
+				accountLabel: account ? (account.label ?? account.externalAccountId) : null,
+				catalogId,
+				connected: Boolean(account),
+				toolId: enablement.toolId,
+			};
+		});
+
+	return {
+		configurationSummary: thinkspace.configurationSummary,
+		connectedAccounts: connectedAccountViews,
+		displayName: draft.identity.displayName,
+		goal: thinkspace.goal,
+		instructions: draft.identity.instructions,
+		model: {
+			modelId: draft.modelBehavior.modelId,
+			provenance:
+				draft.modelBehavior.modelId === defaultModelId ? "inherited_default" : "curator_set",
+			reasoningLevel: draft.modelBehavior.reasoningLevel,
+		},
+		// Readiness gates the (user-only) Activate step #129 will add: a real Goal
+		// plus the model-credential request the draft must carry. Whether that
+		// credential actually resolves is a separate activation-time gate.
+		ready:
+			thinkspace.goal.trim().length > 0 &&
+			draft.requestedPermissions.some(
+				(permission) => permission.kind === "model_provider_credential",
+			),
+		requestedPermissions: draft.requestedPermissions.map(toRequestedPermissionView),
+		tools,
+	};
+};

--- a/packages/api/src/thinkspaces/permission-policy.ts
+++ b/packages/api/src/thinkspaces/permission-policy.ts
@@ -115,6 +115,19 @@ const NO_GRANTS: ThinkspaceToolGrants = {
 };
 
 /**
+ * The fail-closed decision rule applied with no grants, synchronously. Because
+ * a Thinkspace that holds no grants leaves every Permission-governed source
+ * inert, this answers a static question without touching Permission storage:
+ * "would this tool be potent on enablement alone?" — i.e. read-only
+ * (enablement-only) vs needs-Permission. A draft under curation holds no grants,
+ * so the Curator card badges its enabled tools from exactly this rule rather
+ * than hand-classifying sources.
+ */
+export const evaluateEnablementOnlyToolPotency = (
+	enablements: ToolEnablement[],
+): ToolPotencyVerdict[] => evaluateAgainstGrants(enablements, NO_GRANTS);
+
+/**
  * The decision rule with no grant lookup: useful where Permission storage is
  * out of reach (pure assembly tests) — equivalent to the store-backed policy
  * when the Thinkspace holds no grants, so every tool-governing source is
@@ -122,7 +135,7 @@ const NO_GRANTS: ThinkspaceToolGrants = {
  */
 export const createEnablementOnlyPermissionPolicy = (): ThinkspacePermissionPolicy => ({
 	evaluateToolPotency: ({ enablements }) =>
-		Promise.resolve(evaluateAgainstGrants(enablements, NO_GRANTS)),
+		Promise.resolve(evaluateEnablementOnlyToolPotency(enablements)),
 });
 
 /** Test adapter with caller-chosen verdicts per tool id. */


### PR DESCRIPTION
## What

Implements #128 (`curator_creation_v1`, child of PRD #123): the **live agent card**. After each propose-only Curator tool writes the draft (#127), the `CuratorAgent` DO re-reads the draft from D1 and pushes a **card projection** into Project Think's synced agent state; the web card renders it live via `useAgent` `state`/`onStateUpdate` and seeds its initial view from the draft query through the **same pure builder**. **D1 stays the source of truth; synced state is only a projection.**

## Deliverables

- **`packages/api/src/thinkspaces/curator-card.ts`** (new) — pure `buildCuratorCardProjection` (the testable seam): display name, Goal, configuration summary, instructions, model id + reasoning level + **provenance** (Curator-set vs inherited default), **enabled tools** badged enablement-only vs needs-Permission, **requested Permissions**, **Connected Accounts** status (per proposed connected-account tool, via the passed-in list), and a **readiness** flag. Think-free; shared by the DO and the web seed.
- **`permission-policy.ts`** — exported sync `evaluateEnablementOnlyToolPotency` so tool badging reuses the fail-closed potency rule instead of hand-classifying.
- **`apps/server/src/agents/curator-agent.ts`** — `Think` `State` generic + `initialState: null`, and `afterToolCall` → `projectCard` → `setState` (best-effort: a projection failure never fails the completed turn). The Think-free boundary stays clean (no `@cloudflare/think` in `packages/api`).
- **`apps/web/src/components/curator-agent-card.tsx`** (new) — standalone live card. Reconciles a builder-seeded initial view (from `thinkspaces.get` + `connectedAccounts.list` + `models.getDefaults`) with live synced deltas. The page that places it beside the chat pane + the Activate step lands in #129; no route added here.

## Decisions

- **Provenance**: heuristic — draft model equal to owner default reads as inherited (documented; no schema change).
- **Readiness**: non-empty Goal AND the model-credential request present on the draft (credential-resolution is a separate activation-time gate).
- **Tool badge**: enablement-only-potency seam — every current tool is "Needs Permission" (no enablement-only-potent tool exists yet; forward-looking and not hand-classified).

## Tests / gates

- Projection-shape test asserts a representative `set_goal` + `enable_tool` sequence **including a not-connected connected-account tool**, plus fresh-draft, connected-account, and `set_model` provenance cases.
- `bun run check-types` (api/server/ui) ✅ · `bun test packages/api` → **363 pass** (359 baseline + 4) ✅ · `bun x ultracite check` on changed files ✅
- No schema change → no migration.

`/code-review high` run: no correctness findings; low-severity cleanup observations are documented conscious tradeoffs.

Closes #128