### PR TITLE
Thinkspace: unlock registered + mutating MCP servers for grants

### DIFF
--- a/apps/server/src/agents/thinkspace-agent.ts
+++ b/apps/server/src/agents/thinkspace-agent.ts
@@ -15,6 +15,7 @@ import type {
 } from "@better-agent/api/thinkspaces/inspect";
 import type { BuiltInMcpServer } from "@better-agent/api/mcp/catalog";
 import { listBuiltInMcpServers } from "@better-agent/api/mcp/catalog";
+import { listGrantableMcpServers } from "@better-agent/api/mcp/grantable-servers";
 import {
 	assertThinkspaceRuntimePolicySupportsBuiltInTools,
 	evaluateBuiltInRuntimeToolCallPermission,
@@ -405,8 +406,14 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 			}),
 			webReader: createFetchWebReader(),
 		});
+		// The grantable catalog is built-in servers ∪ the owner's registered MCP
+		// connections, so a Thinkspace can run tools from a server the owner added,
+		// not only the curated built-ins. The server's declared risk decides whether
+		// its tool calls run inline (read-only) or are held for Approval (mutating).
+		const grantableMcpServers = await listGrantableMcpServers(db, turnContext.ownerUserId);
 		const mcpPlan = planThinkspaceMcpRuntimeTools({
 			activeProductToolIds: assembly.activeTools,
+			builtInMcpServers: grantableMcpServers,
 			revision: resolved.activeRevision,
 		});
 
@@ -414,7 +421,7 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 
 		const mcpPreparation = await prepareThinkspaceMcpRuntimeTools({
 			activeProductToolIds: mcpPlan.activeProductToolIds,
-			connectServer: ({ server }) => this.connectBuiltInMcpServerForTurn(server),
+			connectServer: ({ server }) => this.connectMcpServerForTurn(server),
 			servers: mcpPlan.servers,
 		});
 
@@ -489,6 +496,7 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 			const db = createDb(this.env.DB);
 			const resolved = await this.resolveTurnModel(db, turnContext);
 			const permissionPolicy = createPermissionStorePolicy({ db });
