### PR TITLE
Curator: conversational creation surface + remove static form + in-surface activation (#129)

### DIFF
--- a/apps/web/src/components/curator-agent-card.tsx
+++ b/apps/web/src/components/curator-agent-card.tsx
@@ -113,7 +113,21 @@ const ListPanel = ({
 		</div>
 	);
 
-const CuratorCardBody = ({ card }: { card: CuratorCardProjection }) => (
+/**
+ * The presentational agent card. Pure render over a {@link CuratorCardProjection}
+ * with no transport of its own, so the creation surface (#129) can own one shared
+ * `useAgent` connection and feed both the chat and this card from it.
+ * `showRequestedPermissions` is `false` when the surface renders the requested
+ * Permissions as interactive grant toggles in its Activate step instead, so the
+ * same list never appears twice.
+ */
+export const CuratorAgentCardBody = ({
+	card,
+	showRequestedPermissions = true,
+}: {
+	card: CuratorCardProjection;
+	showRequestedPermissions?: boolean;
+}) => (
 	<div className="grid gap-4 rounded-lg p-5 ring-1 ring-foreground/10">
 		<div className="flex items-start justify-between gap-4">
 			<div className="grid gap-1">
@@ -175,22 +189,24 @@ const CuratorCardBody = ({ card }: { card: CuratorCardProjection }) => (
 			</ListPanel>
 		</CardField>
 
-		<CardField label="Requested Permissions">
-			<div className="flex items-center gap-2 pb-1">
-				<KeyRoundIcon aria-hidden className="size-4 text-muted-foreground" />
-				<span className="text-muted-foreground text-xs">
-					You grant these when you activate the Thinkspace.
-				</span>
-			</div>
-			<ListPanel
-				count={card.requestedPermissions.length}
-				emptyMessage="No Permissions requested yet."
-			>
-				{card.requestedPermissions.map((permission) => (
-					<PermissionRow key={`${permission.kind}:${permission.label}`} permission={permission} />
-				))}
-			</ListPanel>
-		</CardField>
+		{showRequestedPermissions ? (
+			<CardField label="Requested Permissions">
+				<div className="flex items-center gap-2 pb-1">
+					<KeyRoundIcon aria-hidden className="size-4 text-muted-foreground" />
+					<span className="text-muted-foreground text-xs">
+						You grant these when you activate the Thinkspace.
+					</span>
+				</div>
+				<ListPanel
+					count={card.requestedPermissions.length}
+					emptyMessage="No Permissions requested yet."
+				>
+					{card.requestedPermissions.map((permission) => (
+						<PermissionRow key={`${permission.kind}:${permission.label}`} permission={permission} />
+					))}
+				</ListPanel>
+			</CardField>
+		) : null}
 
 		{card.connectedAccounts.length > 0 ? (
 			<CardField label="Connected Accounts">
@@ -205,34 +221,26 @@ const CuratorCardBody = ({ card }: { card: CuratorCardProjection }) => (
 );
 
 /**
- * The live agent card (#128) — the surface the creation conversation converges
- * on. It reads the Curator runtime's synced state (`useAgent` `state`, kept in
- * sync via `onStateUpdate`), which the DO re-projects after each propose-only
- * tool writes the draft. On load — and for a freshly minted draft that has had
- * no tool calls yet, so the runtime has not projected — it seeds the same view
- * from the draft query through the shared pure builder, then lets live synced
- * deltas take over. **D1 is the source of truth; synced state is a projection.**
+ * Builds the card's seed projection from the draft query — the initial-load
+ * reconciliation. The same pure builder the DO uses runs here so the card has
+ * content before the first synced delta arrives (and for a freshly minted draft
+ * that has had no tool calls yet, whose synced state is still null). Returns
+ * `null` until the draft query resolves to an actual draft revision.
  *
- * The page that places this beside the chat pane plus the Activate step is #129;
- * this is the standalone card.
+ * Exposed as a hook so the creation surface (#129) can share the seed: it derives
+ * the live card display from it (`syncedState ?? seed`) and its Activate step
+ * reads the requested Permissions from the same authoritative draft query, never
+ * from the lagging synced projection. **D1 is the source of truth; synced state
+ * is a projection.**
  */
-export const CuratorAgentCard = ({ draftThinkspaceId }: { draftThinkspaceId: string }) => {
+export const useCuratorCardSeed = (draftThinkspaceId: string): CuratorCardProjection | null => {
 	const thinkspaceQuery = useQuery(
 		orpc.thinkspaces.get.queryOptions({ input: { thinkspaceId: draftThinkspaceId } }),
 	);
 	const connectedAccountsQuery = useQuery(orpc.connectedAccounts.list.queryOptions());
 	const modelDefaultsQuery = useQuery(orpc.models.getDefaults.queryOptions());
 
-	const agent = useAgent<CuratorCardProjection | null>({
-		agent: CURATOR_AGENT_RUNTIME,
-		basePath: `api/curator/${draftThinkspaceId}`,
-		host: env.VITE_SERVER_URL,
-		name: draftThinkspaceId,
-	});
-
-	// The initial-load reconciliation: build the same projection from the draft
-	// query so the card has content before the first synced delta arrives.
-	const seed = useMemo<CuratorCardProjection | null>(() => {
+	return useMemo<CuratorCardProjection | null>(() => {
 		const thinkspace = thinkspaceQuery.data;
 		const draft = thinkspace?.agentProfileRevision;
 
@@ -247,6 +255,24 @@ export const CuratorAgentCard = ({ draftThinkspaceId }: { draftThinkspaceId: str
 			thinkspace,
 		});
 	}, [thinkspaceQuery.data, connectedAccountsQuery.data, modelDefaultsQuery.data]);
+};
+
+/**
+ * The live agent card (#128) — the surface the creation conversation converges
+ * on. It self-connects to the Curator runtime and reads its synced state
+ * (`useAgent` `state`, kept in sync via `onStateUpdate`), which the DO re-projects
+ * after each propose-only tool writes the draft, falling back to the seed before
+ * the first delta. The creation page (#129) owns one shared `useAgent` instead and
+ * renders {@link CuratorAgentCardBody} directly; this stays the standalone card.
+ */
+export const CuratorAgentCard = ({ draftThinkspaceId }: { draftThinkspaceId: string }) => {
+	const seed = useCuratorCardSeed(draftThinkspaceId);
+	const agent = useAgent<CuratorCardProjection | null>({
+		agent: CURATOR_AGENT_RUNTIME,
+		basePath: `api/curator/${draftThinkspaceId}`,
+		host: env.VITE_SERVER_URL,
+		name: draftThinkspaceId,
+	});
 
 	// Synced state wins once the runtime has projected; the seed covers the first
 	// load and a fresh, never-curated draft (whose synced state is still null).
@@ -260,5 +286,5 @@ export const CuratorAgentCard = ({ draftThinkspaceId }: { draftThinkspaceId: str
 		);
 	}
 
-	return <CuratorCardBody card={card} />;
+	return <CuratorAgentCardBody card={card} />;
 };

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -11,29 +11,30 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ThinkspacesRouteImport } from './routes/thinkspaces'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as ReviewQueueRouteImport } from './routes/review-queue'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ThinkspacesIndexRouteImport } from './routes/thinkspaces.index'
 import { Route as SettingsIndexRouteImport } from './routes/settings.index'
+import { Route as ReviewQueueIndexRouteImport } from './routes/review-queue.index'
 import { Route as ThinkspacesThinkspaceIdRouteImport } from './routes/thinkspaces.$thinkspaceId'
 import { Route as SettingsProfileRouteImport } from './routes/settings.profile'
 import { Route as SettingsProductRouteImport } from './routes/settings.product'
-import { Route as ReviewQueueRouteImport } from './routes/review-queue'
-import { Route as ReviewQueueIndexRouteImport } from './routes/review-queue.index'
+import { Route as ThinkspacesCreateDraftThinkspaceIdRouteImport } from './routes/thinkspaces.create.$draftThinkspaceId'
 
 const ThinkspacesRoute = ThinkspacesRouteImport.update({
   id: '/thinkspaces',
   path: '/thinkspaces',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ReviewQueueRoute = ReviewQueueRouteImport.update({
-  id: '/review-queue',
-  path: '/review-queue',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ReviewQueueRoute = ReviewQueueRouteImport.update({
+  id: '/review-queue',
+  path: '/review-queue',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -51,15 +52,15 @@ const ThinkspacesIndexRoute = ThinkspacesIndexRouteImport.update({
   path: '/',
   getParentRoute: () => ThinkspacesRoute,
 } as any)
-const ReviewQueueIndexRoute = ReviewQueueIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => ReviewQueueRoute,
-} as any)
 const SettingsIndexRoute = SettingsIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => SettingsRoute,
+} as any)
+const ReviewQueueIndexRoute = ReviewQueueIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ReviewQueueRoute,
 } as any)
 const ThinkspacesThinkspaceIdRoute = ThinkspacesThinkspaceIdRouteImport.update({
   id: '/$thinkspaceId',
@@ -76,6 +77,12 @@ const SettingsProductRoute = SettingsProductRouteImport.update({
   path: '/product',
   getParentRoute: () => SettingsRoute,
 } as any)
+const ThinkspacesCreateDraftThinkspaceIdRoute =
+  ThinkspacesCreateDraftThinkspaceIdRouteImport.update({
+    id: '/create/$draftThinkspaceId',
+    path: '/create/$draftThinkspaceId',
+    getParentRoute: () => ThinkspacesRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -89,6 +96,7 @@ export interface FileRoutesByFullPath {
   '/review-queue/': typeof ReviewQueueIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/thinkspaces/': typeof ThinkspacesIndexRoute
+  '/thinkspaces/create/$draftThinkspaceId': typeof ThinkspacesCreateDraftThinkspaceIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -99,6 +107,7 @@ export interface FileRoutesByTo {
   '/review-queue': typeof ReviewQueueIndexRoute
   '/settings': typeof SettingsIndexRoute
   '/thinkspaces': typeof ThinkspacesIndexRoute
+  '/thinkspaces/create/$draftThinkspaceId': typeof ThinkspacesCreateDraftThinkspaceIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -113,6 +122,7 @@ export interface FileRoutesById {
   '/review-queue/': typeof ReviewQueueIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/thinkspaces/': typeof ThinkspacesIndexRoute
+  '/thinkspaces/create/$draftThinkspaceId': typeof ThinkspacesCreateDraftThinkspaceIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -128,6 +138,7 @@ export interface FileRouteTypes {
     | '/review-queue/'
     | '/settings/'
     | '/thinkspaces/'
+    | '/thinkspaces/create/$draftThinkspaceId'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -138,6 +149,7 @@ export interface FileRouteTypes {
     | '/review-queue'
     | '/settings'
     | '/thinkspaces'
+    | '/thinkspaces/create/$draftThinkspaceId'
   id:
     | '__root__'
     | '/'
@@ -151,6 +163,7 @@ export interface FileRouteTypes {
     | '/review-queue/'
     | '/settings/'
     | '/thinkspaces/'
+    | '/thinkspaces/create/$draftThinkspaceId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -177,18 +190,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/login': {
-      id: '/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof LoginRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/review-queue': {
       id: '/review-queue'
       path: '/review-queue'
       fullPath: '/review-queue'
       preLoaderRoute: typeof ReviewQueueRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -205,19 +218,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ThinkspacesIndexRouteImport
       parentRoute: typeof ThinkspacesRoute
     }
-    '/review-queue/': {
-      id: '/review-queue/'
-      path: '/'
-      fullPath: '/review-queue/'
-      preLoaderRoute: typeof ReviewQueueIndexRouteImport
-      parentRoute: typeof ReviewQueueRoute
-    }
     '/settings/': {
       id: '/settings/'
       path: '/'
       fullPath: '/settings/'
       preLoaderRoute: typeof SettingsIndexRouteImport
       parentRoute: typeof SettingsRoute
+    }
+    '/review-queue/': {
+      id: '/review-queue/'
+      path: '/'
+      fullPath: '/review-queue/'
+      preLoaderRoute: typeof ReviewQueueIndexRouteImport
+      parentRoute: typeof ReviewQueueRoute
     }
     '/thinkspaces/$thinkspaceId': {
       id: '/thinkspaces/$thinkspaceId'
@@ -240,8 +253,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsProductRouteImport
       parentRoute: typeof SettingsRoute
     }
+    '/thinkspaces/create/$draftThinkspaceId': {
+      id: '/thinkspaces/create/$draftThinkspaceId'
+      path: '/create/$draftThinkspaceId'
+      fullPath: '/thinkspaces/create/$draftThinkspaceId'
+      preLoaderRoute: typeof ThinkspacesCreateDraftThinkspaceIdRouteImport
+      parentRoute: typeof ThinkspacesRoute
+    }
   }
 }
+
+interface ReviewQueueRouteChildren {
+  ReviewQueueIndexRoute: typeof ReviewQueueIndexRoute
+}
+
+const ReviewQueueRouteChildren: ReviewQueueRouteChildren = {
+  ReviewQueueIndexRoute: ReviewQueueIndexRoute,
+}
+
+const ReviewQueueRouteWithChildren = ReviewQueueRoute._addFileChildren(
+  ReviewQueueRouteChildren,
+)
 
 interface SettingsRouteChildren {
   SettingsProductRoute: typeof SettingsProductRoute
@@ -262,27 +294,18 @@ const SettingsRouteWithChildren = SettingsRoute._addFileChildren(
 interface ThinkspacesRouteChildren {
   ThinkspacesThinkspaceIdRoute: typeof ThinkspacesThinkspaceIdRoute
   ThinkspacesIndexRoute: typeof ThinkspacesIndexRoute
+  ThinkspacesCreateDraftThinkspaceIdRoute: typeof ThinkspacesCreateDraftThinkspaceIdRoute
 }
 
 const ThinkspacesRouteChildren: ThinkspacesRouteChildren = {
   ThinkspacesThinkspaceIdRoute: ThinkspacesThinkspaceIdRoute,
   ThinkspacesIndexRoute: ThinkspacesIndexRoute,
+  ThinkspacesCreateDraftThinkspaceIdRoute:
+    ThinkspacesCreateDraftThinkspaceIdRoute,
 }
 
 const ThinkspacesRouteWithChildren = ThinkspacesRoute._addFileChildren(
   ThinkspacesRouteChildren,
-)
-
-interface ReviewQueueRouteChildren {
-  ReviewQueueIndexRoute: typeof ReviewQueueIndexRoute
-}
-
-const ReviewQueueRouteChildren: ReviewQueueRouteChildren = {
-  ReviewQueueIndexRoute: ReviewQueueIndexRoute,
-}
-
-const ReviewQueueRouteWithChildren = ReviewQueueRoute._addFileChildren(
-  ReviewQueueRouteChildren,
 )
 
 const rootRouteChildren: RootRouteChildren = {

--- a/apps/web/src/routes/settings.product.tsx
+++ b/apps/web/src/routes/settings.product.tsx
@@ -25,18 +25,29 @@ const PROVIDER_LABELS = {
 
 const REASONING_EFFORTS = ["low", "medium", "high"] as const;
 
+/**
+ * Sentinel Select value for "no Curator override" — clearing the per-user
+ * `curatorModel` so the Curator inherits the account default. The Select cannot
+ * carry a real `null`, so this stands in and maps back to `null` on save.
+ */
+const CURATOR_MODEL_DEFAULT = "__default__";
+
 const RouteComponent = () => {
 	const context = routeApi.useRouteContext();
 	const queryClient = useQueryClient();
 	const catalogQuery = useSuspenseQuery(context.orpc.models.listAvailable.queryOptions());
 	const credentialsQuery = useSuspenseQuery(context.orpc.models.listCredentials.queryOptions());
 	const defaultsQuery = useSuspenseQuery(context.orpc.models.getDefaults.queryOptions());
+	const curatorModelQuery = useSuspenseQuery(context.orpc.models.getCuratorModel.queryOptions());
 	const connectedAccountsQuery = useSuspenseQuery(
 		context.orpc.connectedAccounts.list.queryOptions(),
 	);
 	const [defaultModel, setDefaultModel] = useState(defaultsQuery.data.defaultModel);
 	const [defaultReasoningEffort, setDefaultReasoningEffort] = useState(
 		defaultsQuery.data.reasoningEffort,
+	);
+	const [curatorModel, setCuratorModel] = useState(
+		curatorModelQuery.data.curatorModel ?? CURATOR_MODEL_DEFAULT,
 	);
 	const [providerId, setProviderId] = useState<keyof typeof PROVIDER_LABELS>("openai");
 	const [credential, setCredential] = useState("");
@@ -49,6 +60,16 @@ const RouteComponent = () => {
 				setDefaultReasoningEffort(settings.reasoningEffort);
 				await queryClient.invalidateQueries({
 					queryKey: context.orpc.models.getDefaults.queryKey(),
+				});
+			},
+		}),
+	);
+	const saveCuratorModel = useMutation(
+		context.orpc.models.updateCuratorModel.mutationOptions({
+			onSuccess: async (result) => {
+				setCuratorModel(result.curatorModel ?? CURATOR_MODEL_DEFAULT);
+				await queryClient.invalidateQueries({
+					queryKey: context.orpc.models.getCuratorModel.queryKey(),
 				});
 			},
 		}),
@@ -92,6 +113,10 @@ const RouteComponent = () => {
 		label: `${model.name} · ${model.providerName}`,
 		value: model.id,
 	}));
+	const curatorModelItems = [
+		{ label: "Use account default", value: CURATOR_MODEL_DEFAULT },
+		...modelItems,
+	];
 	const reasoningItems = REASONING_EFFORTS.map((effort) => ({ label: effort, value: effort }));
 	const providerItems = Object.entries(PROVIDER_LABELS).map(([value, providerName]) => ({
 		label: providerName,
@@ -108,6 +133,19 @@ const RouteComponent = () => {
 			return;
 		}
 		saveDefaults.mutate({ defaultModel, reasoningEffort: defaultReasoningEffort });
+	};
+
+	const curatorModelChanged =
+		curatorModel !== (curatorModelQuery.data.curatorModel ?? CURATOR_MODEL_DEFAULT);
+
+	const handleCuratorModelSubmit = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (!curatorModelChanged || saveCuratorModel.isPending) {
+			return;
+		}
+		saveCuratorModel.mutate({
+			curatorModel: curatorModel === CURATOR_MODEL_DEFAULT ? null : curatorModel,
+		});
 	};
 
 	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -201,6 +239,59 @@ const RouteComponent = () => {
 						type="submit"
 					>
 						{saveDefaults.isPending ? "Saving…" : "Save defaults"}
+					</Button>
+				</form>
+			</section>
+
+			<Separator />
+
+			<section aria-labelledby="curator-model-heading" className="grid gap-4">
+				<div className="grid gap-1">
+					<h3 className="text-sm font-medium" id="curator-model-heading">
+						Curator model
+					</h3>
+					<p className="text-muted-foreground text-sm">
+						The model the Curator reasons with while you shape a new Thinkspace in conversation. It
+						runs on your own provider credential and is separate from the model each Thinkspace
+						Agent uses. Leave it on the account default unless you want the Curator to use a
+						specific model.
+					</p>
+				</div>
+				<form
+					className="grid max-w-xl gap-4 rounded-lg p-4 ring-1 ring-foreground/10"
+					onSubmit={handleCuratorModelSubmit}
+				>
+					<div className="grid gap-1.5">
+						<Label htmlFor="curator-model">Curator model</Label>
+						<Select
+							items={curatorModelItems}
+							onValueChange={(value) => setCuratorModel(value as string)}
+							value={curatorModel}
+						>
+							<SelectTrigger className="w-full" id="curator-model">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value={CURATOR_MODEL_DEFAULT}>Use account default</SelectItem>
+								{catalogQuery.data.map((model) => (
+									<SelectItem key={model.id} value={model.id}>
+										{model.name} · {model.providerName} · {model.id}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+					{saveCuratorModel.error ? (
+						<p className="text-destructive text-sm" role="alert">
+							{saveCuratorModel.error.message}
+						</p>
+					) : null}
+					<Button
+						className="w-fit"
+						disabled={!curatorModelChanged || saveCuratorModel.isPending}
+						type="submit"
+					>
+						{saveCuratorModel.isPending ? "Saving…" : "Save Curator model"}
 					</Button>
 				</form>
 			</section>

--- a/apps/web/src/routes/thinkspaces.create.$draftThinkspaceId.tsx
+++ b/apps/web/src/routes/thinkspaces.create.$draftThinkspaceId.tsx
@@ -1,0 +1,421 @@
+import { buildCuratorCardProjection } from "@better-agent/api/thinkspaces/curator-card";
+import type {
+	CuratorCardProjection,
+	CuratorCardRequestedPermissionView,
+} from "@better-agent/api/thinkspaces/curator-card";
+import { env } from "@better-agent/env/web";
+import { Badge } from "@better-agent/ui/components/badge";
+import { Button } from "@better-agent/ui/components/button";
+import { Switch } from "@better-agent/ui/components/switch";
+import { Textarea } from "@better-agent/ui/components/textarea";
+import { useAgentChat } from "@cloudflare/ai-chat/react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, getRouteApi, Link, useNavigate } from "@tanstack/react-router";
+import { useAgent } from "agents/react";
+import {
+	ChevronRightIcon,
+	KeyRoundIcon,
+	MessagesSquareIcon,
+	PlugIcon,
+	SparklesIcon,
+	TriangleAlertIcon,
+} from "lucide-react";
+import type { FormEvent } from "react";
+import { useState } from "react";
+
+import { CuratorAgentCardBody, useCuratorCardSeed } from "@/components/curator-agent-card";
+
+const routeApi = getRouteApi("/thinkspaces/create/$draftThinkspaceId");
+
+/**
+ * Kebab-cased Durable Object class name. With `basePath` set, the client connects
+ * to the worker's authenticated Curator route directly and the worker resolves
+ * the runtime by draft Thinkspace id, so this value only labels the connection.
+ * Mirrors the Sitting transport.
+ */
+const CURATOR_AGENT_RUNTIME = "curator-agent";
+
+/** The shared connection both the chat and the live card read from. */
+type CuratorAgentConnection = ReturnType<typeof useAgent<CuratorCardProjection | null>>;
+
+/**
+ * A stable identity for a requested Permission, used to track grant decisions
+ * across the live (synced) card and the authoritative draft re-read at activation
+ * time. The view label encodes each Permission's discriminator (providerId,
+ * catalogId, serverId), so `kind|label` is unique within a draft regardless of
+ * array position — which lets the grant set survive the projection re-ordering or
+ * lagging behind the draft mid-conversation.
+ */
+const permissionKey = (permission: CuratorCardRequestedPermissionView): string =>
+	`${permission.kind}|${permission.label}`;
+
+const getCuratorMessageRoleLabel = (role: string): string => (role === "user" ? "You" : "Curator");
+
+const LiveCuration = ({ agent }: { agent: CuratorAgentConnection }) => {
+	const { error, isRecovering, messages, sendMessage, status, stop } = useAgentChat({
+		agent,
+		credentials: "include",
+	});
+	const [draft, setDraft] = useState("");
+	const isBusy = status === "submitted" || status === "streaming";
+
+	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		const text = draft.trim();
+
+		if (!text || isBusy) {
+			return;
+		}
+
+		setDraft("");
+		void sendMessage({ text });
+	};
+
+	return (
+		<div className="grid gap-4 rounded-lg p-4 ring-1 ring-foreground/10">
+			<div className="flex items-center gap-2">
+				<MessagesSquareIcon aria-hidden className="size-4 text-muted-foreground" />
+				<h2 className="text-sm font-medium">Curation conversation</h2>
+			</div>
+			<div
+				aria-label="Curation conversation"
+				aria-live="polite"
+				className="grid max-h-[30rem] gap-4 overflow-y-auto"
+			>
+				{messages.length === 0 ? (
+					<p className="text-muted-foreground text-sm leading-relaxed">
+						Describe the agent you want — its Goal, what it should pay attention to, which Sources
+						and tools it should use, and how it should work. The Curator shapes the agent card
+						beside this conversation as you talk; you grant Permissions and activate when it&apos;s
+						ready.
+					</p>
+				) : (
+					messages.map((message) => {
+						const renderableParts = message.parts.filter(
+							(part) => part.type === "text" || part.type === "reasoning",
+						);
+
+						// Curator tools are propose-only writes to the draft — the card reflects
+						// them — so a turn with only tool parts shows nothing here. Skip it; the
+						// streaming/thinking badges below already signal an in-flight turn.
+						if (renderableParts.length === 0) {
+							return null;
+						}
+
+						return (
+							<div className="grid gap-1" key={message.id}>
+								<p className="text-muted-foreground text-xs font-medium">
+									{getCuratorMessageRoleLabel(message.role)}
+								</p>
+								{renderableParts.map((part, index) => {
+									if (part.type === "reasoning") {
+										return (
+											<p
+												className="whitespace-pre-wrap border-border border-l-2 pl-3 text-muted-foreground text-xs italic leading-relaxed"
+												key={`${message.id}-reasoning-${index}`}
+											>
+												{part.text}
+											</p>
+										);
+									}
+
+									return (
+										<p
+											className="whitespace-pre-wrap text-sm leading-relaxed"
+											key={`${message.id}-text-${index}`}
+										>
+											{part.type === "text" ? part.text : ""}
+										</p>
+									);
+								})}
+							</div>
+						);
+					})
+				)}
+			</div>
+			<div className="flex flex-wrap items-center gap-3 border-border border-t pt-3">
+				{isRecovering ? (
+					<Badge variant="secondary">Recovering the Curator&apos;s turn…</Badge>
+				) : null}
+				{status === "streaming" ? <Badge variant="secondary">Streaming…</Badge> : null}
+				{status === "submitted" ? <Badge variant="secondary">Thinking…</Badge> : null}
+			</div>
+			{error ? (
+				<p className="text-destructive text-xs" role="alert">
+					{error.message}
+				</p>
+			) : null}
+			<form className="grid gap-2" onSubmit={handleSubmit}>
+				<label className="sr-only" htmlFor="curation-message">
+					Message to the Curator
+				</label>
+				<Textarea
+					id="curation-message"
+					onChange={(event) => setDraft(event.target.value)}
+					onKeyDown={(event) => {
+						if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+							event.currentTarget.form?.requestSubmit();
+						}
+					}}
+					placeholder="Describe the agent you want to build, or refine the card on the right."
+					rows={3}
+					value={draft}
+				/>
+				<div className="flex items-center justify-end gap-2">
+					{isBusy ? (
+						<Button onClick={() => void stop()} type="button" variant="outline">
+							Stop
+						</Button>
+					) : null}
+					<Button disabled={!draft.trim() || isBusy} type="submit">
+						Send
+					</Button>
+				</div>
+			</form>
+		</div>
+	);
+};
+
+const ActivateStep = ({
+	card,
+	draftThinkspaceId,
+}: {
+	card: CuratorCardProjection;
+	draftThinkspaceId: string;
+}) => {
+	const context = routeApi.useRouteContext();
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
+	// Default is grant-all: a Permission is granted unless the owner toggles it off.
+	const [deniedKeys, setDeniedKeys] = useState<ReadonlySet<string>>(new Set());
+	const activateMutation = useMutation(
+		context.orpc.thinkspaces.activateAgentProfile.mutationOptions({
+			onSuccess: async () => {
+				await queryClient.invalidateQueries({
+					queryKey: context.orpc.thinkspaces.list.queryKey(),
+				});
+				await navigate({
+					params: { thinkspaceId: draftThinkspaceId },
+					to: "/thinkspaces/$thinkspaceId",
+				});
+			},
+		}),
+	);
+
+	const { requestedPermissions } = card;
+	const unconnectedAccounts = card.connectedAccounts.filter((account) => !account.connected);
+
+	const toggleGrant = (key: string, granted: boolean) => {
+		setDeniedKeys((previous) => {
+			const next = new Set(previous);
+			if (granted) {
+				next.delete(key);
+			} else {
+				next.add(key);
+			}
+			return next;
+		});
+	};
+
+	const handleActivate = async () => {
+		if (!card.ready || activateMutation.isPending) {
+			return;
+		}
+
+		// Re-read the draft from D1 so the grant indexes map against the server's
+		// current `requestedPermissions` array, not the live projection (which can lag
+		// the draft mid-conversation). The grant decision is tracked by stable key, so
+		// it survives the array having grown since the toggles first rendered.
+		const fresh = await queryClient.fetchQuery(
+			context.orpc.thinkspaces.get.queryOptions({ input: { thinkspaceId: draftThinkspaceId } }),
+		);
+		const freshDraft = fresh.agentProfileRevision;
+
+		if (!freshDraft || freshDraft.status !== "draft") {
+			return;
+		}
+
+		const [connectedAccounts, modelDefaults] = await Promise.all([
+			queryClient.ensureQueryData(context.orpc.connectedAccounts.list.queryOptions()),
+			queryClient.ensureQueryData(context.orpc.models.getDefaults.queryOptions()),
+		]);
+		const freshProjection = buildCuratorCardProjection({
+			connectedAccounts,
+			defaultModelId: modelDefaults.defaultModel ?? freshDraft.modelBehavior.modelId,
+			draft: freshDraft,
+			thinkspace: fresh,
+		});
+		const grantedPermissionIndexes = freshProjection.requestedPermissions
+			.map((permission, index) => ({ index, key: permissionKey(permission) }))
+			.filter(({ key }) => !deniedKeys.has(key))
+			.map(({ index }) => index);
+
+		activateMutation.mutate({ grantedPermissionIndexes, thinkspaceId: draftThinkspaceId });
+	};
+
+	return (
+		<section
+			aria-labelledby="activate-heading"
+			className="grid gap-4 rounded-lg p-5 ring-1 ring-foreground/10"
+		>
+			<div className="grid gap-1">
+				<h2 className="text-sm font-medium" id="activate-heading">
+					Activate
+				</h2>
+				<p className="text-muted-foreground text-xs leading-relaxed">
+					Grant the Permissions this agent needs, then activate to make the Thinkspace live. You can
+					change Permissions later from the Thinkspace.
+				</p>
+			</div>
+
+			<div className="grid gap-2">
+				<div className="flex items-center gap-2">
+					<KeyRoundIcon aria-hidden className="size-4 text-muted-foreground" />
+					<p className="text-muted-foreground text-xs">Permissions to grant on activation</p>
+				</div>
+				{requestedPermissions.length === 0 ? (
+					<p className="rounded-lg p-4 ring-1 ring-foreground/10 text-muted-foreground text-sm">
+						The Curator hasn&apos;t requested any Permissions yet.
+					</p>
+				) : (
+					<div className="divide-y divide-border overflow-hidden rounded-lg ring-1 ring-foreground/10">
+						{requestedPermissions.map((permission) => {
+							const key = permissionKey(permission);
+							const granted = !deniedKeys.has(key);
+
+							return (
+								<div className="flex items-start justify-between gap-4 p-4" key={key}>
+									<div className="grid gap-0.5">
+										<p className="text-sm font-medium">{permission.label}</p>
+										<p className="text-muted-foreground text-xs">{permission.reason}</p>
+									</div>
+									<Switch
+										aria-label={`Grant ${permission.label}`}
+										checked={granted}
+										disabled={activateMutation.isPending}
+										onCheckedChange={(checked) => toggleGrant(key, checked)}
+									/>
+								</div>
+							);
+						})}
+					</div>
+				)}
+			</div>
+
+			{unconnectedAccounts.length > 0 ? (
+				<div className="grid gap-2 rounded-lg p-4 ring-1 ring-foreground/10">
+					{unconnectedAccounts.map((account) => (
+						<div className="flex items-start justify-between gap-4" key={account.toolId}>
+							<div className="flex items-start gap-2">
+								<TriangleAlertIcon
+									aria-hidden
+									className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+								/>
+								<p className="text-muted-foreground text-xs leading-relaxed">
+									The <span className="font-medium capitalize">{account.catalogId}</span> tool stays
+									inert until you connect an account. You can still activate now and connect later.
+								</p>
+							</div>
+							<Button render={<Link to="/settings/product" />} size="sm" variant="outline">
+								<PlugIcon />
+								Connect
+							</Button>
+						</div>
+					))}
+				</div>
+			) : null}
+
+			{card.ready ? null : (
+				<p className="text-muted-foreground text-xs">
+					Give the agent a Goal and a model before activating — keep shaping it in the conversation.
+				</p>
+			)}
+
+			{activateMutation.error ? (
+				<p className="text-destructive text-sm" role="alert">
+					{activateMutation.error.message}
+				</p>
+			) : null}
+
+			<Button
+				className="w-full"
+				disabled={!card.ready || activateMutation.isPending}
+				onClick={() => void handleActivate()}
+				type="button"
+			>
+				<SparklesIcon />
+				{activateMutation.isPending ? "Activating…" : "Activate Thinkspace"}
+			</Button>
+		</section>
+	);
+};
+
+const RouteComponent = () => {
+	const { draftThinkspaceId } = routeApi.useParams();
+	const seed = useCuratorCardSeed(draftThinkspaceId);
+	const agent = useAgent<CuratorCardProjection | null>({
+		agent: CURATOR_AGENT_RUNTIME,
+		basePath: `api/curator/${draftThinkspaceId}`,
+		host: env.VITE_SERVER_URL,
+		name: draftThinkspaceId,
+	});
+
+	// Synced state wins once the runtime has projected after the first propose-only
+	// tool; the seed covers the first load and a fresh, never-curated draft.
+	const card = agent.state ?? seed;
+
+	return (
+		<div className="mx-auto grid w-full max-w-6xl gap-6 px-4 py-8">
+			<header className="grid gap-3">
+				<nav
+					aria-label="Breadcrumb"
+					className="flex items-center gap-1.5 text-muted-foreground text-xs"
+				>
+					<Link className="transition-colors hover:text-foreground" to="/thinkspaces">
+						Thinkspaces
+					</Link>
+					<ChevronRightIcon aria-hidden className="size-3.5" />
+					<span aria-current="page" className="text-foreground">
+						New Thinkspace
+					</span>
+				</nav>
+				<div className="flex items-start gap-2.5">
+					<SparklesIcon aria-hidden className="mt-1 size-5 shrink-0 text-muted-foreground" />
+					<div className="grid gap-1">
+						<h1 className="text-2xl font-semibold tracking-tight">Create a Thinkspace</h1>
+						<p className="max-w-xl text-muted-foreground text-sm leading-relaxed text-pretty">
+							Shape the agent through a conversation with the Curator. It proposes the Goal,
+							instructions, model, tools, and Permissions on the card; you grant and activate.
+						</p>
+					</div>
+				</div>
+			</header>
+
+			<div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_24rem]">
+				<LiveCuration agent={agent} />
+				<div className="grid content-start gap-4">
+					{card ? (
+						<>
+							<CuratorAgentCardBody card={card} showRequestedPermissions={false} />
+							<ActivateStep card={card} draftThinkspaceId={draftThinkspaceId} />
+						</>
+					) : (
+						<p className="rounded-lg p-5 ring-1 ring-foreground/10 text-muted-foreground text-sm">
+							Starting the curation conversation…
+						</p>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export const Route = createFileRoute("/thinkspaces/create/$draftThinkspaceId")({
+	component: RouteComponent,
+	loader: async ({ context, params }) =>
+		await context.queryClient.ensureQueryData(
+			context.orpc.thinkspaces.get.queryOptions({
+				input: { thinkspaceId: params.draftThinkspaceId },
+			}),
+		),
+});

--- a/apps/web/src/routes/thinkspaces.index.tsx
+++ b/apps/web/src/routes/thinkspaces.index.tsx
@@ -1,21 +1,19 @@
 import { Badge } from "@better-agent/ui/components/badge";
 import { Button } from "@better-agent/ui/components/button";
 import { Input } from "@better-agent/ui/components/input";
-import { Label } from "@better-agent/ui/components/label";
-import { Textarea } from "@better-agent/ui/components/textarea";
 import { cn } from "@better-agent/ui/lib/utils";
-import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router";
+import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute, getRouteApi, Link, useNavigate } from "@tanstack/react-router";
 import {
 	ArchiveIcon,
 	CircleDashedIcon,
 	CircleDotIcon,
 	ClockIcon,
+	KeyRoundIcon,
 	PlusIcon,
 	SearchIcon,
 	TargetIcon,
 } from "lucide-react";
-import type { FormEvent } from "react";
 import { useState } from "react";
 
 const routeApi = getRouteApi("/thinkspaces/");
@@ -71,46 +69,53 @@ const GHOST_THINKSPACES = [
 
 const RouteComponent = () => {
 	const context = routeApi.useRouteContext();
-	const queryClient = useQueryClient();
+	const navigate = useNavigate();
 	const thinkspacesQuery = useSuspenseQuery(context.orpc.thinkspaces.list.queryOptions());
-	const [goal, setGoal] = useState("");
-	const [initialInstructions, setInitialInstructions] = useState("");
-	const [configurationSummary, setConfigurationSummary] = useState("");
-	const [showCreate, setShowCreate] = useState(false);
+	const readinessQuery = useQuery(context.orpc.models.getCuratorReadiness.queryOptions());
+	const [showGate, setShowGate] = useState(false);
 	const [search, setSearch] = useState("");
 	const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
-	const createMutation = useMutation(
-		context.orpc.thinkspaces.create.mutationOptions({
-			onSuccess: async () => {
-				setGoal("");
-				setInitialInstructions("");
-				setConfigurationSummary("");
-				setShowCreate(false);
-				await queryClient.invalidateQueries({
-					queryKey: context.orpc.thinkspaces.list.queryKey(),
+	// Minting a Thinkspace now opens a conversational creation surface: start a
+	// curation draft, then route to it by id. The 3-field form is gone.
+	const startCurationMutation = useMutation(
+		context.orpc.thinkspaces.startCuration.mutationOptions({
+			onSuccess: async (draft) => {
+				if (!draft) {
+					return;
+				}
+
+				await navigate({
+					params: { draftThinkspaceId: draft.id },
+					to: "/thinkspaces/create/$draftThinkspaceId",
 				});
 			},
 		}),
 	);
 
-	const trimmedGoal = goal.trim();
-	const trimmedConfigurationSummary = configurationSummary.trim();
-	const canCreate =
-		Boolean(trimmedGoal && trimmedConfigurationSummary) && !createMutation.isPending;
+	const readiness = readinessQuery.data;
+	const isStarting = startCurationMutation.isPending;
+	const startDisabled = isStarting || readinessQuery.isLoading;
 
-	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-		event.preventDefault();
-
-		if (!canCreate) {
+	// No credential → gate creation with a connect-first prompt, never a form. A
+	// missing credential is a not-ready readiness; everything else proceeds.
+	const handleStartCuration = () => {
+		if (startDisabled) {
 			return;
 		}
 
-		createMutation.mutate({
-			configurationSummary,
-			goal,
-			initialInstructions,
-		});
+		if (readiness?.status !== "ready") {
+			setShowGate(true);
+			return;
+		}
+
+		setShowGate(false);
+		startCurationMutation.mutate({});
 	};
+
+	const gateMessage =
+		readiness?.status === "not_ready"
+			? readiness.message
+			: "Connect a model provider credential before starting a curation conversation with the Curator.";
 
 	const thinkspaces = thinkspacesQuery.data;
 	const hasThinkspaces = thinkspaces.length > 0;
@@ -135,68 +140,38 @@ const RouteComponent = () => {
 				</p>
 			</div>
 
-			{showCreate ? (
-				<form
+			{showGate ? (
+				<section
+					aria-labelledby="curator-gate-heading"
 					className="grid gap-4 rounded-lg p-6 ring-1 ring-foreground/10"
-					onSubmit={handleSubmit}
 				>
-					<div className="grid gap-1">
-						<h2 className="text-lg font-semibold tracking-tight">Create Thinkspace</h2>
-						<p className="text-muted-foreground text-sm">
-							Define a bounded Goal and initial configuration.
-						</p>
+					<div className="flex items-start gap-2.5">
+						<KeyRoundIcon aria-hidden className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+						<div className="grid gap-1">
+							<h2 className="text-lg font-semibold tracking-tight" id="curator-gate-heading">
+								Connect a model provider first
+							</h2>
+							<p className="max-w-lg text-muted-foreground text-sm leading-relaxed text-pretty">
+								{gateMessage}
+							</p>
+						</div>
 					</div>
-					<div className="grid gap-1.5">
-						<Label htmlFor="thinkspace-goal">Goal</Label>
-						<Input
-							id="thinkspace-goal"
-							name="goal"
-							onChange={(event) => setGoal(event.target.value)}
-							placeholder="The bounded outcome this Thinkspace will pursue"
-							required
-							value={goal}
-						/>
-					</div>
-					<div className="grid gap-1.5">
-						<Label htmlFor="thinkspace-configuration-summary">Configuration summary</Label>
-						<Textarea
-							id="thinkspace-configuration-summary"
-							name="configurationSummary"
-							onChange={(event) => setConfigurationSummary(event.target.value)}
-							placeholder="Scope, Sources to consider, and review expectations"
-							required
-							rows={4}
-							value={configurationSummary}
-						/>
-					</div>
-					<div className="grid gap-1.5">
-						<Label htmlFor="thinkspace-initial-instructions">Initial instructions</Label>
-						<Textarea
-							id="thinkspace-initial-instructions"
-							name="initialInstructions"
-							onChange={(event) => setInitialInstructions(event.target.value)}
-							placeholder="Starting guidance for the Thinkspace Agent (optional)"
-							rows={3}
-							value={initialInstructions}
-						/>
-					</div>
-					{createMutation.error ? (
-						<p className="text-destructive text-sm" role="alert">
-							{createMutation.error.message}
-						</p>
-					) : null}
 					<div className="flex gap-2">
-						<Button disabled={!canCreate} type="submit">
-							{createMutation.isPending ? "Creating…" : "Create Thinkspace"}
-						</Button>
-						<Button onClick={() => setShowCreate(false)} type="button" variant="ghost">
-							Cancel
+						<Button render={<Link to="/settings/product" />}>Go to provider settings</Button>
+						<Button onClick={() => setShowGate(false)} type="button" variant="ghost">
+							Dismiss
 						</Button>
 					</div>
-				</form>
+				</section>
 			) : null}
 
-			{!showCreate && hasThinkspaces ? (
+			{startCurationMutation.error ? (
+				<p className="text-destructive text-sm" role="alert">
+					{startCurationMutation.error.message}
+				</p>
+			) : null}
+
+			{hasThinkspaces ? (
 				<section aria-labelledby="thinkspace-list-heading" className="grid gap-4">
 					<h2 className="sr-only" id="thinkspace-list-heading">
 						Your Thinkspaces
@@ -232,9 +207,13 @@ const RouteComponent = () => {
 								</button>
 							))}
 						</div>
-						<Button className="ml-auto shrink-0" onClick={() => setShowCreate(true)}>
+						<Button
+							className="ml-auto shrink-0"
+							disabled={startDisabled}
+							onClick={handleStartCuration}
+						>
 							<PlusIcon />
-							New Thinkspace
+							{isStarting ? "Starting…" : "New Thinkspace"}
 						</Button>
 					</div>
 					{filteredThinkspaces.length === 0 ? (
@@ -277,7 +256,7 @@ const RouteComponent = () => {
 				</section>
 			) : null}
 
-			{!showCreate && !hasThinkspaces ? (
+			{hasThinkspaces ? null : (
 				<section
 					aria-labelledby="thinkspace-empty-heading"
 					className="grid overflow-hidden rounded-lg ring-1 ring-foreground/10 md:grid-cols-2"
@@ -288,12 +267,13 @@ const RouteComponent = () => {
 						</h2>
 						<p className="max-w-sm text-muted-foreground text-sm leading-relaxed text-pretty">
 							A Thinkspace is a bounded environment for one Goal — its own Sources, Permissions, and
-							a dedicated agent. Compose it once, then return to review what it produced.
+							a dedicated agent. Shape it in a conversation with the Curator, then return to review
+							what it produced.
 						</p>
 						<div>
-							<Button onClick={() => setShowCreate(true)}>
+							<Button disabled={startDisabled} onClick={handleStartCuration}>
 								<PlusIcon />
-								Create Thinkspace
+								{isStarting ? "Starting…" : "Create Thinkspace"}
 							</Button>
 						</div>
 					</div>
@@ -327,7 +307,7 @@ const RouteComponent = () => {
 						</div>
 					</div>
 				</section>
-			) : null}
+			)}
 		</div>
 	);
 };


### PR DESCRIPTION
Closes #129. Sixth child of PRD #123 (`curator_creation_v1`), built on #124–#128.

## What this delivers
The conversational creation surface that ties curator_creation_v1 together, the removal of the static form, and **in-surface activation**.

- **Creation surface** — new route `apps/web/src/routes/thinkspaces.create.$draftThinkspaceId.tsx`. One shared `useAgent` connection feeds both the streamed Curator chat (`useAgentChat`, #125) and the live agent card (#128), placed in a two-column Workbench layout.
- **Entry point** — "New Thinkspace" / "Create Thinkspace" call `startCuration` (#126) and route to the surface for the returned draft id. The static 3-field form is **removed** from `thinkspaces.index.tsx`.
- **No-credential gate** — if `models.getCuratorReadiness` (#124) reports no credential, creation is gated with a connect-first prompt linking to `/settings/product` — never a form.
- **In-surface activation** — the Activate step renders requested Permissions as **grant toggles** plus each connected-account tool's connected/not status. It calls `activateAgentProfile({ grantedPermissionIndexes })`, flips DRAFT → ACTIVE with exactly the granted Permissions, and routes to the now-active Thinkspace. Gated on **draft readiness**; an unconnected-account tool **warns but does not block**.
- **Grant-index correctness** — indexes are computed against a **fresh re-read** of the draft (`thinkspaces.get` at click time) and the grant decision is tracked by a stable Permission key, so it never drifts from the lagging synced projection.
- **Curator model setting** — a set/clear control in `settings.product.tsx` (`getCuratorModel` / `updateCuratorModel`, #124).

## Refactor
`curator-agent-card.tsx` split into `useCuratorCardSeed` (hook) + presentational `CuratorAgentCardBody` (with `showRequestedPermissions`) so the surface owns a single websocket; `CuratorAgentCard` remains the standalone self-connecting card.

## Verification
- Route tree regenerated with the project's pinned toolchain (new route present, `createStart` augmentation preserved).
- `bunx tsc -p apps/web/tsconfig.json`: **no new errors** vs `origin/main` — none in changed files; only pre-existing cross-package raw-tsc noise remains.
- `bun x ultracite check`: clean on all changed files.
- `bun run check-types` (api/server/ui): green.
- **Owner-run browser E2E pending**: the full `New Thinkspace → curate → watch the card converge → grant → Activate → land on the active Thinkspace` round-trip needs a connected model provider credential. This run also clears the #128 live state-sync eyeball debt.