+			const grantableMcpServers = await listGrantableMcpServers(db, turnContext.ownerUserId);
 			const builtInDecision = await evaluateBuiltInRuntimeToolCallPermission({
 				permissionPolicy,
 				revision: resolved.activeRevision,
@@ -527,6 +535,7 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 			}
 
 			const decision = await evaluateMcpRuntimeToolCallPermission({
+				builtInMcpServers: grantableMcpServers,
 				permissionPolicy,
 				revision: resolved.activeRevision,
 				runtimeToolName: ctx.toolName,
@@ -558,7 +567,7 @@ export class ThinkspaceAgent extends Think<CloudflareEnv> {
 		return super.onChatError(error, ctx);
 	}
 
-	private async connectBuiltInMcpServerForTurn(server: BuiltInMcpServer): Promise<ToolSet> {
+	private async connectMcpServerForTurn(server: BuiltInMcpServer): Promise<ToolSet> {
 		const result = await this.addMcpServer(server.name, server.url, {
 			id: server.id,
 			transport: { type: toRuntimeMcpTransport(server.transport) },

--- a/apps/web/src/routes/review-queue.index.tsx
+++ b/apps/web/src/routes/review-queue.index.tsx
@@ -1,4 +1,7 @@
-import { parseProposedGitHubIssue } from "@better-agent/api/thinkspaces/approvals";
+import {
+	parseProposedGitHubIssue,
+	parseProposedMcpToolCall,
+} from "@better-agent/api/thinkspaces/approvals";
 import { Badge } from "@better-agent/ui/components/badge";
 import { Button } from "@better-agent/ui/components/button";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
@@ -17,16 +20,45 @@ const formatProposedAt = (value: Date | number | string): string =>
 
 const ACTION_LABELS: Record<string, string> = {
 	github_create_issue: "GitHub issue",
+	mcp_tool_call: "External tool call",
 	memory_write: "Memory proposal",
 };
 
 const actionLabel = (actionKind: string): string => ACTION_LABELS[actionKind] ?? "Held action";
 
 /**
+ * A held MCP tool call's detail: the proposed tool above its arguments, shown as
+ * formatted JSON so the owner sees exactly what would run. Falls back to the
+ * summary line when the stored payload is malformed.
+ */
+const McpToolCallDetail = ({
+	proposedContent,
+	proposedSummary,
+}: {
+	proposedContent: string;
+	proposedSummary: string;
+}) => {
+	const call = parseProposedMcpToolCall(proposedContent);
+
+	if (!call) {
+		return <p className="text-foreground text-sm leading-relaxed">{proposedSummary}</p>;
+	}
+
+	return (
+		<div className="grid gap-1">
+			<p className="break-all font-mono text-muted-foreground text-xs">{call.runtimeToolName}</p>
+			<pre className="overflow-x-auto whitespace-pre-wrap rounded-md bg-muted p-2 font-mono text-foreground text-xs">
+				{JSON.stringify(call.args, null, 2)}
+			</pre>
+		</div>
+	);
+};
+
+/**
  * The held proposal's detail. A GitHub-issue proposal parses its serialized
- * payload to show the target repo prominently above the title and body; any
- * other kind (and a malformed issue payload) falls back to the product-language
- * summary line.
+ * payload to show the target repo prominently above the title and body; a held
+ * MCP tool call shows the tool and its arguments; any other kind (and a
+ * malformed payload) falls back to the product-language summary line.
  */
 const ProposalDetail = ({
 	actionKind,
@@ -37,6 +69,10 @@ const ProposalDetail = ({
 	proposedContent: string;
 	proposedSummary: string;
 }) => {
+	if (actionKind === "mcp_tool_call") {
+		return <McpToolCallDetail proposedContent={proposedContent} proposedSummary={proposedSummary} />;
+	}
+
 	const issue =
 		actionKind === "github_create_issue" ? parseProposedGitHubIssue(proposedContent) : null;
 

--- a/packages/api/src/mcp/grantable-servers.test.ts
+++ b/packages/api/src/mcp/grantable-servers.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { user } from "@better-agent/db/schema/auth";
+import type { UserMcpConnection } from "@better-agent/db/schema/settings";
+
+import { createTestProductDb } from "../testing/product-db";
+import { listBuiltInMcpServers } from "./catalog";
+import { listGrantableMcpServers, userMcpConnectionToGrantableServer } from "./grantable-servers";
+import { createCustomMcpConnection } from "./repository";
+
+const baseConnection: UserMcpConnection = {
+	authType: "none",
+	catalogVisible: true,
+	createdAt: new Date(),
+	description: "Internal docs.",
+	encryptedHeaders: "{}",
+	id: "mcp_connection_docs",
+	name: "Internal Docs",
+	riskLevel: "read_only",
+	serverId: null,
+	transport: "streamable_http",
+	updatedAt: new Date(),
+	url: "https://example.com/mcp",
+	userId: "user_grantable",
+};
+
+test("maps a registered connection onto the grantable shape", () => {
+	const server = userMcpConnectionToGrantableServer(baseConnection);
+
+	assert.equal(server.id, "mcp_connection_docs");
+	assert.equal(server.authType, "none");
+	assert.equal(server.riskLevel, "read_only");
+	assert.equal(server.enabledByDefaultForThinkspaces, false);
+});
+
+test("treats a connection carrying secret headers as authenticated even if it declares none", () => {
+	const server = userMcpConnectionToGrantableServer({
+		...baseConnection,
+		authType: "none",
+		encryptedHeaders: JSON.stringify({ encrypted: "secret" }),
+	});
+
+	assert.equal(server.authType, "bearer");
+});
+
+test("lists built-in servers alongside the owner's registered connections", async () => {
+	const db = createTestProductDb();
+	await db.insert(user).values({ email: "owner@example.com", id: "user_grantable", name: "Owner" });
+	await createCustomMcpConnection(db, {
+		authType: "none",
+		description: "Internal docs.",
+		encryptedHeaders: "{}",
+		id: "mcp_connection_docs",
+		name: "Internal Docs",
+		riskLevel: "read_only",
+		transport: "streamable_http",
+		url: "https://example.com/mcp",
+		userId: "user_grantable",
+	});
+
+	const servers = await listGrantableMcpServers(db, "user_grantable");
+	const ids = new Set(servers.map((server) => server.id));
+
+	for (const builtIn of listBuiltInMcpServers()) {
+		assert.ok(ids.has(builtIn.id));
+	}
+	assert.ok(ids.has("mcp_connection_docs"));
+});

--- a/packages/api/src/mcp/grantable-servers.ts
+++ b/packages/api/src/mcp/grantable-servers.ts
@@ -1,0 +1,89 @@
+/**
+ * The set of MCP servers a Thinkspace may be granted access to at activation.
+ *
+ * The Thinkspace permission grant path (`thinkspaces/permissions.ts`) used to
+ * recognize only the hardcoded built-in catalog, so a user's own registered
+ * MCP servers could be *proposed* by the Curator but never *granted* — they
+ * tripped the "Only built-in MCP servers can be granted" guard. This module is
+ * the seam that unifies the two: built-in catalog entries plus the owner's
+ * registered connections, expressed in one shape the grant guards understand.
+ *
+ * A registered connection is still subject to the remaining grant guards: it is
+ * grantable now only if it declares `authType: "none"` and `riskLevel:
+ * "read_only"`. Authenticated servers wait on the credential seam (ADR-0009);
+ * mutating servers wait on the draft-or-approval policy (ADR-0003).
+ */
+import type { ProductDb } from "@better-agent/db";
+import type { UserMcpConnection } from "@better-agent/db/schema/settings";
+
+import { listBuiltInMcpServers } from "./catalog";
+import type { BuiltInMcpServer, McpAuthType, McpRiskLevel, McpTransport } from "./catalog";
+import { listCustomMcpConnections } from "./repository";
+
+/**
+ * The shape every grant-path guard reads. A registered user connection and a
+ * built-in catalog entry both project onto it, so the guards never branch on
+ * where a server came from. Structurally identical to `BuiltInMcpServer`; named
+ * for the role it plays at the grant boundary.
+ */
+export type GrantableMcpServer = BuiltInMcpServer;
+
+const AUTH_TYPES = new Set<string>(["none", "bearer", "api_key_header"]);
+const RISK_LEVELS = new Set<string>(["read_only", "unknown", "mutating"]);
+const TRANSPORTS = new Set<string>(["streamable_http", "sse"]);
+
+const coerceAuthType = (value: string): McpAuthType =>
+	AUTH_TYPES.has(value) ? (value as McpAuthType) : "bearer";
+
+const coerceRiskLevel = (value: string): McpRiskLevel =>
+	RISK_LEVELS.has(value) ? (value as McpRiskLevel) : "unknown";
+
+const coerceTransport = (value: string): McpTransport =>
+	TRANSPORTS.has(value) ? (value as McpTransport) : "streamable_http";
+
+/**
+ * Projects a registered connection onto the grantable shape. Auth is resolved
+ * defensively: a connection that carries stored secret headers is treated as
+ * authenticated even if its declared `authType` is "none", so a header-bearing
+ * server can never slip past the no-credential grant guard.
+ */
+export const userMcpConnectionToGrantableServer = (
+	connection: UserMcpConnection,
+): GrantableMcpServer => {
+	const declaredAuthType = coerceAuthType(connection.authType);
+	const carriesSecretHeaders = connection.encryptedHeaders !== "{}";
+	const authType =
+		declaredAuthType === "none" && carriesSecretHeaders ? "bearer" : declaredAuthType;
+
+	return {
+		authType,
+		description: connection.description ?? "",
+		enabledByDefaultForThinkspaces: false,
+		id: connection.id,
+		name: connection.name,
+		riskLevel: coerceRiskLevel(connection.riskLevel),
+		transport: coerceTransport(connection.transport),
+		url: connection.url,
+	};
+};
+
+/**
+ * The grantable catalog for one owner: built-in servers plus their registered
+ * connections. Built-ins come first; on an id collision the built-in wins,
+ * since a user cannot redefine a curated server.
+ */
+export const listGrantableMcpServers = async (
+	db: ProductDb,
+	userId: string,
+): Promise<GrantableMcpServer[]> => {
+	const builtIn = listBuiltInMcpServers();
+	const builtInIds = new Set(builtIn.map((server) => server.id));
+	const connections = await listCustomMcpConnections(db, userId);
+
+	return [
+		...builtIn,
+		...connections
+			.filter((connection) => !builtInIds.has(connection.id))
+			.map(userMcpConnectionToGrantableServer),
+	];
+};

--- a/packages/api/src/mcp/repository.ts
+++ b/packages/api/src/mcp/repository.ts
@@ -1,13 +1,17 @@
 import type { ProductDb } from "@better-agent/db";
-import { schema } from "@better-agent/db";
+import * as schema from "@better-agent/db/schema/index";
 import { and, eq } from "drizzle-orm";
 
+import type { McpAuthType, McpRiskLevel, McpTransport } from "./catalog";
+
 export interface CustomMcpConnectionInput {
+	authType: McpAuthType;
 	description?: string;
 	encryptedHeaders: string;
 	id: string;
 	name: string;
-	transport: "streamable_http" | "sse";
+	riskLevel: McpRiskLevel;
+	transport: McpTransport;
 	url: string;
 	userId: string;
 }
@@ -16,11 +20,13 @@ export const createCustomMcpConnection = async (db: ProductDb, input: CustomMcpC
 	const [created] = await db
 		.insert(schema.userMcpConnections)
 		.values({
+			authType: input.authType,
 			catalogVisible: true,
 			description: input.description,
 			encryptedHeaders: input.encryptedHeaders,
 			id: input.id,
 			name: input.name,
+			riskLevel: input.riskLevel,
 			transport: input.transport,
 			url: input.url,
 			userId: input.userId,
@@ -46,9 +52,11 @@ export const updateCustomMcpConnection = async (
 	const [updated] = await db
 		.update(schema.userMcpConnections)
 		.set({
+			authType: input.authType,
 			description: input.description,
 			encryptedHeaders: input.encryptedHeaders,
 			name: input.name,
+			riskLevel: input.riskLevel,
 			transport: input.transport,
 			updatedAt: new Date(),
 			url: input.url,

--- a/packages/api/src/mcp/router.ts
+++ b/packages/api/src/mcp/router.ts
@@ -13,11 +13,15 @@ import {
 import { assertSafeMcpServerUrl, McpUrlPolicyError } from "./url-policy";
 
 const transportSchema = z.enum(["streamable_http", "sse"]);
+const authTypeSchema = z.enum(["none", "bearer", "api_key_header"]);
+const riskLevelSchema = z.enum(["read_only", "unknown", "mutating"]);
 const headersSchema = z.record(z.string().min(1), z.string().min(1)).optional();
 const connectionInput = z.object({
+	authType: authTypeSchema.default("none"),
 	description: z.string().trim().max(400).optional(),
 	headers: headersSchema,
 	name: z.string().trim().min(1).max(100),
+	riskLevel: riskLevelSchema.default("unknown"),
 	transport: transportSchema.default("streamable_http"),
 	url: z.string().trim().min(1),
 });
@@ -29,6 +33,7 @@ const encryptionSecret = (env: { API_ENCRYPTION_KEY?: string; BETTER_AUTH_SECRET
 const redactHeaderNames = (headers: Record<string, string> | undefined) =>
 	Object.keys(headers ?? {}).map((name) => ({ name, value: "••••" }));
 const toConnectionOutput = (row: Awaited<ReturnType<typeof listCustomMcpConnections>>[number]) => ({
+	authType: row.authType,
 	createdAt: row.createdAt,
 	description: row.description,
 	enabledByDefaultForThinkspaces: false,
@@ -37,6 +42,7 @@ const toConnectionOutput = (row: Awaited<ReturnType<typeof listCustomMcpConnecti
 	name: row.name,
 	redactedHeaders:
 		row.encryptedHeaders === "{}" ? [] : [{ name: "stored secret headers", value: "••••" }],
+	riskLevel: row.riskLevel,
 	transport: row.transport,
 	updatedAt: row.updatedAt,
 	url: row.url,
@@ -54,10 +60,12 @@ export const mcpRouter = {
 					? await encryptCredential(JSON.stringify(input.headers), encryptionSecret(context.env))
 					: "{}";
 				const created = await createCustomMcpConnection(context.db, {
+					authType: input.authType,
 					description: input.description,
 					encryptedHeaders,
 					id: `mcp_connection_${crypto.randomUUID()}`,
 					name: input.name,
+					riskLevel: input.riskLevel,
 					transport: input.transport,
 					url: url.toString(),
 					userId: context.session.user.id,
@@ -94,10 +102,12 @@ export const mcpRouter = {
 				? await encryptCredential(JSON.stringify(input.headers), encryptionSecret(context.env))
 				: undefined;
 			const updated = await updateCustomMcpConnection(context.db, {
+				authType: input.authType,
 				description: input.description,
 				encryptedHeaders,
 				id: input.connectionId,
 				name: input.name,
+				riskLevel: input.riskLevel,
 				transport: input.transport,
 				url: input.url ? assertSafeMcpServerUrl(input.url).toString() : undefined,
 				userId: context.session.user.id,

--- a/packages/api/src/thinkspaces/approvals.test.ts
+++ b/packages/api/src/thinkspaces/approvals.test.ts
@@ -8,8 +8,10 @@ import {
 	flipApprovalInTranscript,
 	MEMORY_WRITE_TOOL_PART_TYPE,
 	parseProposedGitHubIssue,
+	parseProposedMcpToolCall,
 	readProposedGitHubIssue,
 	summarizeGitHubIssueProposal,
+	summarizeMcpToolCall,
 	summarizeMemoryProposal,
 } from "./approvals";
 
@@ -32,6 +34,15 @@ const githubPart = (overrides: Record<string, unknown> = {}) => ({
 	state: "approval-requested",
 	toolCallId: "tool_call_gh",
 	type: CREATE_GITHUB_ISSUE_TOOL_PART_TYPE,
+	...overrides,
+});
+
+const mcpToolPart = (overrides: Record<string, unknown> = {}) => ({
+	approval: { id: "approval_req_mcp" },
+	input: { repo: "octocat/hello-world", title: "Ship it" },
+	state: "approval-requested",
+	toolCallId: "tool_call_mcp",
+	type: "tool-tool_mutatingdocs_open_pr",
 	...overrides,
 });
 
@@ -68,6 +79,53 @@ test("a parked GitHub-issue proposal is extracted with a serialized payload and 
 		body: "Steps to reproduce the flake.",
 		repo: "octocat/hello-world",
 		title: "Fix the flaky test",
+	});
+});
+
+test("a parked MCP tool call is extracted with a dynamic part type and its args preserved", () => {
+	const [pending, ...rest] = extractPendingApprovals([
+		assistant([{ text: "Opening a PR.", type: "text" }, mcpToolPart()]),
+	]);
+
+	assert.equal(rest.length, 0);
+	assert.ok(pending);
+	assert.equal(pending.actionKind, "mcp_tool_call");
+	assert.equal(pending.approvalRequestId, "approval_req_mcp");
+	assert.equal(pending.toolCallId, "tool_call_mcp");
+	assert.equal(pending.proposedSummary, 'Call the external tool "mutatingdocs_open_pr"');
+	assert.deepEqual(parseProposedMcpToolCall(pending.proposedContent), {
+		args: { repo: "octocat/hello-world", title: "Ship it" },
+		runtimeToolName: "tool_mutatingdocs_open_pr",
+	});
+});
+
+test("a held MCP tool call flips and reads back like any other hold", () => {
+	const messages = [assistant([mcpToolPart()])];
+	const flip = flipApprovalInTranscript({
+		decision: "approved",
+		messages,
+		toolCallId: "tool_call_mcp",
+	});
+
+	assert.equal(flip.flipped, true);
+	const resolved = extractResolvedApprovals(flip.messages);
+	assert.deepEqual(resolved, [{ status: "approved", toolCallId: "tool_call_mcp" }]);
+});
+
+test("an MCP tool-call summary strips the runtime prefix and bounds length", () => {
+	assert.equal(summarizeMcpToolCall("tool_server_do_thing"), 'Call the external tool "server_do_thing"');
+
+	const long = summarizeMcpToolCall(`tool_${"x".repeat(500)}`);
+	assert.ok(long.length < 500);
+	assert.match(long, /…"$/u);
+});
+
+test("a malformed MCP tool-call payload parses back to null", () => {
+	assert.equal(parseProposedMcpToolCall("not json"), null);
+	assert.equal(parseProposedMcpToolCall(JSON.stringify({ args: {} })), null);
+	assert.deepEqual(parseProposedMcpToolCall(JSON.stringify({ runtimeToolName: "tool_x" })), {
+		args: {},
+		runtimeToolName: "tool_x",
 	});
 });
 

--- a/packages/api/src/thinkspaces/approvals.ts
+++ b/packages/api/src/thinkspaces/approvals.ts
@@ -29,6 +29,18 @@ export const MEMORY_WRITE_TOOL_PART_TYPE = "tool-memory_write" as const;
 /** The runtime tool-part type the held GitHub-issue-proposing tool produces. */
 export const CREATE_GITHUB_ISSUE_TOOL_PART_TYPE = "tool-create_github_issue" as const;
 
+/**
+ * The transcript part-type prefix every held MCP tool call shares. An MCP tool's
+ * runtime name is `tool_<server>_<tool>` (see `mcp/tool-identity.ts`), so its UI
+ * message part type is `tool-tool_<server>_<tool>`. Unlike the fixed Memory and
+ * GitHub part types, MCP tool calls are dynamic, so their descriptor matches by
+ * this prefix rather than an exact string. No built-in or connected-account tool
+ * name begins with `tool_`, so the prefix is unambiguous.
+ */
+export const MCP_TOOL_PART_TYPE_PREFIX = "tool-tool_" as const;
+
+export const MCP_TOOL_CALL_SUMMARY_NAME_MAX_LENGTH = 120;
+
 const APPROVAL_REQUESTED_STATE = "approval-requested";
 const APPROVAL_RESPONDED_STATE = "approval-responded";
 const OUTPUT_AVAILABLE_STATE = "output-available";
@@ -141,21 +153,103 @@ export const summarizeGitHubIssueProposal = ({
 	)}" in ${collapseWhitespace(repo)}`;
 
 /**
- * One held action kind's transcript shape: which tool-part type it produces and
- * how to turn a parked part's `input` into the durable `proposed_content` (the
- * serialized payload) plus a human `proposed_summary`. `describeProposal`
- * returns null for a malformed input so the hold is skipped and never surfaces
- * as a decidable Approval.
+ * A held call to a tool on a mutating-risk MCP server, the payload the
+ * `needsApproval` wrapper parks. `runtimeToolName` is the server-qualified tool
+ * name as the runtime named it (`tool_<server>_<tool>`); `args` is the model's
+ * proposed input, preserved verbatim so the owner sees exactly what would run.
+ */
+export interface ProposedMcpToolCall {
+	args: Record<string, unknown>;
+	runtimeToolName: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * The bare tool label shown to the owner: the runtime name with its leading
+ * `tool_` runtime prefix removed. Lossy by design (the server id and tool name
+ * are joined with no reliable separator), so it is a display hint only; the args
+ * carry the decidable detail. A richer server/tool split is a later refinement.
+ */
+const mcpToolDisplayName = (runtimeToolName: string): string =>
+	runtimeToolName.replace(/^tool_/u, "");
+
+/** A short product-language summary of a held MCP tool call for the Review Queue. */
+export const summarizeMcpToolCall = (runtimeToolName: string): string =>
+	`Call the external tool "${bound(
+		mcpToolDisplayName(runtimeToolName),
+		MCP_TOOL_CALL_SUMMARY_NAME_MAX_LENGTH,
+	)}"`;
+
+/**
+ * Pulls a proposed MCP tool call out of a held part's type (for the tool name)
+ * and input (for the args). Null when the part type is not a held MCP tool part,
+ * so the hold stays held rather than surfacing a card with no tool to name.
+ */
+export const readProposedMcpToolCall = (
+	partType: string,
+	input: unknown,
+): ProposedMcpToolCall | null => {
+	if (!partType.startsWith(MCP_TOOL_PART_TYPE_PREFIX)) {
+		return null;
+	}
+
+	const runtimeToolName = partType.slice("tool-".length);
+
+	if (!runtimeToolName) {
+		return null;
+	}
+
+	return { args: isRecord(input) ? input : {}, runtimeToolName };
+};
+
+const serializeProposedMcpToolCall = (proposal: ProposedMcpToolCall): string =>
+	JSON.stringify({ args: proposal.args, runtimeToolName: proposal.runtimeToolName });
+
+/**
+ * Parses a serialized `proposed_content` MCP tool-call payload back into its
+ * fields for the Review Queue. Null when the stored content is not a well-formed
+ * payload, so a malformed row renders nothing rather than throwing.
+ */
+export const parseProposedMcpToolCall = (proposedContent: string): ProposedMcpToolCall | null => {
+	try {
+		const parsed = JSON.parse(proposedContent) as unknown;
+
+		if (!isRecord(parsed) || typeof parsed.runtimeToolName !== "string") {
+			return null;
+		}
+
+		return {
+			args: isRecord(parsed.args) ? parsed.args : {},
+			runtimeToolName: parsed.runtimeToolName,
+		};
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * One held action kind's transcript shape: whether it owns a given tool-part
+ * type and how to turn a parked part's type + `input` into the durable
+ * `proposed_content` (the serialized payload) plus a human `proposed_summary`.
+ * `matches` is a predicate rather than a fixed string so dynamic part types
+ * (MCP tool calls, whose names are server-qualified) can be recognized.
+ * `describeProposal` returns null for a malformed part so the hold is skipped
+ * and never surfaces as a decidable Approval.
  */
 interface ApprovalActionDescriptor {
 	actionKind: ThinkspaceApprovalActionKind;
-	describeProposal: (input: unknown) => { proposedContent: string; proposedSummary: string } | null;
-	partType: string;
+	describeProposal: (
+		partType: string,
+		input: unknown,
+	) => { proposedContent: string; proposedSummary: string } | null;
+	matches: (partType: string) => boolean;
 }
 
 const memoryWriteDescriptor: ApprovalActionDescriptor = {
 	actionKind: THINKSPACE_APPROVAL_ACTION_KIND.MEMORY_WRITE,
-	describeProposal: (input) => {
+	describeProposal: (_partType, input) => {
 		const content = readMemoryContent(input);
 
 		if (!content) {
@@ -164,12 +258,12 @@ const memoryWriteDescriptor: ApprovalActionDescriptor = {
 
 		return { proposedContent: content, proposedSummary: summarizeMemoryProposal(content) };
 	},
-	partType: MEMORY_WRITE_TOOL_PART_TYPE,
+	matches: (partType) => partType === MEMORY_WRITE_TOOL_PART_TYPE,
 };
 
 const githubCreateIssueDescriptor: ApprovalActionDescriptor = {
 	actionKind: THINKSPACE_APPROVAL_ACTION_KIND.GITHUB_CREATE_ISSUE,
-	describeProposal: (input) => {
+	describeProposal: (_partType, input) => {
 		const proposal = readProposedGitHubIssue(input);
 
 		if (!proposal) {
@@ -181,20 +275,36 @@ const githubCreateIssueDescriptor: ApprovalActionDescriptor = {
 			proposedSummary: summarizeGitHubIssueProposal(proposal),
 		};
 	},
-	partType: CREATE_GITHUB_ISSUE_TOOL_PART_TYPE,
+	matches: (partType) => partType === CREATE_GITHUB_ISSUE_TOOL_PART_TYPE,
+};
+
+const mcpToolCallDescriptor: ApprovalActionDescriptor = {
+	actionKind: THINKSPACE_APPROVAL_ACTION_KIND.MCP_TOOL_CALL,
+	describeProposal: (partType, input) => {
+		const proposal = readProposedMcpToolCall(partType, input);
+
+		if (!proposal) {
+			return null;
+		}
+
+		return {
+			proposedContent: serializeProposedMcpToolCall(proposal),
+			proposedSummary: summarizeMcpToolCall(proposal.runtimeToolName),
+		};
+	},
+	matches: (partType) => partType.startsWith(MCP_TOOL_PART_TYPE_PREFIX),
 };
 
 const APPROVAL_ACTION_DESCRIPTORS: readonly ApprovalActionDescriptor[] = [
 	memoryWriteDescriptor,
 	githubCreateIssueDescriptor,
+	mcpToolCallDescriptor,
 ];
 
-const descriptorByPartType = new Map<string, ApprovalActionDescriptor>(
-	APPROVAL_ACTION_DESCRIPTORS.map((descriptor) => [descriptor.partType, descriptor]),
-);
-
 const descriptorForPart = (part: TranscriptToolPart): ApprovalActionDescriptor | undefined =>
-	typeof part.type === "string" ? descriptorByPartType.get(part.type) : undefined;
+	typeof part.type === "string"
+		? APPROVAL_ACTION_DESCRIPTORS.find((descriptor) => descriptor.matches(part.type as string))
+		: undefined;
 
 /** A held proposal awaiting the owner's decision, of any registered action kind. */
 export interface PendingApproval {
@@ -237,7 +347,7 @@ export const extractPendingApprovals = (
 
 			const toolCallId = toNonEmptyString(part.toolCallId);
 			const approvalRequestId = toNonEmptyString(part.approval?.id);
-			const proposal = descriptor.describeProposal(part.input);
+			const proposal = descriptor.describeProposal(part.type as string, part.input);
 
 			if (!(toolCallId && approvalRequestId && proposal)) {
 				continue;

--- a/packages/api/src/thinkspaces/mcp-runtime-tools.test.ts
+++ b/packages/api/src/thinkspaces/mcp-runtime-tools.test.ts
@@ -135,7 +135,7 @@ test("Cloudflare Agents MCP tool identity maps product server ids to runtime too
 	assert.equal(parseCloudflareAgentsMcpToolName("web_search", ["cloudflare-docs"]), null);
 });
 
-test("turn MCP runtime planning connects only potent grantable built-in servers", () => {
+test("turn MCP runtime planning connects potent auth-free servers of any risk, never authed ones", () => {
 	const revision = createRevision([
 		{ source: "mcp_server", toolId: "cloudflare-docs" },
 		{ source: "mcp_server", toolId: "aws-knowledge:search" },
@@ -150,11 +150,51 @@ test("turn MCP runtime planning connects only potent grantable built-in servers"
 		revision,
 	});
 
+	// The auth-free read-only and mutating servers both connect (the mutating
+	// one's tools are held); the api-key server stays out (auth deferred to the
+	// credential seam).
 	assert.deepEqual(
 		plan.servers.map((server) => server.id),
-		["cloudflare-docs"],
+		["cloudflare-docs", "mutating-docs"],
 	);
-	assert.deepEqual(plan.activeProductToolIds, ["cloudflare-docs"]);
+	assert.deepEqual(plan.activeProductToolIds, ["cloudflare-docs", "mutating-docs"]);
+});
+
+test("preparation holds every tool from a mutating server for Approval, leaving read-only tools inline", async () => {
+	const prepared = await prepareThinkspaceMcpRuntimeTools({
+		activeProductToolIds: ["cloudflare-docs", "mutating-docs"],
+		connectServer: ({ server }) =>
+			Promise.resolve(
+				server.id === "mutating-docs"
+					? toolSet(["tool_mutatingdocs_open_pr"])
+					: toolSet(["tool_cloudflaredocs_search_docs"]),
+			),
+		servers: [CLOUD_FLARE_DOCS, MUTATING_SERVER],
+	});
+
+	assert.equal(
+		(prepared.tools.tool_mutatingdocs_open_pr as { needsApproval?: boolean }).needsApproval,
+		true,
+	);
+	assert.equal(
+		(prepared.tools.tool_cloudflaredocs_search_docs as { needsApproval?: boolean }).needsApproval,
+		undefined,
+	);
+});
+
+test("before-tool-call authorization allows a potent mutating-server tool (held, not blocked)", async () => {
+	const revision = createRevision([{ source: "mcp_server", toolId: "mutating-docs" }]);
+	const decision = await evaluateMcpRuntimeToolCallPermission({
+		builtInMcpServers: [MUTATING_SERVER],
+		permissionPolicy: createMemoryPermissionPolicy({ "mutating-docs": "potent" }),
+		revision,
+		runtimeToolName: "tool_mutatingdocs_open_pr",
+		thinkspaceId: revision.thinkspaceId,
+	});
+
+	assert.equal(decision.applies, true);
+	assert.equal(decision.allowed, true);
+	assert.equal(decision.productToolId, "mutating-docs:open_pr");
 });
 
 test("inert MCP enablements produce no connection attempts and no active runtime tool", async () => {

--- a/packages/api/src/thinkspaces/mcp-runtime-tools.ts
+++ b/packages/api/src/thinkspaces/mcp-runtime-tools.ts
@@ -1,4 +1,4 @@
-import type { ToolSet } from "ai";
+import type { Tool, ToolSet } from "ai";
 
 import type { BuiltInMcpServer } from "../mcp/catalog";
 import { listBuiltInMcpServers } from "../mcp/catalog";
@@ -45,8 +45,39 @@ export type ConnectThinkspaceMcpRuntimeServer = (input: {
 
 const unique = <T>(values: T[]): T[] => [...new Set(values)];
 
-export const isGrantableBuiltInMcpServer = (server: BuiltInMcpServer): boolean =>
-	server.authType === "none" && server.riskLevel === "read_only";
+/**
+ * Whether a granted MCP server can be connected for a turn at all. Auth-free
+ * servers connect regardless of risk: a read-only server's tools run inline, a
+ * mutating-risk server's tools are held for the owner's Approval (see
+ * `requiresMcpApprovalHold`). Authenticated servers stay non-connectable until
+ * the credential seam (ADR-0009) lands.
+ */
+export const isConnectableMcpServer = (server: BuiltInMcpServer): boolean =>
+	server.authType === "none";
+
+/**
+ * Whether every tool on this server must be held for the owner's Approval
+ * before it runs. A server that does not clearly declare itself read-only is
+ * treated as mutating and held — the conservative default that keeps external
+ * mutations behind the draft-or-approval holdpoint (ADR-0003).
+ */
+export const requiresMcpApprovalHold = (server: BuiltInMcpServer): boolean =>
+	server.riskLevel !== "read_only";
+
+/**
+ * Marks every tool in a server's toolset as held for Approval: Project Think's
+ * `needsApproval` parks the call in the transcript instead of executing it, so
+ * a mutating MCP tool reaches the Review Queue exactly like the held
+ * Memory-write and GitHub-issue tools. A constant `true` keeps the hold
+ * unambiguous (fail closed).
+ */
+const holdToolSetForApproval = (toolSet: ToolSet): ToolSet =>
+	Object.fromEntries(
+		Object.entries(toolSet).map(([name, definition]) => [
+			name,
+			{ ...definition, needsApproval: true } as Tool,
+		]),
+	);
 
 const mcpEnablementToolIds = (revision: ActiveAgentProfileRevision): Set<string> =>
 	new Set(
@@ -76,7 +107,7 @@ export const planThinkspaceMcpRuntimeTools = ({
 	const servers = activeServerIds
 		.map((serverId) => findBuiltInMcpServer(serverId, builtInMcpServers))
 		.filter((server): server is BuiltInMcpServer =>
-			Boolean(server && isGrantableBuiltInMcpServer(server)),
+			Boolean(server && isConnectableMcpServer(server)),
 		);
 	const serverIds = new Set(servers.map((server) => server.id));
 
@@ -131,7 +162,12 @@ export const prepareThinkspaceMcpRuntimeTools = async ({
 
 	for (const server of servers) {
 		try {
-			Object.assign(tools, await connectServer({ server }));
+			const serverTools = await connectServer({ server });
+
+			Object.assign(
+				tools,
+				requiresMcpApprovalHold(server) ? holdToolSetForApproval(serverTools) : serverTools,
+			);
 			connectedServerIds.push(server.id);
 		} catch {
 			degradedServers.push({ serverId: server.id, serverName: server.name });
@@ -214,7 +250,7 @@ export const evaluateMcpRuntimeToolCallPermission = async ({
 		identity.toolName,
 	);
 
-	if (!(server && isGrantableBuiltInMcpServer(server) && enablements.length > 0)) {
+	if (!(server && isConnectableMcpServer(server) && enablements.length > 0)) {
 		return {
 			allowed: false,
 			applies: true,

--- a/packages/api/src/thinkspaces/permissions.test.ts
+++ b/packages/api/src/thinkspaces/permissions.test.ts
@@ -110,7 +110,7 @@ test("connected-account credential requests convert into a credential grant keye
 
 test("grantable MCP requests convert into MCP tool access grants with explicit scope", () => {
 	const grant = toThinkspacePermissionGrant(grantInput(), {
-		builtInMcpServers: [readOnlyAuthFreeServer],
+		grantableMcpServers: [readOnlyAuthFreeServer],
 	});
 
 	assert.equal(grant?.kind, THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS);
@@ -118,48 +118,61 @@ test("grantable MCP requests convert into MCP tool access grants with explicit s
 	assert.equal(grant?.resourceScope, JSON.stringify({ type: "server" }));
 });
 
-test("MCP grants reject servers outside the built-in catalog", () => {
+test("MCP grants reject servers outside the grantable catalog", () => {
 	assert.throws(
-		() => toThinkspacePermissionGrant(grantInput(), { builtInMcpServers: [] }),
+		() => toThinkspacePermissionGrant(grantInput(), { grantableMcpServers: [] }),
 		ThinkspacePermissionGrantError,
 	);
 });
 
-test("MCP grants reject servers requiring auth, non-read-only requests, and unsafe URLs", () => {
+test("MCP grants accept a registered server resolved into the grantable catalog", () => {
+	const registeredServer: BuiltInMcpServer = {
+		...readOnlyAuthFreeServer,
+		id: "mcp_connection_registered",
+		name: "My Registered Docs",
+	};
+	const grant = toThinkspacePermissionGrant(
+		grantInput(mcpRequest({ serverId: "mcp_connection_registered" })),
+		{ grantableMcpServers: [registeredServer] },
+	);
+
+	assert.equal(grant?.kind, THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS);
+	assert.equal(grant?.providerId, "mcp_connection_registered");
+});
+
+test("MCP grants reject servers requiring auth and unsafe URLs", () => {
 	assert.throws(
 		() =>
 			toThinkspacePermissionGrant(grantInput(), {
-				builtInMcpServers: [{ ...readOnlyAuthFreeServer, authType: "api_key_header" }],
-			}),
-		ThinkspacePermissionGrantError,
-	);
-	assert.throws(
-		() =>
-			toThinkspacePermissionGrant(grantInput(mcpRequest({ risk: "mutating" })), {
-				builtInMcpServers: [readOnlyAuthFreeServer],
+				grantableMcpServers: [{ ...readOnlyAuthFreeServer, authType: "api_key_header" }],
 			}),
 		ThinkspacePermissionGrantError,
 	);
 	assert.throws(
 		() =>
 			toThinkspacePermissionGrant(grantInput(), {
-				builtInMcpServers: [{ ...readOnlyAuthFreeServer, riskLevel: "mutating" }],
+				grantableMcpServers: [{ ...readOnlyAuthFreeServer, url: "http://127.0.0.1/mcp" }],
 			}),
 		ThinkspacePermissionGrantError,
 	);
-	assert.throws(
-		() =>
-			toThinkspacePermissionGrant(grantInput(), {
-				builtInMcpServers: [{ ...readOnlyAuthFreeServer, url: "http://127.0.0.1/mcp" }],
-			}),
-		ThinkspacePermissionGrantError,
-	);
+});
+
+test("MCP grants accept mutating and unknown-risk servers (held for Approval at runtime)", () => {
+	const mutatingGrant = toThinkspacePermissionGrant(grantInput(mcpRequest({ risk: "mutating" })), {
+		grantableMcpServers: [{ ...readOnlyAuthFreeServer, riskLevel: "mutating" }],
+	});
+	const unknownGrant = toThinkspacePermissionGrant(grantInput(mcpRequest({ risk: "unknown" })), {
+		grantableMcpServers: [{ ...readOnlyAuthFreeServer, riskLevel: "unknown" }],
+	});
+
+	assert.equal(mutatingGrant?.kind, THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS);
+	assert.equal(unknownGrant?.kind, THINKSPACE_PERMISSION_KINDS.MCP_TOOL_ACCESS);
 });
 
 test("MCP grants keep per-Thinkspace uniqueness by kind and server id", async () => {
 	const db = await createSeededDb();
 	const firstGrant = prepareThinkspacePermissionGrants([grantInput()], {
-		builtInMcpServers: [readOnlyAuthFreeServer],
+		grantableMcpServers: [readOnlyAuthFreeServer],
 	});
 	await saveThinkspacePermissionGrants(db, firstGrant);
 
@@ -172,7 +185,7 @@ test("MCP grants keep per-Thinkspace uniqueness by kind and server id", async ()
 				}),
 			),
 		],
-		{ builtInMcpServers: [readOnlyAuthFreeServer] },
+		{ grantableMcpServers: [readOnlyAuthFreeServer] },
 	);
 	const saved = await saveThinkspacePermissionGrants(db, replacementGrant);
 
@@ -187,7 +200,7 @@ test("revoking a Thinkspace Permission deletes only the matching grant row", asy
 	const [grant] = await saveThinkspacePermissionGrants(
 		db,
 		prepareThinkspacePermissionGrants([grantInput()], {
-			builtInMcpServers: [readOnlyAuthFreeServer],
+			grantableMcpServers: [readOnlyAuthFreeServer],
 		}),
 	);
 	assert.ok(grant);

--- a/packages/api/src/thinkspaces/permissions.ts
+++ b/packages/api/src/thinkspaces/permissions.ts
@@ -12,7 +12,7 @@ import { and, eq } from "drizzle-orm";
 import { MODEL_PROVIDER_IDS } from "../models/catalog";
 import type { ModelProviderId } from "../models/catalog";
 import { listBuiltInMcpServers } from "../mcp/catalog";
-import type { BuiltInMcpServer } from "../mcp/catalog";
+import type { GrantableMcpServer } from "../mcp/grantable-servers";
 import { assertSafeMcpServerUrl } from "../mcp/url-policy";
 import type {
 	BuiltInToolAccessPermissionRequest,
@@ -28,7 +28,13 @@ export interface GrantThinkspacePermissionInput {
 
 export interface ThinkspacePermissionGrantOptions {
 	allowInsecureDevUrls?: boolean;
-	builtInMcpServers?: BuiltInMcpServer[];
+	/**
+	 * The MCP servers this owner may be granted: built-in catalog entries plus
+	 * their registered connections (see `mcp/grantable-servers.ts`). Defaults to
+	 * the built-in catalog alone when a caller does not resolve the owner's
+	 * registry.
+	 */
+	grantableMcpServers?: GrantableMcpServer[];
 }
 
 export interface RevokeThinkspacePermissionInput {
@@ -84,11 +90,11 @@ const isModelProviderId = (value: string): value is ModelProviderId =>
 
 const createPermissionId = (): string => `thinkspace_permission_${crypto.randomUUID()}`;
 
-const findBuiltInMcpServer = (
+const findGrantableMcpServer = (
 	serverId: string,
 	options: ThinkspacePermissionGrantOptions,
-): BuiltInMcpServer | null => {
-	const catalog = options.builtInMcpServers ?? listBuiltInMcpServers();
+): GrantableMcpServer | null => {
+	const catalog = options.grantableMcpServers ?? listBuiltInMcpServers();
 
 	return catalog.find((server) => server.id === serverId) ?? null;
 };
@@ -96,12 +102,12 @@ const findBuiltInMcpServer = (
 const assertGrantableMcpToolAccess = (
 	permission: McpToolAccessPermissionRequest,
 	options: ThinkspacePermissionGrantOptions,
-): BuiltInMcpServer => {
-	const server = findBuiltInMcpServer(permission.serverId, options);
+): GrantableMcpServer => {
+	const server = findGrantableMcpServer(permission.serverId, options);
 
 	if (!server) {
 		throw new ThinkspacePermissionGrantError(
-			"Only built-in MCP servers can be granted to a Thinkspace in this slice.",
+			"That MCP server is not a built-in or one you have registered, so it cannot be granted to a Thinkspace.",
 		);
 	}
 
@@ -111,11 +117,10 @@ const assertGrantableMcpToolAccess = (
 		);
 	}
 
-	if (server.riskLevel !== "read_only" || permission.risk !== "read_only") {
-		throw new ThinkspacePermissionGrantError(
-			"Only read-only MCP tool access is grantable in this slice.",
-		);
-	}
+	// Mutating and unknown-risk MCP access is grantable: a non-read-only server's
+	// tool calls are held for the owner's Approval at runtime rather than executed
+	// on the grant alone (ADR-0003), so the grant records the capability and the
+	// holdpoint enforces consent.
 
 	try {
 		assertSafeMcpServerUrl(server.url, options.allowInsecureDevUrls ?? false);

--- a/packages/api/src/thinkspaces/router.test.ts
+++ b/packages/api/src/thinkspaces/router.test.ts
@@ -105,7 +105,13 @@ const createDbForAgentProfileActivation = (row: Record<string, unknown>) => {
 		batch: (statements: unknown[]) => Promise.resolve(statements.map(() => [])),
 		select: () => ({
 			from: () => ({
-				where: () => ({ limit: () => Promise.resolve([row]) }),
+				// `.where()` is awaited directly by list reads (e.g. the owner's MCP
+				// connections, none here) and chained with `.limit()` by single-row
+				// reads, so it resolves empty on its own but yields the row when limited.
+				where: () =>
+					Object.assign(Promise.resolve([] as Record<string, unknown>[]), {
+						limit: () => Promise.resolve([row]),
+					}),
 			}),
 		}),
 		update: () => ({

--- a/packages/api/src/thinkspaces/router.ts
+++ b/packages/api/src/thinkspaces/router.ts
@@ -9,6 +9,7 @@ import {
 	getUserProductModelSettings,
 	ThinkspaceTurnModelUnavailableError,
 } from "../models/readiness";
+import { listGrantableMcpServers } from "../mcp/grantable-servers";
 import { protectedProcedure } from "../procedures";
 import {
 	AgentProfileValidationError,
@@ -256,7 +257,12 @@ export const thinkspacesRouter = {
 					permission,
 					thinkspaceId: thinkspace.id,
 				}));
-				const permissionGrants = prepareThinkspacePermissionGrants(grantInputs);
+				const permissionGrants = prepareThinkspacePermissionGrants(grantInputs, {
+					grantableMcpServers: await listGrantableMcpServers(
+						context.db,
+						context.session.user.id,
+					),
+				});
 
 				await applyAgentProfileActivation(context.db, { activation });
 				const grantedPermissions = await saveThinkspacePermissionGrants(

--- a/packages/db/src/migrations/0012_worried_roxanne_simpson.sql
+++ b/packages/db/src/migrations/0012_worried_roxanne_simpson.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `user_mcp_connections` ADD `auth_type` text DEFAULT 'none' NOT NULL;--> statement-breakpoint
+ALTER TABLE `user_mcp_connections` ADD `risk_level` text DEFAULT 'unknown' NOT NULL;

--- a/packages/db/src/migrations/meta/0012_snapshot.json
+++ b/packages/db/src/migrations/meta/0012_snapshot.json
@@ -1,0 +1,1768 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b61093d8-d1e2-44d8-bda6-d647d6ae6705",
+  "prevId": "77e1a365-3736-4992-bb7d-0f44c063e985",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_account_provider_account": {
+          "name": "idx_account_provider_account",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connected_account_catalog": {
+      "name": "connected_account_catalog",
+      "columns": {
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_server_catalog": {
+      "name": "mcp_server_catalog",
+      "columns": {
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'streamable_http'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_agent_profiles": {
+      "name": "thinkspace_agent_profiles",
+      "columns": {
+        "activated_at": {
+          "name": "activated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_permissions": {
+          "name": "requested_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "routines": {
+          "name": "routines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "skill_references": {
+          "name": "skill_references",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_enablements": {
+          "name": "tool_enablements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_agent_profiles_thinkspace_version": {
+          "name": "uq_agent_profiles_thinkspace_version",
+          "columns": [
+            "thinkspace_id",
+            "version"
+          ],
+          "isUnique": true
+        },
+        "uq_agent_profiles_thinkspace_active": {
+          "name": "uq_agent_profiles_thinkspace_active",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'active'"
+        },
+        "uq_agent_profiles_thinkspace_draft": {
+          "name": "uq_agent_profiles_thinkspace_draft",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'draft'"
+        },
+        "idx_agent_profiles_thinkspace_status": {
+          "name": "idx_agent_profiles_thinkspace_status",
+          "columns": [
+            "thinkspace_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_agent_profiles_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_agent_profiles_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_agent_profiles",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_approvals": {
+      "name": "thinkspace_approvals",
+      "columns": {
+        "action_kind": {
+          "name": "action_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_request_id": {
+          "name": "approval_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_revision_id": {
+          "name": "profile_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_version": {
+          "name": "profile_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposed_content": {
+          "name": "proposed_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposed_summary": {
+          "name": "proposed_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_thinkspace_approvals_owner_status_created": {
+          "name": "idx_thinkspace_approvals_owner_status_created",
+          "columns": [
+            "owner_user_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_thinkspace_approvals_thinkspace_status": {
+          "name": "idx_thinkspace_approvals_thinkspace_status",
+          "columns": [
+            "thinkspace_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "uq_thinkspace_approvals_thinkspace_tool_call": {
+          "name": "uq_thinkspace_approvals_thinkspace_tool_call",
+          "columns": [
+            "thinkspace_id",
+            "tool_call_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_approvals_owner_user_id_user_id_fk": {
+          "name": "thinkspace_approvals_owner_user_id_user_id_fk",
+          "tableFrom": "thinkspace_approvals",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thinkspace_approvals_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_approvals_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_approvals",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_memories": {
+      "name": "thinkspace_memories",
+      "columns": {
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_revision_id": {
+          "name": "profile_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_version": {
+          "name": "profile_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_thinkspace_memories_thinkspace_created": {
+          "name": "idx_thinkspace_memories_thinkspace_created",
+          "columns": [
+            "thinkspace_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "uq_thinkspace_memories_thinkspace_tool_call": {
+          "name": "uq_thinkspace_memories_thinkspace_tool_call",
+          "columns": [
+            "thinkspace_id",
+            "tool_call_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_memories_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_memories_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_memories",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_permissions": {
+      "name": "thinkspace_permissions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "resource_scope": {
+          "name": "resource_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_thinkspace_permissions_thinkspace": {
+          "name": "idx_thinkspace_permissions_thinkspace",
+          "columns": [
+            "thinkspace_id"
+          ],
+          "isUnique": false
+        },
+        "uidx_thinkspace_permissions_model_provider": {
+          "name": "uidx_thinkspace_permissions_model_provider",
+          "columns": [
+            "thinkspace_id",
+            "kind",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_permissions_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_permissions_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_permissions",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspace_sources": {
+      "name": "thinkspace_sources",
+      "columns": {
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thinkspace_id": {
+          "name": "thinkspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_thinkspace_sources_thinkspace_created": {
+          "name": "idx_thinkspace_sources_thinkspace_created",
+          "columns": [
+            "thinkspace_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thinkspace_sources_thinkspace_id_thinkspaces_id_fk": {
+          "name": "thinkspace_sources_thinkspace_id_thinkspaces_id_fk",
+          "tableFrom": "thinkspace_sources",
+          "tableTo": "thinkspaces",
+          "columnsFrom": [
+            "thinkspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thinkspaces": {
+      "name": "thinkspaces",
+      "columns": {
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration_summary": {
+          "name": "configuration_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memory_governance": {
+          "name": "memory_governance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_thinkspaces_owner_status_updated": {
+          "name": "idx_thinkspaces_owner_status_updated",
+          "columns": [
+            "owner_user_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "idx_thinkspaces_owner_created": {
+          "name": "idx_thinkspaces_owner_created",
+          "columns": [
+            "owner_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_thinkspaces_owner_archived": {
+          "name": "idx_thinkspaces_owner_archived",
+          "columns": [
+            "owner_user_id",
+            "archived_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thinkspaces_owner_user_id_user_id_fk": {
+          "name": "thinkspaces_owner_user_id_user_id_fk",
+          "tableFrom": "thinkspaces",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_connected_accounts": {
+      "name": "user_connected_accounts",
+      "columns": {
+        "catalog_id": {
+          "name": "catalog_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pat'"
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_connected_accounts_user": {
+          "name": "idx_user_connected_accounts_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_connected_accounts_catalog": {
+          "name": "idx_user_connected_accounts_catalog",
+          "columns": [
+            "catalog_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_connected_accounts_user_catalog": {
+          "name": "idx_user_connected_accounts_user_catalog",
+          "columns": [
+            "user_id",
+            "catalog_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_connected_accounts_catalog_id_connected_account_catalog_id_fk": {
+          "name": "user_connected_accounts_catalog_id_connected_account_catalog_id_fk",
+          "tableFrom": "user_connected_accounts",
+          "tableTo": "connected_account_catalog",
+          "columnsFrom": [
+            "catalog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_connected_accounts_user_id_user_id_fk": {
+          "name": "user_connected_accounts_user_id_user_id_fk",
+          "tableFrom": "user_connected_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_mcp_connections": {
+      "name": "user_mcp_connections",
+      "columns": {
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "catalog_visible": {
+          "name": "catalog_visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_headers": {
+          "name": "encrypted_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'streamable_http'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_mcp_connections_user": {
+          "name": "idx_user_mcp_connections_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_mcp_connections_server": {
+          "name": "idx_user_mcp_connections_server",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_mcp_connections_server_id_mcp_server_catalog_id_fk": {
+          "name": "user_mcp_connections_server_id_mcp_server_catalog_id_fk",
+          "tableFrom": "user_mcp_connections",
+          "tableTo": "mcp_server_catalog",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_mcp_connections_user_id_user_id_fk": {
+          "name": "user_mcp_connections_user_id_user_id_fk",
+          "tableFrom": "user_mcp_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_product_settings": {
+      "name": "user_product_settings",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "curator_model": {
+          "name": "curator_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_product_settings_user_id_user_id_fk": {
+          "name": "user_product_settings_user_id_user_id_fk",
+          "tableFrom": "user_product_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_provider_credentials": {
+      "name": "user_provider_credentials",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_provider_credentials_user": {
+          "name": "idx_user_provider_credentials_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_provider_credentials_user_provider": {
+          "name": "idx_user_provider_credentials_user_provider",
+          "columns": [
+            "user_id",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_provider_credentials_user_id_user_id_fk": {
+          "name": "user_provider_credentials_user_id_user_id_fk",
+          "tableFrom": "user_provider_credentials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        },
+        "idx_verification_expires_at": {
+          "name": "idx_verification_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1781980580055,
       "tag": "0011_fat_matthew_murdock",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1782193349014,
+      "tag": "0012_worried_roxanne_simpson",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/approvals.ts
+++ b/packages/db/src/schema/approvals.ts
@@ -23,11 +23,13 @@ export type ThinkspaceApprovalStatus =
 /**
  * The class of action a pending Approval holds. The first held action was the
  * agent proposing a durable Product Memory; `github_create_issue` is the first
- * held *external* mutation (PRD #108). Both reuse `proposed_content` /
+ * held *external* mutation (PRD #108); `mcp_tool_call` is a held call to a tool
+ * on a mutating-risk MCP server (ADR-0003). All reuse `proposed_content` /
  * `proposed_summary`, so adding a kind needs no migration.
  */
 export const THINKSPACE_APPROVAL_ACTION_KIND = {
 	GITHUB_CREATE_ISSUE: "github_create_issue",
+	MCP_TOOL_CALL: "mcp_tool_call",
 	MEMORY_WRITE: "memory_write",
 } as const;
 

--- a/packages/db/src/schema/settings.ts
+++ b/packages/db/src/schema/settings.ts
@@ -61,12 +61,27 @@ export const mcpServerCatalog = sqliteTable("mcp_server_catalog", {
 export const userMcpConnections = sqliteTable(
 	"user_mcp_connections",
 	{
+		/**
+		 * How this server authenticates: "none" for open servers, otherwise the
+		 * header scheme it expects. The registry declares it so the Thinkspace
+		 * grant path can decide whether the server is grantable without a stored
+		 * credential. Authenticated servers stay non-grantable until the
+		 * credential seam (ADR-0009) lands.
+		 */
+		authType: text("auth_type").default("none").notNull(),
 		catalogVisible: integer("catalog_visible", { mode: "boolean" }).default(true).notNull(),
 		createdAt: integer("created_at", { mode: "timestamp_ms" }).default(timestampMsNow).notNull(),
 		description: text("description"),
 		encryptedHeaders: text("encrypted_headers").default("{}").notNull(),
 		id: text("id").primaryKey(),
 		name: text("name").notNull(),
+		/**
+		 * The blast radius of this server's tools, as declared at registration:
+		 * "read_only", "mutating", or "unknown". The Thinkspace grant path only
+		 * grants read-only access until the draft-or-approval policy for
+		 * mutations (ADR-0003) governs the rest.
+		 */
+		riskLevel: text("risk_level").default("unknown").notNull(),
 		serverId: text("server_id").references(() => mcpServerCatalog.id, { onDelete: "set null" }),
 		transport: text("transport").default("streamable_http").notNull(),
 		updatedAt: integer("updated_at", { mode: "timestamp_ms" })


### PR DESCRIPTION
## What

Lifts two of the three MVP "in this slice" MCP guardrails in `assertGrantableMcpToolAccess` (`packages/api/src/thinkspaces/permissions.ts`):

### Scope A — registered/custom MCP servers
Registered user MCP connections (`userMcpConnections`) now feed the grant path and runtime alongside the hardcoded built-in catalog, via the new resolver `mcp/grantable-servers.ts`. Adds `auth_type` + `risk_level` columns (migration `0012`) so the registry declares each server's auth scheme and blast radius.

### Scope C — mutating / unknown-risk MCP tools
Mutating and unknown-risk MCP servers are now **grantable and connectable**, but their tool calls are **held for the owner's Approval** (ADR-0003) via the existing `needsApproval` holdpoint + Review Queue, rather than executed on the grant alone. Adds the `mcp_tool_call` approval action kind (reuses existing payload columns — no migration needed).

## Still gated (out of scope)

Authenticated servers (`authType !== "none"`) remain non-grantable pending the connected-account-credential seam (ADR-0009) — this is the next slice (Scope B).

## Verification

- `bun run check-types` (api): clean
- `bun test` (api): 374/374 pass
- `bun x ultracite check` on touched files: only pre-existing `no-await-in-loop` flags (unchanged counts)
- `bun run db:generate` (db): schema in sync, migration `0012` committed with snapshot

## Notes

A and C were developed and validated together and share migration `0012` plus interleaved hunks across `permissions.ts`, `mcp/router.ts`, and `schema/settings.ts`, so they ship as one cohesive PR.